### PR TITLE
docs: formalize MMD architecture v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,94 @@
+# MMD Workers
+
+MMD is a channel-agnostic operating system with personality.
+
+This repository contains the worker-based core of the MMD platform: the system layer that controls experience, payments, membership, automation, real-time coordination, and internal operations across channels.
+
+## What this repo is
+
+`mmd-workers` is the operational backbone of MMD.
+
+It is not a single app and not a single workflow. It is a multi-layer system designed to run human experience through controlled flows, clear worker boundaries, and character-led interfaces.
+
+At the center of the platform is one principle:
+
+**System at the core. Character at the surface. Experience as the output.**
+
+## Architecture at a glance
+
+### Experience Layer
+- `chat-worker`
+- TMIB character interface
+- Web / LINE / Telegram / future channels
+
+### Core Production Layer
+- `payments-worker`
+- `admin-worker`
+- `events-worker`
+- `telegram-worker`
+
+### Real-time Layer
+- `realtime-worker`
+
+### Migration Layer
+- `immigrate-worker`
+
+### Operator Layer
+- `Admin Console V1`
+
+## Worker roles
+
+### `chat-worker`
+Public-facing AI concierge and TMIB character interface.  
+This is the layer users experience directly.
+
+### `payments-worker`
+Payment truth and payment lifecycle control.  
+Handles verification, payment state, and session-payment coupling.
+
+### `admin-worker`
+Administrative authority and orchestration layer.  
+Handles membership lifecycle, access control, internal actions, and system operations.
+
+### `events-worker`
+Session and job automation engine.  
+Controls timeline-driven state transitions across the platform.
+
+### `telegram-worker`
+Internal system messaging gateway only.  
+Not a public chatbot surface.
+
+### `realtime-worker`
+Live interaction layer.  
+Supports real-time session coordination such as room opening, chat/location signaling, and live session support.
+
+### `immigrate-worker`
+Migration bridge layer.  
+Used to move data and workflows into the core production system without polluting core contracts.
+
+## Core truths
+
+- `session_id` is the primary session and idempotency reference
+- token parameter must be `t`
+- Airtable is the back-office source of truth
+- Memberstack is the public auth and membership layer
+- worker boundaries are production contracts
+- migration must remain separate from the core
+
+## Documentation
+
+Architecture docs live in:
+
+- `docs/architecture/README.md`
+- `docs/architecture/SYSTEM_OVERVIEW.md`
+- `docs/architecture/WORKERS.md`
+- `docs/architecture/REALTIME.md`
+- `docs/architecture/STATE_MACHINE.md`
+- `docs/architecture/CHARACTERS.md`
+- `docs/architecture/LAYERS.md`
+- `docs/architecture/PRINCIPLES.md`
+- `docs/architecture/INTERNAL_DOCTRINE.md`
+
+## Final definition
+
+MMD is a channel-agnostic operating system with personality — expressed through TMIB characters, powered by core production workers, extended by a real-time layer, supported by a migration layer, and operated through Admin Console V1.

--- a/docs/architecture/CHARACTERS.md
+++ b/docs/architecture/CHARACTERS.md
@@ -6,14 +6,11 @@ MMD does not present itself as a neutral interface.
 
 The platform uses a **character layer** as the surface of the system, turning interaction into guided experience instead of generic UI behavior.
 
-In practice, this means users do not only interact with a product.
-They interact through **TMIB characters**.
+This version aligns the character model with the current lane structure and corrected canon.
 
-## Role in the platform
+---
 
-Characters are part of the **Experience Layer**.
-They do not replace system logic.
-They express it.
+## Core principle
 
 ```txt
 System at the core
@@ -21,120 +18,224 @@ Character at the surface
 Experience as the output
 ```
 
-This is one of the most important distinctions in MMD:
-- business logic stays shared and controlled
-- personality changes the experience of the interface
-- the system remains consistent underneath
+Characters express the system. They do not replace the system.
 
