### PR TITLE
feat: wire model promote immigration route

### DIFF
--- a/immigrate-worker/src/index.model-promotion-wiring.example.ts
+++ b/immigrate-worker/src/index.model-promotion-wiring.example.ts
@@ -4,6 +4,7 @@
 import {
   maybeHandleModelPromoteImmigrationRoute,
 } from "./lib/model-promote-immigration-route";
+import type { Env } from "./types";
 
 // Inside fetch handler, after pathname is available:
 // const pathname = url.pathname;

--- a/immigrate-worker/src/index.ts
+++ b/immigrate-worker/src/index.ts
@@ -1,4 +1,5 @@
 import { isAuthorized, readInternalToken } from "./lib/auth";
+import { handleModelPromoteImmigration } from "./lib/model-promote-immigration";
 import {
   buildImmigrationLinkContext,
   canReadAirtable,
@@ -65,6 +66,10 @@ const CANONICAL = {
   intake: "/v1/immigration/intake",
   promote: "/v1/immigration/promote",
   links: "/v1/immigration/links",
+} as const;
+
+const SIGIL = {
+  modelPromoteImmigration: "/sigil/admin/models/promote-immigration",
 } as const;
 
 const CONTROL_ROOM = {
@@ -3793,6 +3798,10 @@ export default {
 
     try {
       const url = new URL(request.url);
+
+      if (url.pathname === SIGIL.modelPromoteImmigration) {
+        return await handleModelPromoteImmigration(request, env);
+      }
 
       if (
         request.method === "OPTIONS" &&

--- a/immigrate-worker/src/lib/model-promote-immigration.ts
+++ b/immigrate-worker/src/lib/model-promote-immigration.ts
@@ -76,20 +76,24 @@ function airtableTableUrl(env: Env, table: string): string {
   return `https://api.airtable.com/v0/${env.AIRTABLE_BASE_ID}/${encodeURIComponent(table)}`;
 }
 
+function envRecord(env: Env): Record<string, unknown> {
+  return env as unknown as Record<string, unknown>;
+}
+
 function modelDraftsTable(env: Env): string {
-  return toStr((env as Record<string, unknown>).AIRTABLE_TABLE_MODEL_DRAFTS) || "models/draft";
+  return toStr(envRecord(env).AIRTABLE_TABLE_MODEL_DRAFTS) || "models/draft";
 }
 
 function modelsTable(env: Env): string {
-  return toStr((env as Record<string, unknown>).AIRTABLE_TABLE_MODELS) || "tblcatsmzAT5nKqIn";
+  return toStr(envRecord(env).AIRTABLE_TABLE_MODELS) || "tblcatsmzAT5nKqIn";
 }
 
 function activityLogsTable(env: Env): string {
-  return toStr((env as Record<string, unknown>).AIRTABLE_TABLE_ACTIVITY_LOGS) || "tblbUWRoFL6OI6QMJ";
+  return toStr(envRecord(env).AIRTABLE_TABLE_ACTIVITY_LOGS) || "tblbUWRoFL6OI6QMJ";
 }
 
 function envField(env: Env, key: string, fallback: string): string {
-  return toStr((env as Record<string, unknown>)[key]) || fallback;
+  return toStr(envRecord(env)[key]) || fallback;
 }
 
 function escapeFormulaValue(value: string): string {

--- a/immigrate-worker/src/public-renewal-bridge.ts
+++ b/immigrate-worker/src/public-renewal-bridge.ts
@@ -13,6 +13,20 @@ function toNum(value: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+type UpstreamJson = {
+  ok?: boolean;
+  payment_url?: string;
+  url?: string;
+  data?: {
+    payment_url?: string;
+    url?: string;
+  };
+};
+
+function asUpstreamJson(value: unknown): UpstreamJson {
+  return value && typeof value === "object" ? (value as UpstreamJson) : {};
+}
+
 function publicCors(request: Request, env: Env): Headers {
   const headers = new Headers();
   const allowed = String(
@@ -79,7 +93,7 @@ async function intakeFallback(request: Request, env: Env, payload: Record<string
       headers: { "content-type": "application/json" },
       body: JSON.stringify(fallbackPayload),
     });
-    const data = await response.json().catch(() => null);
+    const data = asUpstreamJson(await response.json().catch(() => null));
     return {
       attempted: true,
       ok: response.ok && data?.ok !== false,
@@ -134,7 +148,7 @@ export async function handlePublicPointsTopup(request: Request, env: Env): Promi
     try {
       const upstream = await forwardJson(url, env, payload);
       if (!upstream) continue;
-      const data = await upstream.json().catch(() => null);
+      const data = asUpstreamJson(await upstream.json().catch(() => null));
       if (upstream.ok && data?.ok !== false) {
         return publicJson(request, env, {
           ok: true,
@@ -212,7 +226,7 @@ export async function handlePublicActivateVip(request: Request, env: Env): Promi
     try {
       const upstream = await forwardJson(url, env, payload);
       if (!upstream) continue;
-      const data = await upstream.json().catch(() => null);
+      const data = asUpstreamJson(await upstream.json().catch(() => null));
       if (upstream.ok && data?.ok !== false) {
         return publicJson(request, env, {
           ok: true,


### PR DESCRIPTION
## Summary
- Wire the runtime entrypoint for `POST /sigil/admin/models/promote-immigration` in `immigrate-worker/src/index.ts`.
- Keep the model promotion handler in `immigrate-worker/src/lib/model-promote-immigration.ts` tracked and TypeScript-safe.
- Add minimal type-only fixes needed for `npm run typecheck` on the current `origin/main` immigrate-worker baseline.

## Route
- `POST /sigil/admin/models/promote-immigration`

## Verification
- `npm run typecheck` passed.
- `npm run deploy -- --dry-run` passed.
- No production deploy performed.

## Notes
- No production deploy performed.
- `internal-routes.ts` is not used for this route.