### PR TITLE
Add Webflow export sync workflow and README

### DIFF
--- a/.github/workflows/webflow-sync.yml
+++ b/.github/workflows/webflow-sync.yml
@@ -1,0 +1,42 @@
+name: Webflow Export Sync
+
+on:
+  push:
+    paths:
+      - "exports/latest.zip"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Unzip Webflow export
+        run: |
+          test -f exports/latest.zip
+          rm -rf _webflow_tmp
+          mkdir -p _webflow_tmp
+          unzip -o exports/latest.zip -d _webflow_tmp
+
+      - name: Sync to site folder
+        run: |
+          mkdir -p site
+          rsync -a --delete _webflow_tmp/ site/
+
+      - name: Commit & push if changed
+        run: |
+          git config user.name "webflow-sync-bot"
+          git config user.email "webflow-sync-bot@users.noreply.github.com"
+          git add site/
+          if git diff --cached --quiet; then
+            echo "No changes"
+            exit 0
+          fi
+          git commit -m "chore: sync Webflow export"
+          git push

--- a/exports/README.md
+++ b/exports/README.md
@@ -1,0 +1,7 @@
+# Webflow export drop folder
+
+Place your latest Webflow code export ZIP at:
+
+- `exports/latest.zip`
+
+Then commit and push that ZIP. GitHub Actions (`.github/workflows/webflow-sync.yml`) will unpack and sync it into `site/`.


### PR DESCRIPTION
### Motivation

- Provide an automated way to unpack a Webflow export placed at `exports/latest.zip` and keep the repository `site/` folder in sync with that export.

### Description

- Add a GitHub Actions workflow `.github/workflows/webflow-sync.yml` that triggers on pushes to `exports/latest.zip` and on manual dispatch, unpacks the ZIP to a temporary folder, rsyncs its contents into `site/`, and persists repository changes when differences exist.
- Add `exports/README.md` documenting where to place the Webflow export (`exports/latest.zip`) and how the workflow will unpack and sync it into `site/`.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c0c4c3006c832abbaecff6c32ab3bd)