### PR TITLE
feat: wire model promotion route through internal routes

### DIFF
--- a/immigrate-worker/src/internal-routes.ts
+++ b/immigrate-worker/src/internal-routes.ts
@@ -4,6 +4,7 @@ import {
   renderCreateSessionPage,
   type InternalPageEnv,
 } from "./internal-pages";
+import { handleModelPromoteImmigration } from "./lib/model-promote-immigration";
 
 export interface InternalRoutesEnv extends InternalPageEnv {
   ADMIN_WORKER_BASE_URL?: string;
@@ -103,6 +104,10 @@ export async function handleInternalRoutes(request: Request, env: InternalRoutes
 
   const assetRes = await serveAsset(request, env);
   if (assetRes) return assetRes;
+
+  if (pathname === "/sigil/admin/models/promote-immigration") {
+    return handleModelPromoteImmigration(request, env);
+  }
 
   const apiRes = await proxyAdminApi(request, env);
   if (apiRes) return apiRes;


### PR DESCRIPTION
Closed in favor of a direct `immigrate-worker/src/index.ts` wiring PR.

Codex review correctly identified that `internal-routes.ts` is not imported or called by the deployed entrypoint (`wrangler.toml` main = `src/index.ts`), so this PR would not make `POST /sigil/admin/models/promote-immigration` live in production.

Next action: create a new PR that wires the route through the deployed entrypoint directly.