-## Current character set
+Rule:
 
-The current TMIB character interface includes:
+**Character shapes perception. System determines truth.**
+
+---
+
+## Character groups
+
+### 1. Core selectable route guides
+These characters shape the feel of the guided experience after entry:
 - Hito
 - Hiro
 - Hima
 - Hiei
+
+They are best understood as:
+- route mood
+- experience flavor
+- selectable interface expression
+
+They are not the main continuity owner of the client lane.
+
+### 2. Client continuity and front-facing guidance
 - Kenji
-- Tart
 
-These are not decorative mascots.
-They are experience modes expressed through identity, tone, and interaction style.
+Kenji should be treated as:
+- the central assistant of the client lane
+- continuity guide
+- polished reassurance layer
+- premium care and handling surface
 
-## Architectural relationship
+### 3. Recruitment and model-side intelligence
+- TarT
 
-```txt
-User
-  ↓
-TMIB Character Interface
-  ↓
-chat-worker
-  ↓
-Core Production Workers
-  - payments-worker
-  - admin-worker
-  - events-worker
-  - telegram-worker
-  ↓
-MMD Operating System
-```
+TarT should be treated as:
+- scout energy
+- recruitment face
+- model/apply guide
+- model-side intelligence layer
+- client context interpreter for models
 
-The character layer is primarily surfaced through `chat-worker`.
+TarT is **not** the primary face of the standard client purchase flow.
 
-## Core rules
+### 4. Authority, gatekeeping, and protected access roles
+- Boss Per
+- Yuki
+- Ewvon
 
-### 1. Character is interface, not authority
-Characters shape the way the system is felt.
-They do not change the underlying production truth.
+These roles should not be flattened into the same function.
+They represent different kinds of authority.
 
-### 2. Shared system, multiple personalities
-All characters sit on top of the same operating system.
-This preserves control and consistency.
+---
 
-### 3. No logic leakage
-Character expression must not break worker boundaries or canonical business contracts.
+## Character-by-character role map
 
-### 4. Personality must remain intentional
-A character should not feel random or generic.
-Each one should deliver a distinct experience.
+## Boss Per
+Core role:
+- authority
+- gate
+- system owner
+- premium standards
+- selective approval energy
 
-## Why the character layer matters
+Best use:
+- trust framing
+- authority statements
+- controlled access moments
+- approval energy
+- high-level invitation tone
 
-MMD is building an operating system with personality.
-That means the interface must feel human without letting the system become chaotic.
+---
 
-The character layer helps MMD do three things at once:
+## Kenji
+Core role:
+- client continuity
+- care
+- warmth
+- polished support
+- relationship-preserving guidance
 
-### Trust
-Users feel guided by someone, not abandoned inside a tool.
+Best use:
+- first visible contact in the client lane
+- concierge gateway
+- route explanation
+- dashboard continuity
+- booking flow guidance
+- payment follow-up
+- pre-service and aftercare continuity
 
-### Differentiation
-MMD does not feel like a standard SaaS product, concierge bot, or booking flow.
+Important:
 
-### Emotional control
-The system can shape tone, pace, and atmosphere while keeping the underlying mechanics stable.
+**Kenji is the strongest fit for client-facing continuity.**
 
-## Character principles
+---
 
-### Character-first experience
-Users should feel that they are entering through a person, not through a machine.
+## Hito / Hiro / Hima / Hiei
+These characters are part of the selectable guide layer.
 
-### System-first control
-Even when the user experiences a character, the system underneath remains deterministic.
+They are best used for:
+- choose-guide moments
+- route mood
+- dashboard skin and tone
+- experience flavor after selection
 
