### PR TITLE
Require CONFIRM_KEY and send X-Confirm-Key when creating admin payment link; normalize payments base URL

### DIFF
--- a/admin-worker/src/index.js
+++ b/admin-worker/src/index.js
@@ -399,6 +399,10 @@ async function createAdminSession(env, body) {
   if (!paymentsBaseUrl) {
     return { ok: false, error: "missing_payments_base_url", status: 500 };
   }
+  const confirmKey = String(env.CONFIRM_KEY || "").trim();
+  if (!confirmKey) {
+    return { ok: false, error: "missing_confirm_key", status: 500 };
+  }
 
   const paymentRef = String(
     body.payment_ref || body.paymentRef || `admin_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`
@@ -417,7 +421,8 @@ async function createAdminSession(env, body) {
     metadata: body.metadata && typeof body.metadata === "object" ? body.metadata : {},
   };
 
-  const linkUrl = new URL("/v1/confirm/link", paymentsBaseUrl).toString();
+  const paymentsBaseWithSlash = paymentsBaseUrl.endsWith("/") ? paymentsBaseUrl : `${paymentsBaseUrl}/`;
+  const linkUrl = new URL("v1/confirm/link", paymentsBaseWithSlash).toString();
   const linkPayload = {
     session_id: normalized.session_id,
     payment_ref: normalized.payment_ref,
@@ -432,7 +437,10 @@ async function createAdminSession(env, body) {
 
   const res = await fetch(linkUrl, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      "X-Confirm-Key": confirmKey,
+    },
     body: JSON.stringify(linkPayload),
   });
 


### PR DESCRIPTION
### Motivation

- Ensure the admin worker authenticates requests to the payments service by requiring a `CONFIRM_KEY` and including it in the request header.  
- Prevent broken request URLs when `PAYMENTS_BASE_URL` lacks a trailing slash by normalizing the base URL before building the endpoint path.  

### Description

- Add retrieval and validation of `CONFIRM_KEY` from `env` and return an error when it is missing.  
- Normalize `PAYMENTS_BASE_URL` to always include a trailing slash and construct the link endpoint with `new URL("v1/confirm/link", paymentsBaseWithSlash)`.  
- Include the `X-Confirm-Key` header in the `fetch` call when posting the payment link payload.  

### Testing

- Ran the existing automated test suite with `npm test` and the tests completed successfully.  
- Ran `npm run lint` to validate formatting and style and the lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d237719c04832a8c8d610c176bdb11)