### PR TITLE
docs: add model promotion index wiring example

### DIFF
--- a/immigrate-worker/src/index.model-promotion-wiring.example.ts
+++ b/immigrate-worker/src/index.model-promotion-wiring.example.ts
@@ -1,0 +1,27 @@
+// Model promotion route wiring example for immigrate-worker/src/index.ts
+// Apply these two blocks to the real index.ts runtime entrypoint.
+
+import {
+  maybeHandleModelPromoteImmigrationRoute,
+} from "./lib/model-promote-immigration-route";
+
+// Inside fetch handler, after pathname is available:
+// const pathname = url.pathname;
+
+export async function maybeRouteModelPromotion(
+  request: Request,
+  env: Env,
+  pathname: string,
+): Promise<Response | null> {
+  const modelPromotionResponse = await maybeHandleModelPromoteImmigrationRoute(
+    request,
+    env,
+    pathname,
+  );
+
+  if (modelPromotionResponse) {
+    return modelPromotionResponse;
+  }
+
+  return null;
+}


### PR DESCRIPTION
Adds the final runtime wiring reference for the Model Promote Immigration flow.

Already on main before this PR:
- `immigrate-worker/src/lib/model-promote-immigration.ts`
- `immigrate-worker/src/lib/model-promote-immigration-core.ts`
- `immigrate-worker/src/lib/model-promote-immigration-route.ts`
- `immigrate-worker/docs/model-promote-immigration-index-patch.md`

This PR adds:
- `immigrate-worker/src/index.model-promotion-wiring.example.ts`

Purpose:
- Provide a safe reference for wiring `POST /sigil/admin/models/promote-immigration` into `immigrate-worker/src/index.ts`.
- Keep actual runtime `index.ts` untouched until a full-file local patch can be applied safely.

Endpoint target:
```http
POST /sigil/admin/models/promote-immigration
Authorization: Bearer <INTERNAL_TOKEN>
Content-Type: application/json
```

Minimal body:
```json
{
  "draft_id": "recXXXXXXXXXXXXXX",
  "promoted_by": "per"
}
```

Manual runtime wiring required in `immigrate-worker/src/index.ts`:
```ts
import {
  maybeHandleModelPromoteImmigrationRoute,
} from "./lib/model-promote-immigration-route";
```

Then after `pathname` exists:
```ts
const modelPromotionResponse = await maybeHandleModelPromoteImmigrationRoute(
  request,
  env,
  pathname,
);

if (modelPromotionResponse) {
  return modelPromotionResponse;
}
```

Safety note:
The connector could not safely patch the large runtime `index.ts` because file reads are truncated. This PR deliberately avoids blind modification of the production route entrypoint.