-### Consistent canon
-Characters should remain aligned with the TMIB universe and the approved MMD character canon.
+They shape experience tone, not system truth.
+
+---
+
+## TarT
+Core role:
+- scout
+- selection
+- recruitment
+- model-side intelligence
+- pre-reading potential
+
+Best use:
+- apply lane
+- recruitment flow
+- fit/readiness surfaces
+- model dashboard tone
+- model console
+- client brief for model
+- expectation and caution interpretation
+
+Important:
+
+**TarT should not be treated as the front-facing guide of the standard client purchase flow.**
+
+TarT belongs more strongly to the **Model / Apply Lane**.
+
+---
+
+## Yuki
+Core role:
+- partner-facing gatekeeping
+- screening
+- controlled introductions
+- quiet oversight
+- business-side boundary keeper
+
+Best use:
+- partner inquiry flow
+- partner review moments
+- controlled access boundaries
+- business-side trust filtering
+
+Important:
+
+**Yuki is not the owner of Black Card authority.**
+
+Yuki belongs to the **Partner Lane gatekeeping layer**.
+
+---
+
+## Ewvon
+Core role:
+- Black Card authority
+- elite access privilege
+- elevated access class
+- authority tied to Black Card-level right
+
+Best use:
+- Black Card authority framing
+- elite access moments
+- high-level privilege logic
+- rarefied approval or access surfaces where that authority matters
+
+Important:
+
+**Ewvon, not Yuki, should be treated as the stronger holder of Black Card-linked authority.**
+
+This distinction is important:
+- Yuki = partner-facing gatekeeping and controlled relationship boundary
+- Ewvon = Black Card-linked authority
+
+---
+
+## Lane alignment
+
+### Client Lane
+Best aligned:
+- Boss Per = authority / trust / gate
+- Kenji = continuity / care / client-facing handling
+- Hito / Hiro / Hima / Hiei = selectable route guides / mood layer
+
+### Model / Apply Lane
+Best aligned:
+- TarT = recruitment / scout / model-side intelligence
+- Boss Per = approval / standards / authority
+
+### Partner Lane
+Best aligned:
+- Yuki = partner gatekeeping / screening / controlled introductions
+- Boss Per = overarching authority above the lane
+
+### Black Card / elite authority moments
+Best aligned:
+- Ewvon
+- Boss Per at the system-owner level
+
+---
 
 ## Relationship to `chat-worker`
 
-`chat-worker` is the public-facing AI concierge layer.
-It is the main place where the character system becomes visible to users.
+`chat-worker` is the public-facing AI concierge layer and the main place where the character system becomes visible to users.
 
 This means:
-- `chat-worker` delivers character expression
-- core workers deliver system truth
-- the platform stays unified under one architecture
+- `chat-worker` can express character
+- route surfaces can reinforce lane-specific character fit
+- core workers still deliver system truth
 
-## Product implication
+Not every character should be surfaced in the same way.
 
-MMD website and chat surfaces should be designed with the understanding that:
-- users may choose who guides them
-- the system may present interaction through character identity
-- character selection is part of the experience layer, not an afterthought
-
-## Design implication
-
-When building interface surfaces, do not treat characters as campaign art only.
-Treat them as interaction architecture.
-
-That means:
-- copy
-- tone
-- onboarding
-- guidance
-- trust signals
-- choice architecture
-
-all need to reflect the role of characters as part of the system.
+---
 
 ## One-line definition
 
-The TMIB character layer is the personality surface of MMD — the human-facing interface through which users experience a controlled operating system.
+The MMD character layer is the personality surface of the platform — a structured system of route guides, continuity roles, authority figures, and lane-specific identities that make the operating system feel human without making it chaotic.

