### PR TITLE
fix: bridge model promotion through admin worker

### DIFF
--- a/admin-worker/index.js
+++ b/admin-worker/index.js
@@ -28,6 +28,8 @@ import { demoLinksCreate, demoLinksGet } from "./src/routes/demo-links.js";
 
 const LOCK = "admin-worker-v2026-03-11-full";
 const AIRTABLE_API = "https://api.airtable.com/v0";
+const MODEL_PROMOTE_IMMIGRATION_ROUTE = "/sigil/admin/models/promote-immigration";
+const DEFAULT_IMMIGRATE_WORKER_BASE_URL = "https://immigrate-worker.malemodel-bkk.workers.dev";
 
 export default {
   async fetch(req, env) {
@@ -64,6 +66,10 @@ export default {
 
     if (method === "GET" && path === "/v1/demo-links/get") {
       return withCors(await demoLinksGet(req, env), cors);
+    }
+
+    if (path === MODEL_PROMOTE_IMMIGRATION_ROUTE) {
+      return withCors(await bridgeModelPromoteImmigration(req, env), cors);
     }
 
     // ------------------------------------------------------
@@ -553,6 +559,18 @@ function isConfirmKeyAuthed(req, env) {
   return Boolean(env.CONFIRM_KEY && ck && ck === env.CONFIRM_KEY);
 }
 
+function isModelPromotionBridgeAuthed(req, env) {
+  const auth = req.headers.get("Authorization") || "";
+  const bearer = auth.toLowerCase().startsWith("bearer ") ? auth.slice(7).trim() : "";
+  const internalToken = str(req.headers.get("X-Internal-Token") || "");
+  const confirmKey = str(req.headers.get("X-Confirm-Key") || "");
+
+  return Boolean(
+    (env.INTERNAL_TOKEN && (bearer === env.INTERNAL_TOKEN || internalToken === env.INTERNAL_TOKEN)) ||
+      (env.CONFIRM_KEY && confirmKey === env.CONFIRM_KEY)
+  );
+}
+
 /* =========================
    JSON / utils
 ========================= */
@@ -623,6 +641,47 @@ function numReq(value, field) {
   const n = Number(value);
   if (!Number.isFinite(n) || n <= 0) throw new Error(`invalid_${field}`);
   return n;
+}
+
+async function bridgeModelPromoteImmigration(req, env) {
+  if (!isModelPromotionBridgeAuthed(req, env)) {
+    return json({ ok: false, error: "unauthorized" }, 401);
+  }
+
+  const requestUrl = new URL(req.url);
+  const base = str(env.IMMIGRATE_WORKER_BASE_URL || DEFAULT_IMMIGRATE_WORKER_BASE_URL).replace(/\/+$/, "");
+  if (!base) return json({ ok: false, error: "missing_immigrate_worker_base_url" }, 500);
+
+  const target = new URL(`${base}${MODEL_PROMOTE_IMMIGRATION_ROUTE}`);
+  target.search = requestUrl.search;
+
+  const headers = new Headers();
+  for (const name of ["accept", "authorization", "content-type", "x-confirm-key", "x-internal-token"]) {
+    const value = req.headers.get(name);
+    if (value) headers.set(name, value);
+  }
+
+  if (env.INTERNAL_TOKEN) {
+    headers.set("X-Internal-Token", env.INTERNAL_TOKEN);
+  }
+
+  try {
+    return await fetch(target.toString(), {
+      method: req.method,
+      headers,
+      body: req.method === "GET" || req.method === "HEAD" ? undefined : req.body,
+      redirect: "manual",
+    });
+  } catch (e) {
+    return json(
+      {
+        ok: false,
+        error: "model_promotion_bridge_failed",
+        detail: String(e?.message || e),
+      },
+      502
+    );
+  }
 }
 
 function inferLayerFromTable(tableName) {

--- a/admin-worker/wrangler.toml
+++ b/admin-worker/wrangler.toml
@@ -12,6 +12,7 @@ ALLOWED_ORIGINS = "https://mmdbkk.com,https://www.mmdbkk.com,https://mmdprive.co
 
 # Base URLs (LOCK)
 PAYMENTS_BASE_URL = "https://payments-worker.malemodel-bkk.workers.dev"
+IMMIGRATE_WORKER_BASE_URL = "https://immigrate-worker.malemodel-bkk.workers.dev"
 TELEGRAM_INTERNAL_SEND_URL = "https://telegram-worker.malemodel-bkk.workers.dev/telegram/internal/send"
 
 # Airtable


### PR DESCRIPTION
## Summary
- Add an admin-worker bridge for `POST /sigil/admin/models/promote-immigration`.
- Proxy the SIGIL host route to `immigrate-worker` at `IMMIGRATE_WORKER_BASE_URL`.
- Preserve internal auth by accepting `Authorization: Bearer INTERNAL_TOKEN`, `X-Internal-Token`, or `X-Confirm-Key`, then forwarding `X-Internal-Token` to the immigrate worker when available.

## Route ownership finding
- Repo Wrangler config says `immigrate-worker` has no custom routes and that `admin-worker` owns internal admin and SIGIL host routes.
- Therefore PR #35 alone wires the immigrate worker runtime but is not sufficient for `https://sigil.mmdbkk.com/sigil/admin/models/promote-immigration` unless the SIGIL host reaches immigrate-worker outside repo config.

## Merge / deploy order
1. Merge PR #35 first.
2. Merge this PR second.
3. Deploy `immigrate-worker` first.
4. Deploy `admin-worker` second.
5. Smoke test the SIGIL host route.

## Verification
- `node --check admin-worker/index.js` passed.
- No production deploy performed.

## Warning
- `wrangler deploy --dry-run --config admin-worker/wrangler.toml` currently fails before this bridge code because `origin/main` imports missing `./src/routes/demo-links.js`. This PR intentionally does not modify unrelated CI/root workflow files or unrelated demo-links code.