### PR TITLE
docs: add runtime wiring checklist for model promotion

### DIFF
--- a/immigrate-worker/docs/runtime-wiring-pr-checklist.md
+++ b/immigrate-worker/docs/runtime-wiring-pr-checklist.md
@@ -1,0 +1,56 @@
+# Runtime Wiring PR Checklist
+
+Issue: #32
+
+Target endpoint:
+
+```http
+POST /sigil/admin/models/promote-immigration
+```
+
+## Patch target
+
+```txt
+immigrate-worker/src/index.ts
+```
+
+## Checklist
+
+- [ ] Add import:
+
+```ts
+import {
+  maybeHandleModelPromoteImmigrationRoute,
+} from "./lib/model-promote-immigration-route";
+```
+
+- [ ] Add route block after `pathname` exists and before generic fallback handlers:
+
+```ts
+const modelPromotionResponse = await maybeHandleModelPromoteImmigrationRoute(
+  request,
+  env,
+  pathname,
+);
+
+if (modelPromotionResponse) {
+  return modelPromotionResponse;
+}
+```
+
+- [ ] Run build/typecheck for `immigrate-worker`.
+- [ ] Deploy `immigrate-worker`.
+- [ ] Smoke test endpoint.
+- [ ] Close #32 after successful smoke test.
+
+## Smoke test
+
+```bash
+curl -X POST "https://sigil.mmdbkk.com/sigil/admin/models/promote-immigration" \
+  -H "Authorization: Bearer $INTERNAL_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "draft_id": "recXXXXXXXXXXXXXX",
+    "promoted_by": "per"
+  }'
+```


### PR DESCRIPTION
Links #32

Adds a runtime wiring checklist for the Model Promote Immigration endpoint.

This PR does not modify `immigrate-worker/src/index.ts` directly. It documents the exact remaining production wiring step so the runtime patch can be applied safely from an editor/local checkout that can read the full `index.ts` file.

Remaining steps after this PR:
1. Add the model promotion route import to `immigrate-worker/src/index.ts`
2. Add the `maybeHandleModelPromoteImmigrationRoute` block after `pathname` exists
3. Build/typecheck
4. Deploy `immigrate-worker`
5. Smoke test `POST /sigil/admin/models/promote-immigration`
6. Close #32