--- a/docs/architecture/CLIENT_LANE.md
+++ b/docs/architecture/CLIENT_LANE.md
@@ -1,0 +1,246 @@
+# CLIENT_LANE
+
+## Purpose
+
+This document defines the **Client Lane** of MMD.
+
+The Client Lane is the primary route family for people who enter MMD in order to:
+- understand the system
+- build trust
+- explore the offer
+- choose the right next step
+- enter guided chat
+- move toward package, payment, session, and continuity flows
+
+This document exists to keep the client journey distinct from the model/apply journey.
+
+Rule:
+
+**The Client Lane should feel premium, legible, and controlled from first entry to ongoing continuity.**
+
+---
+
+## What the Client Lane is
+
+The Client Lane is the client-first path through MMD.
+
+It begins at the public trust layer and continues into:
+- guided interaction
+- package understanding
+- payment or booking progression
+- session continuity
+- post-entry support and relationship flow
+
+The Client Lane is not:
+- the recruitment lane
+- the model intelligence lane
+- the scout/select lane
+- the operator lane
+- the migration lane
+
+Its job is simple:
+
+**turn trust into controlled progression.**
+
+---
+
+## Position inside the architecture
+
+The Client Lane begins in the **Experience Layer**, passes through the **Core Production Layer**, and may touch the **Real-time Layer** when live coordination becomes relevant.
+
+```txt
+Client Lane flow
+
+Public Trust Surface
+→ chat-worker / character-led interface
+→ package / FAQ / guided next step
+→ payment / session progression
+→ session continuity
+→ support / dashboard / ongoing client relationship
+```
+
+This means the Client Lane should:
+- start with trust
+- move into guided choice
+- preserve clarity during payment or booking progression
+- remain consistent after entry
+
+---
+
+## Front door
+
+### `/trust/inme`
+
+`/trust/inme` should be treated as the **client-first front door** of the web experience.
+
+Its primary jobs are:
+- establish trust
+- explain the nature of MMD
+- position the system correctly
+- guide people into the correct next action
+- route them into the client-facing flow
+
+It is allowed to reveal a secondary model/apply branch, but it should not stop being client-first.
+
+Rule:
+
+**The Client Lane starts by making the system understandable before making it transactional.**
+
+---
+
+## Primary goals of the Client Lane
+
+The Client Lane should do five things well.
+
+### 1. Build trust
+People should understand what kind of system MMD is.
+
+### 2. Reduce uncertainty
+The lane should answer:
+- where to begin
+- what happens next
+- what the offer is
+- what kind of experience they are entering
+
+### 3. Route intentionally
+The lane should move a person toward:
+- chat
+- package selection
+- payment-linked progression
+- session-linked continuity
+
+### 4. Preserve premium tone
+The lane should feel controlled, selective, and calm.
+
+### 5. Protect continuity
+After entry, the lane should continue to feel coherent rather than dropping the client into fragmented utilities.
+
+---
+
+## Client Lane stages
+
+## Stage 1 — Trust entry
+This stage includes:
+- `/trust/inme`
+- trust framing
+- premium positioning
+- controlled explanation of the system
+- first guided decision surface
+
+Questions this stage should answer:
+- What is MMD?
+- Why should I trust it?
+- What am I supposed to do next?
+
+---
+
+## Stage 2 — Guided entry
+This stage includes:
+- chat entry
+- character-led guidance
+- package or route clarification
+- next-step explanation
+
+Questions this stage should answer:
+- Should I talk to the system now?
+- Which path is right for me?
+- What kind of help am I getting?
+
+---
+
+## Stage 3 — Offer understanding
+This stage includes:
+- package surfaces
+- FAQ or explanation surfaces
+- expectation-shaping pages
+- controlled offer interpretation
+
+Questions this stage should answer:
+- What is being offered?
+- What does this lane lead to?
+- What is the difference between options?
+
+---
+
+## Stage 4 — Payment or progression gate
+This stage includes:
+- payment-linked steps
+- session-linked progression
+- money-truth transitions
+- confirmed next-step movement
+
+Questions this stage should answer:
+- What must be completed before the system advances?
+- What is already confirmed?
+- What is still pending?
+
+---
+
+## Stage 5 — Continuity
+This stage includes:
+- client-facing dashboard surfaces
+- session continuity pages
+- after-entry support
+- relationship-preserving surfaces
+
+Questions this stage should answer:
+- What is happening now?
+- What do I need to do next?
+- Who is guiding me?
+- How do I continue with confidence?
+
+---
+
+## Character alignment
+
+Characters in the Client Lane should support trust, continuity, and controlled premium guidance.
+
+### Boss Per
+Best use:
+- authority framing
+- gatekeeping tone
+- trust statements
+- premium system identity
+- selective entry energy
+
+### Kenji
+Best use:
+- client continuity
+- warmth
+- premium reassurance
+- polished, relationship-preserving guidance
+- after-entry continuity
+
+Important:
+
+**Kenji is a strong fit for client continuity surfaces.**
+
+### TarT
+Client-lane role:
+- limited
+- selective
+- not the default guide of the standard client purchase flow
+
+Rule:
+
+**TarT should not dominate the standard client lane.**
+
+---
+
+## Recommended route family for the Client Lane
+
+Examples:
+- `/trust/inme`
+- `/start`
+- package surfaces
+- FAQ or explanation pages
+- contact or gateway surfaces
+- chat entry points
+- payment-linked continuity routes
+- client dashboard or continuity pages
+
+---
+
+## One-line definition
+
+**The Client Lane is the premium, client-first path through MMD: a controlled trust-to-continuity journey expressed through the public experience layer.**

--- a/docs/architecture/MODEL_LANE.md
+++ b/docs/architecture/MODEL_LANE.md
@@ -1,0 +1,146 @@
+# MODEL_LANE
+
+## Purpose
+
+This document defines the **Model Lane** of MMD.
+
+The Model Lane is the route family for people who enter MMD in order to:
+- apply
+- be scouted
+- move through recruitment
+- understand model-side expectations
+- receive client-side intelligence in a model-facing format
+- continue into model-facing dashboard or console surfaces
+
+This document exists to keep the model/apply journey distinct from the client journey.
+
+Rule:
+
+**The Model Lane should be explicit, selective, and intelligence-driven — not blended into the standard client purchase path.**
+
+---
+
+## What the Model Lane is
+
+The Model Lane is the model-first path through MMD.
+
+It exists for:
+- application
+- recruitment
+- talent evaluation
+- expectation shaping
+- model-side operational readiness
+- model-side continuity after entry
+
+The Model Lane is not:
+- the standard client booking lane
+- the public trust lane in its primary function
+- the operator/admin lane
+- the migration lane
+
+Its job is to turn:
+- interest
+- potential
+- selectivity
+- model-facing clarity
+
+into controlled progression.
+
+---
+
+## Entry logic
+
+The Model Lane should be visible early enough to be found, but not merged into the client-first front door as if both journeys are identical.
+
+A strong pattern is:
+- keep `/trust/inme` client-first
+- reveal an explicit secondary branch such as:
+  - Apply to work with MMD
+  - Not here to book? Start your application
+  - Interested in joining? Enter the model lane
+
+Rule:
+
+**The Model Lane should be available without stealing the identity of the Client Lane.**
+
+---
+
+## Model Lane goals
+
+The Model Lane should do five things well.
+
+### 1. Make intent explicit
+This lane is for applying, being evaluated, or moving into model-side opportunity flow.
+
+### 2. Preserve selectivity
+The lane should not feel like a generic signup funnel.
+
+### 3. Shape expectations
+People in this lane should understand:
+- what kind of system they are entering
+- what is expected of them
+- what kind of opportunities or responsibilities exist
+
+### 4. Provide intelligence
+The Model Lane should eventually support model-side reading of:
+- client vibe
+- role context
+- caution points
+- expectation interpretation
+- opportunity fit
+
+### 5. Preserve continuity
+If someone proceeds inside the model-side system, the lane should remain coherent rather than becoming fragmented and tactical too early.
+
+---
+
+## Character alignment
+
+### TarT
+Best use:
+- scout energy
+- pre-reading potential
+- selection
+- recruitment tone
+- client-facing information translated for model understanding
+- model-side intelligence and interpretation
+
+Important:
+
+**TarT is the strongest aligned character for the Model Lane.**
+
+### Boss Per
+Best use:
+- authority
+- standard-setting
+- approval logic
+- selective entry energy
+
+### Kenji
+Model-lane role:
+- limited
+- not the primary face of recruitment or application flow
+
+Rule:
+
+**Kenji is not the default guide of the model/apply lane.**
+
+---
+
+## Recommended route family for the Model Lane
+
+Examples:
+- `/apply`
+- `/join`
+- recruitment branch surfaces
+- audition or application paths
+- model onboarding pages
+- model dashboard or model continuity surfaces
+- model-facing intelligence pages
+- model-side support or expectation pages
+
+---
+
+## One-line definition
+
+**The Model Lane is the selective, model-first path through MMD: an apply-to-continuity journey shaped by scouting, expectation, and model-side intelligence.**

--- a/docs/architecture/PARTNER_LANE.md
+++ b/docs/architecture/PARTNER_LANE.md
@@ -1,0 +1,165 @@
+# PARTNER_LANE
+
+## Purpose
+
+This document defines the **Partner Lane** of MMD.
+
+The Partner Lane exists for business-side relationships that are not the same as:
+- the standard client booking flow
+- the model/apply flow
+- the operator/admin layer
+- the Black Card authority layer
+
+This lane is for:
+- hotels
+- concierges
+- travel contacts
+- event partners
+- brand collaborators
+- trusted introducers
+- controlled external relationship channels
+
+Rule:
+
+**The Partner Lane should create opportunity without exposing protected talent, protected routing, or protected authority.**
+
+---
+
+## Core principle
+
+A partner is not a client.
+A partner is not a model.
+A partner is not an internal operator.
+
+Because of that, the Partner Lane must remain its own lane.
+
+Its purpose is:
+- relationship intake
+- business screening
+- controlled collaboration
+- structured introductions
+- boundary-preserving coordination
+
+It must not become:
+- a backdoor to protected models
+- a roster browser
+- a shortcut around the client lane
+- a shortcut around the model lane
+- a shadow admin surface
+
+---
+
+## Canonical character alignment
+
+### Yuki
+Yuki should align with:
+- partner-facing gatekeeping
+- partner screening
+- controlled introductions
+- quiet oversight
+- partner access boundaries
+- business-side trust filtering
+
+Important:
+
+**Yuki is not the owner of Black Card authority.**
+
+Yuki belongs to the partner-facing gatekeeping layer, not the Black Card authority layer.
+
+### Ewvon
+Ewvon should align with:
+- Black Card authority
+- elite access privilege
+- high-level approval tied to Black Card power
+- the right to grant, hold, or embody that specific level of authority
+
+Important:
+
+**Ewvon, not Yuki, should be treated as the stronger holder of Black Card-linked authority.**
+
+This is a canonical separation that protects role clarity:
+- Yuki = partner gatekeeping and controlled relationship boundary
+- Ewvon = Black Card-level authority
+
+### Boss Per
+Boss Per should align with:
+- system ownership
+- overarching authority
+- high-level approval energy
+- premium standards
+
+### Kenji
+Kenji is not the main face of the Partner Lane by default.
+
+### TarT
+TarT should not be the main owner of the Partner Lane.
+TarT belongs more strongly to model/apply, scouting, recruitment, and model-side intelligence.
+
+---
+
+## Visibility rules
+
+### What partner-side users may see
+- relationship status
+- approved request scope
+- controlled contact path
+- generalized service categories
+- approved business-facing information
+- limited availability class where appropriate
+- curated outcome options
+
+### What partner-side users should not see
+- protected model roster
+- private model faces or identities
+- direct personal handles
+- direct contact details
+- model-side console data
+- protected availability patterns
+- Black Card authority logic
+- admin/operator visibility
+- internal exception workflows
+- internal system notes
+
+Rule:
+
+**Partner usefulness should come from controlled service, not from raw visibility.**
+
+---
+
+## Protected model doctrine
+
+Some models are privacy-sensitive or protected.
+
+That means:
+- they should not appear in ordinary partner-facing recommend surfaces
+- they should not be exposed through guide/concierge convenience flows
+- they should not be reachable by direct deal attempts
+- they should not become visible simply because a partner is around the job
+
+For protected models:
+- assignment should be manual or tightly approved
+- visibility should be abstracted
+- contact should remain system-mediated
+- follow-up should remain controlled by MMD
+
+---
+
+## Suggested route family
+
+Examples:
+- `/partner`
+- `/partner/inquiry`
+- `/partner/apply`
+- `/partner/status`
+
+These routes should be framed around:
+- relationship inquiry
+- collaboration scope
+- approved follow-up
+- controlled continuity
+
+---
+
+## One-line definition
+
+**The Partner Lane is MMD’s controlled business-relationship path: useful enough to collaborate, restricted enough to protect talent, authority, and system boundaries.**

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -2,16 +2,30 @@
 
 This folder contains the current architecture baseline for `mmd-workers`.
 
-## Files
-
+## Core system docs
 - `SYSTEM_OVERVIEW.md` — current corrected view of the MMD system
 - `WORKERS.md` — worker roles, ownership, and boundaries
-- `REALTIME.md` — real-time layer and live coordination
-- `STATE_MACHINE.md` — canonical session flow and transition rules
-- `CHARACTERS.md` — TMIB character layer as interface
 - `LAYERS.md` — architecture layer model
 - `PRINCIPLES.md` — system design principles
 - `INTERNAL_DOCTRINE.md` — internal doctrine for decision-making
+
+## Runtime and control docs
+- `REALTIME.md` — real-time layer and live coordination
+- `STATE_MACHINE.md` — canonical session flow and transition rules
+- `DEPLOYMENT.md` — deployment order and production discipline
+- `ADMIN_CONSOLE_V1.md` — operator surface definition
+- `ERROR_HANDLING.md` — error doctrine and recovery rules
+- `OPERATIONS.md` — day-to-day operational guidance
+- `CHANGE_MANAGEMENT.md` — controlled system evolution rules
+
+## Interface and route docs
+- `CHARACTERS.md` — character system and corrected role alignment
+- `CLIENT_LANE.md` — client-first route and continuity logic
+- `MODEL_LANE.md` — apply/recruitment and model-side intelligence lane
+- `PARTNER_LANE.md` — partner gatekeeping and boundary-protected business lane
+- `ROUTES_AND_SURFACES.md` — route doctrine and surface classification
+- `INFORMATION_ARCHITECTURE.md` — page/domain structure across trust, client, model, operator, and runtime surfaces
+- `GLOSSARY.md` — shared vocabulary for the team
 
 ## Guiding principle
 


### PR DESCRIPTION
## Summary

This PR formalizes the current MMD architecture documentation as **v2**.

It now covers:
- the worker-based system structure
- client, model/apply, and partner lanes
- route and surface separation
- corrected character-role alignment
- runtime, operations, deployment, and doctrine docs

## Included

- refreshed root `README.md`
- expanded architecture index
- core architecture docs already present in the repo
- lane docs for client, model/apply, and partner
- route / IA docs already present in the repo
- rewritten `CHARACTERS.md` aligned with current canon

## Key updates

- keep `/trust/inme` as the client-first public front door
- clarify lane separation across client, model/apply, and partner flows
- align character roles:
  - Kenji = client continuity
  - TarT = model/apply and model intel
  - Yuki = partner gatekeeping
  - Ewvon = Black Card authority
- expand the architecture index to reflect the v2 docs set

## Notes

This PR is documentation-only.
It does not change runtime behavior directly, but it sets a clearer reference for future design and implementation work.
