### PR TITLE
feat: add web admin console and deals api wiring

### DIFF
--- a/admin-worker/index.js
+++ b/admin-worker/index.js
@@ -990,9 +990,71 @@ function redactedPrefix(prefix) {
   return `${parts.slice(0, 3).join("/")}/.../`;
 }
 
+const PUBLIC_MODEL_ASSET_PREFIX_RE = /^models\/[^/]+\/(?:profile|gallery|compcard)\/$/;
+const PUBLIC_MODEL_ASSET_KEY_RE = /^models\/[^/]+\/(?:(?:profile\/main)|(?:gallery\/[^/]+)|(?:compcard\/[^/]+))\.jpg$/;
+const PROTECTED_MODEL_ASSET_PREFIXES = [
+  "private/",
+  "evidence/",
+  "line-notes/",
+  "sigil/",
+  "blackcard/",
+  "slips/",
+];
+
+function validateModelAssetPathSyntax(value) {
+  const raw = str(value);
+  if (!raw) return { ok: false, error: "missing_model_asset_path" };
+  if (/^https?:\/\//i.test(raw)) return { ok: false, error: "model_asset_path_must_not_be_url" };
+  if (raw.startsWith("/")) return { ok: false, error: "model_asset_path_must_not_start_with_slash" };
+  if (raw.includes("\\")) return { ok: false, error: "model_asset_path_must_not_contain_backslash" };
+  if (raw.includes("..")) return { ok: false, error: "model_asset_path_must_not_contain_dotdot" };
+
+  const clean = raw.replace(/\/+$/g, raw.endsWith("/") ? "/" : "");
+  const segmentPath = clean.endsWith("/") ? clean.slice(0, -1) : clean;
+  const parts = segmentPath.split("/");
+  if (parts.some((part) => part === "")) {
+    return { ok: false, error: "model_asset_path_must_not_contain_empty_segments" };
+  }
+
+  const lower = clean.toLowerCase();
+  if (PROTECTED_MODEL_ASSET_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+    return { ok: false, error: "protected_model_asset_prefix_not_allowed" };
+  }
+
+  return { ok: true, path: clean };
+}
+
+function validatePublicModelAssetPrefix(value) {
+  const syntax = validateModelAssetPathSyntax(value);
+  if (!syntax.ok) return syntax;
+  const prefix = normalizeR2Prefix(syntax.path);
+  if (!PUBLIC_MODEL_ASSET_PREFIX_RE.test(prefix)) {
+    return { ok: false, error: "model_asset_prefix_not_public_safe", path: prefix };
+  }
+  return { ok: true, prefix };
+}
+
+function validatePublicModelAssetKey(value) {
+  const syntax = validateModelAssetPathSyntax(value);
+  if (!syntax.ok) return syntax;
+  const key = syntax.path.replace(/\/+$/g, "");
+  if (!PUBLIC_MODEL_ASSET_KEY_RE.test(key)) {
+    return { ok: false, error: "model_asset_key_not_public_safe", path: key };
+  }
+  return { ok: true, key };
+}
+
+function assertPublicModelAssetPrefix(value) {
+  const validation = validatePublicModelAssetPrefix(value);
+  if (!validation.ok) {
+    throw new Error(validation.error || "invalid_model_asset_prefix");
+  }
+  return validation.prefix;
+}
+
 async function listR2ObjectCount(env, folderPrefix, limit = 1000) {
   const bucket = env.MMD_MODEL_ASSETS;
-  const prefix = normalizeR2Prefix(folderPrefix);
+  const prefix = assertPublicModelAssetPrefix(folderPrefix);
   if (!bucket || !prefix || typeof bucket.list !== "function") return { object_count: null, exists: false };
   const listing = await bucket.list({ prefix, limit });
   const objects = Array.isArray(listing?.objects) ? listing.objects : [];
@@ -1077,11 +1139,14 @@ async function searchR2ByConfiguredCategories(env, { q, sourceOwner, categoryPat
   }
 
   for (const basePrefix of uniqueStrings(bases)) {
-    const listing = await bucket.list({ prefix: basePrefix, limit: 1000 });
+    const validation = validatePublicModelAssetPrefix(basePrefix);
+    if (!validation.ok) continue;
+    const safeBasePrefix = validation.prefix;
+    const listing = await bucket.list({ prefix: safeBasePrefix, limit: 1000 });
     const objects = Array.isArray(listing?.objects) ? listing.objects : [];
     const folderCounts = new Map();
     for (const object of objects) {
-      const segment = segmentAfterBase(object?.key, basePrefix);
+      const segment = segmentAfterBase(object?.key, safeBasePrefix);
       if (!segment) continue;
       folderCounts.set(segment, (folderCounts.get(segment) || 0) + 1);
     }
@@ -1089,7 +1154,7 @@ async function searchR2ByConfiguredCategories(env, { q, sourceOwner, categoryPat
     for (const [folderName, objectCount] of folderCounts.entries()) {
       const folderToken = normalizeLooseToken(folderName);
       if (folderToken === queryToken || folderToken.includes(queryToken) || queryToken.includes(folderToken)) {
-        const matchedPrefix = joinR2Path(basePrefix, folderName);
+        const matchedPrefix = joinR2Path(safeBasePrefix, folderName);
         return {
           matched_name: folderName,
           matched_prefix: matchedPrefix,
@@ -1139,11 +1204,13 @@ async function searchR2ModelSource(env, { q, sourceOwner, categoryPath }) {
   const owner = getModelSourceOwner(env, sourceOwner);
   const exactCandidates = buildR2ExactPrefixCandidates({ q, sourceOwner: owner, categoryPath, env });
   for (const prefix of exactCandidates) {
-    const count = await listR2ObjectCount(env, prefix, 200);
+    const validation = validatePublicModelAssetPrefix(prefix);
+    if (!validation.ok) continue;
+    const count = await listR2ObjectCount(env, validation.prefix, 200);
     if (count.exists) {
       return {
         matched_name: str(q),
-        matched_prefix: normalizeR2Prefix(prefix),
+        matched_prefix: validation.prefix,
         category_path: normalizeCategoryPath(categoryPath || inferCategoryFromPrefix(prefix, owner)),
         object_count: count.object_count,
       };
@@ -1224,21 +1291,30 @@ async function stageModelFromSource(env, body = {}) {
   const modelName = str(body.model_name || body.name || body.q);
   const sourceOwner = getModelSourceOwner(env, body.source_owner);
   const categoryPath = normalizeCategoryPath(body.category_path);
-  const r2Prefix = normalizeR2Prefix(body.r2_prefix);
+  const rawR2Prefix = str(body.r2_prefix);
+  const r2Prefix = normalizeR2Prefix(rawR2Prefix);
   if (!modelName) throw new Error("missing_model_name");
 
   const resolved = r2Prefix
-    ? {
+    ? (() => {
+        const prefixValidation = validatePublicModelAssetPrefix(rawR2Prefix);
+        if (!prefixValidation.ok) throw new Error(prefixValidation.error || "invalid_model_asset_prefix");
+        return {
         ok: true,
-        found: (await listR2ObjectCount(env, r2Prefix, 200)).exists,
+        found: null,
         source: "r2",
         query: modelName,
         source_owner: sourceOwner,
         matched_name: modelName,
-        matched_prefix: r2Prefix,
-        category_path: categoryPath || inferCategoryFromPrefix(r2Prefix, sourceOwner),
-      }
+        matched_prefix: prefixValidation.prefix,
+        category_path: categoryPath || inferCategoryFromPrefix(prefixValidation.prefix, sourceOwner),
+      };
+      })()
     : await resolveModelSource(env, { q: modelName, sourceOwner, categoryPath });
+
+  if (r2Prefix && resolved.source === "r2") {
+    resolved.found = (await listR2ObjectCount(env, resolved.matched_prefix, 200)).exists;
+  }
 
   if (resolved.source === "airtable") return { ok: true, staged: false, reason: "already_exists_in_airtable", resolved };
   if (resolved.source !== "r2" || !resolved.found) return { ok: false, staged: false, reason: "r2_source_not_found", resolved };
@@ -2127,6 +2203,8 @@ export {
   calculateProvisionalPricing,
   choosePricingReplyStrategy,
   parseAdContextSignals,
+  validatePublicModelAssetKey,
+  validatePublicModelAssetPrefix,
 };
 
 /* =========================

--- a/admin-worker/model-asset-prefix.test.mjs
+++ b/admin-worker/model-asset-prefix.test.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  validatePublicModelAssetKey,
+  validatePublicModelAssetPrefix,
+} from "./index.js";
+
+test("accepts public-safe model asset prefixes", () => {
+  assert.equal(validatePublicModelAssetPrefix("models/mdl_123/profile/").ok, true);
+  assert.equal(validatePublicModelAssetPrefix("models/mdl_123/gallery/").ok, true);
+  assert.equal(validatePublicModelAssetPrefix("models/mdl_123/compcard/").ok, true);
+});
+
+test("accepts public-safe model asset object keys", () => {
+  assert.equal(validatePublicModelAssetKey("models/mdl_123/profile/main.jpg").ok, true);
+  assert.equal(validatePublicModelAssetKey("models/mdl_123/gallery/img_001.jpg").ok, true);
+  assert.equal(validatePublicModelAssetKey("models/mdl_123/compcard/front.jpg").ok, true);
+});
+
+test("rejects protected prefixes", () => {
+  for (const prefix of ["private/", "evidence/", "line-notes/", "sigil/", "blackcard/", "slips/"]) {
+    const validation = validatePublicModelAssetPrefix(`${prefix}abc/`);
+    assert.equal(validation.ok, false, prefix);
+    assert.equal(validation.error, "protected_model_asset_prefix_not_allowed");
+  }
+});
+
+test("rejects traversal and URL-looking paths", () => {
+  const cases = [
+    "../models/mdl_123/profile/",
+    "models/../mdl_123/profile/",
+    "models/mdl_123\\profile\\",
+    "models//mdl_123/profile/",
+    "/models/mdl_123/profile/",
+    "https://models.mmdbkk.com/models/mdl_123/profile/",
+    "http://models.mmdbkk.com/models/mdl_123/profile/",
+  ];
+
+  for (const value of cases) {
+    assert.equal(validatePublicModelAssetPrefix(value).ok, false, value);
+  }
+});
+
+test("rejects non-public model asset shapes", () => {
+  assert.equal(validatePublicModelAssetPrefix("models/mdl_123/private/").ok, false);
+  assert.equal(validatePublicModelAssetPrefix("models/mdl_123/").ok, false);
+  assert.equal(validatePublicModelAssetKey("models/mdl_123/profile/side.jpg").ok, false);
+  assert.equal(validatePublicModelAssetKey("models/mdl_123/gallery/img_001.png").ok, false);
+});

--- a/admin-worker/src/lib/airtable-deals.ts
+++ b/admin-worker/src/lib/airtable-deals.ts
@@ -1,0 +1,210 @@
+import type { DealLite, Env, UpsertAiRequest, UpsertAiResponse } from "../types";
+
+const DEAL_FIELDS = [
+  "deal_id",
+  "client_id",
+  "client_name",
+  "channel",
+  "client_tier",
+  "occasion",
+  "timing_label",
+  "venue_name",
+  "budget_amount_thb",
+  "budget_signal",
+  "history_signal",
+  "high_value_client",
+  "specific_model_requested",
+  "ai_top_model",
+  "ai_reply_draft",
+  "ai_requires_per_review",
+  "deal_status",
+  "urgency_level",
+] as const;
+
+type AirtableValue = string | number | boolean | string[] | null | undefined;
+
+interface AirtableRecord {
+  id: string;
+  fields?: Record<string, AirtableValue>;
+}
+
+interface AirtableListResponse {
+  records?: AirtableRecord[];
+  offset?: string;
+}
+
+function airtableUrl(env: Env): URL {
+  return new URL(
+    `https://api.airtable.com/v0/${encodeURIComponent(env.AIRTABLE_BASE_ID)}/${encodeURIComponent(env.AIRTABLE_TABLE_DEALS)}`,
+  );
+}
+
+function authHeaders(env: Env): HeadersInit {
+  return {
+    Authorization: `Bearer ${env.AIRTABLE_API_KEY}`,
+    "content-type": "application/json",
+  };
+}
+
+function getString(
+  fields: Record<string, AirtableValue> | undefined,
+  key: string,
+): string | undefined {
+  const value = fields?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function getNumber(
+  fields: Record<string, AirtableValue> | undefined,
+  key: string,
+): number | undefined {
+  const value = fields?.[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function getBoolean(
+  fields: Record<string, AirtableValue> | undefined,
+  key: string,
+): boolean | undefined {
+  const value = fields?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function mapDeal(record: AirtableRecord): DealLite | null {
+  const fields = record.fields;
+  const deal_id = getString(fields, "deal_id");
+  const client_name = getString(fields, "client_name");
+  const channel = getString(fields, "channel");
+  const client_tier = getString(fields, "client_tier");
+  const deal_status = getString(fields, "deal_status");
+
+  if (!deal_id || !client_name || !channel || !client_tier || !deal_status) {
+    return null;
+  }
+
+  return {
+    deal_id,
+    client_id: getString(fields, "client_id"),
+    client_name,
+    channel: channel as DealLite["channel"],
+    client_tier: client_tier as DealLite["client_tier"],
+    occasion: getString(fields, "occasion"),
+    timing_label: getString(fields, "timing_label"),
+    venue_name: getString(fields, "venue_name"),
+    budget_amount_thb: getNumber(fields, "budget_amount_thb"),
+    budget_signal: getString(fields, "budget_signal") as
+      | DealLite["budget_signal"]
+      | undefined,
+    history_signal: getString(fields, "history_signal") as
+      | DealLite["history_signal"]
+      | undefined,
+    high_value_client: getBoolean(fields, "high_value_client"),
+    specific_model_requested: getBoolean(fields, "specific_model_requested"),
+    ai_top_model: getString(fields, "ai_top_model"),
+    ai_reply_draft: getString(fields, "ai_reply_draft"),
+    ai_requires_per_review: getBoolean(fields, "ai_requires_per_review"),
+    deal_status: deal_status as DealLite["deal_status"],
+    urgency_level: getString(fields, "urgency_level") as
+      | DealLite["urgency_level"]
+      | undefined,
+  };
+}
+
+function toAirtableFields(payload: UpsertAiRequest): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(payload).filter(([, value]) => value !== undefined),
+  );
+}
+
+async function findDealRecordId(env: Env, dealId: string): Promise<string | null> {
+  const url = airtableUrl(env);
+  url.searchParams.set("maxRecords", "1");
+  url.searchParams.set("filterByFormula", `{deal_id} = '${dealId.replace(/'/g, "\\'")}'`);
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: authHeaders(env),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Airtable deal lookup failed: ${response.status} ${text}`);
+  }
+
+  const data = (await response.json()) as AirtableListResponse;
+  return data.records?.[0]?.id ?? null;
+}
+
+export async function listDealsLite(env: Env): Promise<DealLite[]> {
+  const all: DealLite[] = [];
+  let offset: string | undefined;
+
+  do {
+    const url = airtableUrl(env);
+
+    for (const field of DEAL_FIELDS) {
+      url.searchParams.append("fields[]", field);
+    }
+
+    url.searchParams.set("pageSize", "100");
+
+    if (offset) {
+      url.searchParams.set("offset", offset);
+    }
+
+    const response = await fetch(url.toString(), {
+      method: "GET",
+      headers: authHeaders(env),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Airtable deals list failed: ${response.status} ${text}`);
+    }
+
+    const data = (await response.json()) as AirtableListResponse;
+
+    for (const record of data.records ?? []) {
+      const mapped = mapDeal(record);
+      if (mapped) {
+        all.push(mapped);
+      }
+    }
+
+    offset = data.offset;
+  } while (offset);
+
+  return all;
+}
+
+export async function upsertDealAi(
+  env: Env,
+  payload: UpsertAiRequest,
+): Promise<UpsertAiResponse> {
+  const existingRecordId = await findDealRecordId(env, payload.deal_id);
+  const fields = toAirtableFields(payload);
+
+  const response = await fetch(
+    existingRecordId ? `${airtableUrl(env).toString()}/${existingRecordId}` : airtableUrl(env).toString(),
+    {
+      method: existingRecordId ? "PATCH" : "POST",
+      headers: authHeaders(env),
+      body: JSON.stringify({ fields }),
+    },
+  );
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Airtable deal upsert failed: ${response.status} ${text}`);
+  }
+
+  const record = (await response.json()) as AirtableRecord;
+
+  return {
+    ok: true,
+    deal_id: payload.deal_id,
+    updated: Boolean(existingRecordId),
+    created: !existingRecordId,
+    airtable_record_id: record.id,
+  };
+}

--- a/admin-worker/src/lib/airtable.ts
+++ b/admin-worker/src/lib/airtable.ts
@@ -1,0 +1,138 @@
+import type { Env, ModelCardLite } from "../types";
+
+const MODEL_FIELDS = [
+  "working_name",
+  "model_tier",
+  "orientation_label",
+  "height_cm",
+  "body_type",
+  "base_area",
+  "vibe_tags",
+  "best_for",
+  "languages",
+  "available_now",
+  "availability_status",
+  "minimum_rate_90m",
+  "ai_match_summary",
+  "requires_per_approval",
+] as const;
+
+type AirtableValue = string | number | boolean | string[] | null | undefined;
+
+interface AirtableRecord {
+  id: string;
+  fields?: Record<string, AirtableValue>;
+}
+
+interface AirtableListResponse {
+  records?: AirtableRecord[];
+  offset?: string;
+}
+
+function getFieldString(
+  fields: Record<string, AirtableValue> | undefined,
+  key: string,
+): string | undefined {
+  const value = fields?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function getFieldNumber(
+  fields: Record<string, AirtableValue> | undefined,
+  key: string,
+): number | undefined {
+  const value = fields?.[key];
+  return typeof value === "number" ? value : undefined;
+}
+
+function getFieldBoolean(
+  fields: Record<string, AirtableValue> | undefined,
+  key: string,
+): boolean {
+  return fields?.[key] === true;
+}
+
+function getFieldStringArray(
+  fields: Record<string, AirtableValue> | undefined,
+  key: string,
+): string[] {
+  const value = fields?.[key];
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function mapRecordToLite(record: AirtableRecord): ModelCardLite | null {
+  const fields = record.fields;
+  const working_name = getFieldString(fields, "working_name");
+  const model_tier = getFieldString(fields, "model_tier");
+
+  if (!working_name || !model_tier) {
+    return null;
+  }
+
+  return {
+    working_name,
+    model_tier: model_tier as ModelCardLite["model_tier"],
+    orientation_label: getFieldString(fields, "orientation_label") as
+      | ModelCardLite["orientation_label"]
+      | undefined,
+    height_cm: getFieldNumber(fields, "height_cm"),
+    body_type: getFieldString(fields, "body_type"),
+    base_area: getFieldString(fields, "base_area"),
+    vibe_tags: getFieldStringArray(fields, "vibe_tags"),
+    best_for: getFieldStringArray(fields, "best_for"),
+    languages: getFieldStringArray(fields, "languages"),
+    available_now: getFieldBoolean(fields, "available_now"),
+    availability_status: getFieldString(fields, "availability_status"),
+    minimum_rate_90m: getFieldNumber(fields, "minimum_rate_90m") ?? 0,
+    ai_match_summary: getFieldString(fields, "ai_match_summary"),
+    requires_per_approval: getFieldBoolean(fields, "requires_per_approval"),
+  };
+}
+
+export async function listModelCardsLite(env: Env): Promise<ModelCardLite[]> {
+  const all: ModelCardLite[] = [];
+  let offset: string | undefined;
+
+  do {
+    const url = new URL(
+      `https://api.airtable.com/v0/${encodeURIComponent(env.AIRTABLE_BASE_ID)}/${encodeURIComponent(env.AIRTABLE_TABLE_MODELS)}`,
+    );
+
+    for (const field of MODEL_FIELDS) {
+      url.searchParams.append("fields[]", field);
+    }
+
+    url.searchParams.set("pageSize", "100");
+
+    if (offset) {
+      url.searchParams.set("offset", offset);
+    }
+
+    const response = await fetch(url.toString(), {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${env.AIRTABLE_API_KEY}`,
+      },
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Airtable list failed: ${response.status} ${text}`);
+    }
+
+    const data = (await response.json()) as AirtableListResponse;
+
+    for (const record of data.records ?? []) {
+      const mapped = mapRecordToLite(record);
+      if (mapped) {
+        all.push(mapped);
+      }
+    }
+
+    offset = data.offset;
+  } while (offset);
+
+  return all;
+}

--- a/admin-worker/src/lib/auth.ts
+++ b/admin-worker/src/lib/auth.ts
@@ -1,0 +1,6 @@
+import type { Env } from "../types";
+
+export function isAuthorized(request: Request, env: Env): boolean {
+  const auth = request.headers.get("authorization");
+  return auth === `Bearer ${env.INTERNAL_TOKEN}`;
+}

--- a/admin-worker/src/types.ts
+++ b/admin-worker/src/types.ts
@@ -4,6 +4,8 @@ export interface Env {
   AIRTABLE_BASE_ID: string;
   AIRTABLE_TABLE_MODELS: string;
   AIRTABLE_TABLE_DEALS: string;
+  AIRTABLE_TABLE_MMD_SHOP_INVENTORY_BATCHES: string;
+  AIRTABLE_TABLE_MMD_SHOP_PRODUCTS: string;
 }
 
 export type ModelTier = "standard" | "premium" | "vip" | "gws" | "ems";
@@ -121,4 +123,43 @@ export interface UpsertAiResponse {
   updated: boolean;
   created?: boolean;
   airtable_record_id?: string;
+}
+
+export interface StockItemLite {
+  id: string;
+  batch_id: string;
+  batch_name: string;
+  batch_code?: string;
+  product_id?: string;
+  product_name: string;
+  supplier_name?: string;
+  category?: string;
+  cost_price: number;
+  retail_price: number;
+  stock_qty: number;
+  quantity_in?: number;
+  stock_status: string;
+  approval_status?: string;
+  mmd_shop_product_url?: string;
+  internal_notes?: string;
+}
+
+export interface StockListResponse {
+  ok: true;
+  count: number;
+  items: StockItemLite[];
+}
+
+export interface StockUpdateRequest {
+  id: string;
+  stock_qty?: number;
+  stock_status?: string;
+  internal_notes?: string;
+  cost_price?: number | null;
+  product_name?: string;
+}
+
+export interface StockUpdateResponse {
+  ok: true;
+  record: unknown;
 }

--- a/admin-worker/wrangler.toml
+++ b/admin-worker/wrangler.toml
@@ -2,46 +2,268 @@
 # LOCK v2026-LOCK-01
 
 name = "admin-worker"
-main = "index.js"
+main = "src/index.ts"
 compatibility_date = "2026-01-01"
 workers_dev = true
 
+[[services]]
+binding = "TELEGRAM_WORKER"
+service = "telegram-worker"
+
+[[services]]
+binding = "CHAT_WORKER"
+service = "chat-worker-ai-integration"
+
+[[services]]
+binding = "EVENTS_WORKER"
+service = "events-worker"
+
 # ใช้สำหรับ CORS (browser calls)
 [vars]
-ALLOWED_ORIGINS = "https://mmdbkk.com,https://www.mmdbkk.com,https://mmdprive.com,https://www.mmdprive.com,https://mmdprive.webflow.io"
+ALLOWED_ORIGINS = "https://sigil.mmdbkk.com,https://mmdbkk.com,https://www.mmdbkk.com,https://mmdprive.com,https://www.mmdprive.com,https://mmdprive.webflow.io"
 
 # Base URLs (LOCK)
+EVENTS_WORKER_BASE_URL = "https://events-worker.malemodel-bkk.workers.dev"
 PAYMENTS_BASE_URL = "https://payments-worker.malemodel-bkk.workers.dev"
 TELEGRAM_INTERNAL_SEND_URL = "https://telegram-worker.malemodel-bkk.workers.dev/telegram/internal/send"
+IMMIGRATE_WORKER_BASE_URL = "https://immigrate-worker.malemodel-bkk.workers.dev"
 
 # Airtable
 AIRTABLE_BASE_ID = "appsV1ILPRfIjkaYg"
+AIRTABLE_TABLE_MEMBERSHIP_APPLICATIONS = "tbl8z2MQpIqcdylim"
+AIRTABLE_TABLE_MEMBERS = "tblgWc5VRon5o8Mhk"
+AIRTABLE_TABLE_PAYMENTS = "tblWGGJJOx5eBvBZJ"
+AIRTABLE_TABLE_SESSIONS = "tblC98mKWbzmPuNzX"
+AIRTABLE_TABLE_ACTIVITY_LOGS = "tblbUWRoFL6OI6QMJ"
+AIRTABLE_TABLE_MEMBER_ENTITLEMENTS = "tblNImdF9PKAxhXGi"
+AIRTABLE_TABLE_POINTS_LEDGER = "points_ledger"
+AT_SESSIONS__SESSION_ID = "fldLTq2kZbyRv22IA"
+AT_SESSIONS__STATUS = "fldHAlxnRfpKucnNV"
+AT_SESSIONS__PACKAGE_CODE = "fldp6xNSvxDh5pjR9"
+AT_SESSIONS__AMOUNT_THB = "fldhwC79ndbnEXSZz"
+AT_SESSIONS__PAYMENT_STATUS = "fldTY5lE6m0kQf72n"
+AT_SESSIONS__PAYMENT_REF = "fldojgjSQLaO0uQLX"
+AT_SESSIONS__MEMBERSTACK_ID = "fldjelgJTzCHSCWZ0"
+AT_PAYMENTS__PAYMENT_REF = "fldOO6SY49iDw8VBZ"
+AT_PAYMENTS__PAYMENT_DATE = "fld3yAwxIu2dkw7fO"
+AT_PAYMENTS__AMOUNT = "fldvCSwrUW8OMAooS"
+AT_PAYMENTS__PAYMENT_STATUS = "fldEJ1hmm7KwWuI6q"
+AT_PAYMENTS__PAYMENT_METHOD = "fldsblzIn0wzan3c9"
+AT_PAYMENTS__VERIFICATION_STATUS = "fldJ7a0Ube9F0bmRy"
+AT_PAYMENTS__PACKAGE_CODE = "fldfyHYVrzbGPvMJR"
+AT_PAYMENTS__CREATED_AT = "flduxcPpowBxEZSLu"
 
 # Writer table IDs (LOCK)
 AIRTABLE_TABLE_CONSOLE_INBOX_ID = "tblFHmfpB2TTrzO2e"
 AIRTABLE_TABLE_PAYMENT_PROOFS_ID = "tblfJfM4Sqag9zrLi"
 
-# Optional table names (ถ้าคุณใช้ name-based endpoints)
-AIRTABLE_TABLE_MEMBERS = "members"
-AIRTABLE_TABLE_MODELS = "models"
+# Optional table names / IDs
+AIRTABLE_TABLE_MODELS = "tblI4B0bI446vp9GX"
+AIRTABLE_TABLE_DEALS = "Deals"
+AIRTABLE_TABLE_JOBS = "tbl0jxIjN8QYwGABX"
+AIRTABLE_TABLE_CLIENTS = "tblVv58TCbwh5j1fS"
+AIRTABLE_TABLE_INTERNAL_NOTES = "tbl1Tt1IXDc9k0zxK"
+ALLOWED_MODEL_FIELDS = "name,working_name,model_name,nickname,telegram_username,telegram_id,unique_key,status,notes,line_id,storage_source_primary,r2_prefix,source_folder,source_owner,requires_per_approval,service_layer,orientation_label,sales_layer,private_tier,private_work_format,exclusive_group,can_work_public,can_work_private,pn_ability,mk_ability,burn_ability,pn_condition_note,mk_condition_note,burn_condition_note,private_admin_note,private_review_status,immigration_source,immigration_job_id,immigration_session_id,immigrated_at,immigrated_by,approved_for_private_sales,model_ability_snapshot"
+MODEL_ASSETS_PUBLIC_BASE_URL = ""
+MODEL_ASSETS_BUCKET_NAME = "MMD_MODEL_ASSETS"
 MODEL_SOURCE_OWNER_DEFAULT = "lonelysomething"
 MODEL_R2_LOOKUP_ENABLED = "true"
-MODEL_R2_USE_SOURCE_OWNER_AS_PREFIX = "false"
 MODEL_R2_ROOT_PREFIX = ""
 MODEL_R2_CATEGORY_PATHS = "MMD Public Models/MMD Travel Compcard,MMD Public Models/MMD Travel Models,MMD Public Models/MMD Travel Models/Straight,MMD Public Models/MMD Travel Models/Gay,MMD Public Models/MMD Travel Models/Both,MMD Public Models/MMD Extreme Models,MMD Public Models/MMD Extreme Models/Straight,MMD Public Models/MMD Extreme Models/Gay,MMD Public Models/MMD Extreme Models/Both,MMD Private Models/Standard Package,MMD Private Models/Premium Package,MMD Exclusive/MMD Exclusive Models,Public Models/Extreme Models/Straight"
+
+# Pricing review flow
 PRICING_TIMEOUT_MINUTES = "10"
 PRICING_TIMEOUT_SEND_TO_CUSTOMER = "false"
 LINE_WEBHOOK_DEBUG = "false"
-PRICING_REVIEW_TELEGRAM_PER_ID = ""
+# Optional: set these to direct Telegram chat IDs if Per/Ewvon should receive DMs.
+# Otherwise pricing reviews use TELEGRAM_CHAT_ID + TG_THREAD_PRICING_REVIEW/TG_THREAD_CONFIRM.
+PRICING_REVIEW_TELEGRAM_PER_ID = "7027379851"
 PRICING_REVIEW_TELEGRAM_EWVON_ID = ""
 TG_THREAD_PRICING_REVIEW = "61"
-
-[[r2_buckets]]
-binding = "MMD_MODEL_ASSETS"
-bucket_name = "mmd-models"
 
 # ---- Secrets (set via wrangler secret) ----
 # ADMIN_BEARER
 # CONFIRM_KEY
 # AIRTABLE_API_KEY
 # INTERNAL_TOKEN
+
+# R2 bucket binding for source-owner model library fallback lookup.
+[[r2_buckets]]
+binding = "MMD_MODEL_ASSETS"
+bucket_name = "mmd-model-assets"
+
+[[routes]]
+pattern = "admin-worker.mmdbkk.com"
+custom_domain = true
+
+[[routes]]
+pattern = "api.mmdbkk.com"
+custom_domain = true
+
+[[routes]]
+pattern = "mmdbkk.com/internal/admin/jobs/create-session*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/internal/admin/jobs/create-session*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/internal/admin/jobs/create-job*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/internal/admin/jobs/create-job*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/internal/admin/*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/internal/admin/*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/internal/admin/notes-hub*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/internal/admin/notes-hub*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/ping*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/ping*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/membership/request*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/membership/request*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/clients/list*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/clients/list*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/models/list*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/models/list*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/models/search*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/models/search*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/models/*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/models/*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/jobs/create-session*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/jobs/create-session*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/jobs/create-job*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/jobs/create-job*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/notes/context*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/notes/context*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/clients/lineage-lookup*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/clients/lineage-lookup*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/clients/recent*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/clients/recent*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/job/create*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/job/create*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/job/draft*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/job/draft*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/admin/line/push*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/admin/line/push*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/api/member/*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/api/member/*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/v1/model/session/*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/v1/model/session/*"
+zone_name = "mmdbkk.com"

--- a/admin-worker/wrangler.toml
+++ b/admin-worker/wrangler.toml
@@ -90,7 +90,7 @@ TG_THREAD_PRICING_REVIEW = "61"
 # R2 bucket binding for source-owner model library fallback lookup.
 [[r2_buckets]]
 binding = "MMD_MODEL_ASSETS"
-bucket_name = "mmd-model-assets"
+bucket_name = "mmd-models"
 
 [[routes]]
 pattern = "admin-worker.mmdbkk.com"

--- a/apps/web-admin-console/.gitignore
+++ b/apps/web-admin-console/.gitignore
@@ -1,0 +1,2 @@
+.next
+node_modules

--- a/apps/web-admin-console/README.md
+++ b/apps/web-admin-console/README.md
@@ -1,0 +1,27 @@
+# Web Admin Console
+
+Next.js admin console for the MMD Privé admin-worker deals API.
+
+## Run Locally
+
+Terminal 1:
+
+```bash
+cd admin-worker
+npx wrangler dev --port 8787
+```
+
+Terminal 2:
+
+```bash
+cd apps/web-admin-console
+NEXT_PUBLIC_ADMIN_API_BASE=http://localhost:8787 ADMIN_INTERNAL_TOKEN=<token> npm run dev
+```
+
+The console routes are:
+
+- `/admin`
+- `/admin/console`
+- `/admin/console/dashboard`
+- `/admin/console/deals`
+- `/admin/console/deals/[deal_id]`

--- a/apps/web-admin-console/app/admin/console/dashboard/page.tsx
+++ b/apps/web-admin-console/app/admin/console/dashboard/page.tsx
@@ -1,0 +1,41 @@
+import { getDashboardSummary } from "@/lib/admin-api";
+
+export const dynamic = "force-dynamic";
+
+export default async function DashboardPage() {
+  const summary = await getDashboardSummary();
+
+  const metrics = [
+    { label: "Open Deals", value: summary.open_deals },
+    { label: "Needs Per", value: summary.needs_per },
+    { label: "Pending Payments", value: summary.pending_payments },
+    { label: "Active Models", value: summary.active_models },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-3 border-b border-white/10 pb-6">
+        <p className="text-xs uppercase tracking-[0.26em] text-amber-200/70">
+          Deal Operations
+        </p>
+        <h1 className="text-3xl font-semibold text-white">Admin Dashboard</h1>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {metrics.map((metric) => (
+          <div
+            key={metric.label}
+            className="rounded-lg border border-white/10 bg-white/[0.04] p-5"
+          >
+            <div className="text-xs uppercase tracking-[0.2em] text-white/45">
+              {metric.label}
+            </div>
+            <div className="mt-3 text-3xl font-semibold text-amber-100">
+              {metric.value}
+            </div>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/web-admin-console/app/admin/console/deals/[deal_id]/page.tsx
+++ b/apps/web-admin-console/app/admin/console/deals/[deal_id]/page.tsx
@@ -1,0 +1,14 @@
+import { DealDetailPanel } from "@/components/admin/deals/deal-detail-panel";
+import { getDealById } from "@/lib/admin-api";
+
+export const dynamic = "force-dynamic";
+
+export default async function DealDetailRoutePage({
+  params,
+}: {
+  params: Promise<{ deal_id: string }>;
+}) {
+  const { deal_id } = await params;
+  const deal = await getDealById(deal_id);
+  return <DealDetailPanel deal={deal} />;
+}

--- a/apps/web-admin-console/app/admin/console/deals/page.tsx
+++ b/apps/web-admin-console/app/admin/console/deals/page.tsx
@@ -1,0 +1,9 @@
+import { DealsPage } from "@/components/admin/deals/deals-page";
+import { getDeals } from "@/lib/admin-api";
+
+export const dynamic = "force-dynamic";
+
+export default async function DealsRoutePage() {
+  const { deals } = await getDeals();
+  return <DealsPage deals={deals} />;
+}

--- a/apps/web-admin-console/app/admin/console/layout.tsx
+++ b/apps/web-admin-console/app/admin/console/layout.tsx
@@ -1,0 +1,9 @@
+import { ConsoleShell } from "@/components/admin/console-shell";
+
+export default function AdminConsoleLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <ConsoleShell>{children}</ConsoleShell>;
+}

--- a/apps/web-admin-console/app/admin/console/page.tsx
+++ b/apps/web-admin-console/app/admin/console/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminConsolePage() {
+  redirect("/admin/console/deals");
+}

--- a/apps/web-admin-console/app/admin/page.tsx
+++ b/apps/web-admin-console/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminPage() {
+  redirect("/admin/console/dashboard");
+}

--- a/apps/web-admin-console/app/globals.css
+++ b/apps/web-admin-console/app/globals.css
@@ -1,0 +1,27 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+  background: #080808;
+}
+
+body {
+  margin: 0;
+  color: #f7f3ea;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/apps/web-admin-console/app/layout.tsx
+++ b/apps/web-admin-console/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "MMD Privé Admin Console",
+  description: "Admin console for MMD Privé deals.",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/web-admin-console/components/admin/console-shell.tsx
+++ b/apps/web-admin-console/components/admin/console-shell.tsx
@@ -1,0 +1,12 @@
+import { Sidebar } from "./sidebar";
+
+export function ConsoleShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-[#080808] text-[#f7f3ea]">
+      <div className="grid min-h-screen grid-cols-1 xl:grid-cols-[260px_1fr]">
+        <Sidebar />
+        <main className="min-w-0 p-5 lg:p-7">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/web-admin-console/components/admin/deals/action-bar.tsx
+++ b/apps/web-admin-console/components/admin/deals/action-bar.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import type { Deal } from "@/lib/types";
+
+export function ActionBar({ deal }: { deal: Deal }) {
+  return (
+    <aside className="rounded-lg border border-white/10 bg-white/[0.04] p-5">
+      <h3 className="font-semibold text-white">Actions</h3>
+      <div className="mt-4 grid gap-3">
+        <button className="rounded-md bg-amber-300 px-4 py-3 text-sm font-semibold text-black transition hover:bg-amber-200">
+          Approve AI
+        </button>
+        <button className="rounded-md border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/80 transition hover:bg-white/10">
+          Ask More
+        </button>
+        <button className="rounded-md border border-white/10 bg-white/5 px-4 py-3 text-sm text-white/80 transition hover:bg-white/10">
+          Send Payment
+        </button>
+        <button className="rounded-md border border-rose-400/20 bg-rose-500/10 px-4 py-3 text-sm text-rose-100 transition hover:bg-rose-500/15">
+          Close Deal
+        </button>
+      </div>
+      <div className="mt-4 text-xs text-white/35">Deal: {deal.deal_id}</div>
+    </aside>
+  );
+}

--- a/apps/web-admin-console/components/admin/deals/deal-card.tsx
+++ b/apps/web-admin-console/components/admin/deals/deal-card.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import type { Deal } from "@/lib/types";
+
+function Badge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex rounded px-2 py-1 text-xs font-medium text-amber-100 ring-1 ring-amber-300/20">
+      {children}
+    </span>
+  );
+}
+
+export function DealCard({ deal }: { deal: Deal }) {
+  return (
+    <Link
+      href={`/admin/console/deals/${deal.deal_id}`}
+      className="block rounded-lg border border-white/10 bg-white/[0.04] p-4 transition hover:border-amber-300/25 hover:bg-white/[0.07]"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate font-semibold text-white">{deal.client_name}</div>
+          <div className="mt-1 truncate text-xs text-white/45">
+            {deal.deal_id} · {deal.channel}
+          </div>
+        </div>
+        <Badge>{deal.client_tier}</Badge>
+      </div>
+
+      <div className="mt-3 text-sm text-white/75">
+        {[deal.occasion, deal.timing_label, deal.venue_name]
+          .filter(Boolean)
+          .join(" · ") || "No request context"}
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-white/60">
+        <span>{deal.deal_status}</span>
+        {deal.urgency_level ? <span>{deal.urgency_level}</span> : null}
+        {deal.budget_amount_thb ? (
+          <span>{deal.budget_amount_thb.toLocaleString()} THB</span>
+        ) : null}
+      </div>
+    </Link>
+  );
+}

--- a/apps/web-admin-console/components/admin/deals/deal-detail-panel.tsx
+++ b/apps/web-admin-console/components/admin/deals/deal-detail-panel.tsx
@@ -1,0 +1,66 @@
+import type { Deal } from "@/lib/types";
+import { ActionBar } from "./action-bar";
+
+function formatThb(value?: number) {
+  return value == null ? "-" : `${value.toLocaleString()} THB`;
+}
+
+function Field({ label, value }: { label: string; value?: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/25 p-4">
+      <div className="text-xs uppercase tracking-[0.18em] text-white/40">{label}</div>
+      <div className="mt-2 text-sm text-white/85">{value || "-"}</div>
+    </div>
+  );
+}
+
+export function DealDetailPanel({ deal }: { deal: Deal }) {
+  return (
+    <section className="min-w-0 space-y-5">
+      <div className="rounded-lg border border-white/10 bg-white/[0.04] p-5 shadow-soft">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="text-xs uppercase tracking-[0.24em] text-white/45">
+              Deal Detail
+            </p>
+            <h2 className="mt-2 text-3xl font-semibold text-white">{deal.deal_id}</h2>
+            <p className="mt-2 text-white/65">{deal.client_name}</p>
+          </div>
+          <div className="flex flex-wrap gap-2 text-xs">
+            <span className="rounded bg-amber-300/10 px-2 py-1 text-amber-100">
+              {deal.client_tier}
+            </span>
+            <span className="rounded bg-white/10 px-2 py-1 text-white/75">
+              {deal.deal_status}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-5 2xl:grid-cols-[1fr_340px]">
+        <div className="space-y-5">
+          <div className="grid gap-3 md:grid-cols-2">
+            <Field label="Occasion" value={deal.occasion} />
+            <Field label="Timing" value={deal.timing_label} />
+            <Field label="Venue" value={deal.venue_name} />
+            <Field label="Budget" value={formatThb(deal.budget_amount_thb)} />
+            <Field label="Budget Signal" value={deal.budget_signal} />
+            <Field label="History Signal" value={deal.history_signal} />
+          </div>
+
+          <div className="rounded-lg border border-white/10 bg-white/[0.04] p-5">
+            <h3 className="font-semibold text-white">AI Recommendation</h3>
+            <div className="mt-4 rounded-lg bg-black/25 p-4 text-sm leading-6 text-white/75">
+              <div className="font-medium text-white">
+                Top model: {deal.ai_top_model || "-"}
+              </div>
+              <p className="mt-2">{deal.ai_reply_draft || "No draft returned yet."}</p>
+            </div>
+          </div>
+        </div>
+
+        <ActionBar deal={deal} />
+      </div>
+    </section>
+  );
+}

--- a/apps/web-admin-console/components/admin/deals/deal-list.tsx
+++ b/apps/web-admin-console/components/admin/deals/deal-list.tsx
@@ -1,0 +1,21 @@
+import type { Deal } from "@/lib/types";
+import { DealCard } from "./deal-card";
+
+export function DealList({ deals }: { deals: Deal[] }) {
+  return (
+    <section className="min-w-0 space-y-4">
+      <div className="border-b border-white/10 pb-4">
+        <p className="text-xs uppercase tracking-[0.24em] text-amber-200/70">
+          Deals
+        </p>
+        <h1 className="mt-2 text-2xl font-semibold text-white">Control Panel</h1>
+      </div>
+
+      <div className="space-y-3">
+        {deals.map((deal) => (
+          <DealCard key={deal.deal_id} deal={deal} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web-admin-console/components/admin/deals/deals-page.tsx
+++ b/apps/web-admin-console/components/admin/deals/deals-page.tsx
@@ -1,0 +1,20 @@
+import type { Deal } from "@/lib/types";
+import { DealDetailPanel } from "./deal-detail-panel";
+import { DealList } from "./deal-list";
+
+export function DealsPage({ deals }: { deals: Deal[] }) {
+  const selected = deals[0];
+
+  return (
+    <div className="grid gap-5 xl:grid-cols-[400px_1fr]">
+      <DealList deals={deals} />
+      {selected ? (
+        <DealDetailPanel deal={selected} />
+      ) : (
+        <div className="rounded-lg border border-white/10 bg-white/[0.04] p-8 text-white/55">
+          No deals returned from admin-worker.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web-admin-console/components/admin/sidebar.tsx
+++ b/apps/web-admin-console/components/admin/sidebar.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+const items = [
+  { href: "/admin/console/dashboard", label: "Dashboard" },
+  { href: "/admin/console/deals", label: "Deals" },
+];
+
+export function Sidebar() {
+  return (
+    <aside className="border-b border-white/10 bg-black/50 p-5 xl:border-b-0 xl:border-r">
+      <div className="mb-6">
+        <div className="text-xs uppercase tracking-[0.26em] text-amber-200/70">
+          MMD Privé
+        </div>
+        <div className="mt-2 text-2xl font-semibold text-white">Admin Console</div>
+      </div>
+
+      <nav className="flex gap-2 xl:block xl:space-y-2">
+        {items.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="block rounded-md border border-transparent px-3 py-2 text-sm text-white/70 transition hover:border-white/10 hover:bg-white/5 hover:text-white"
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/apps/web-admin-console/lib/admin-api.ts
+++ b/apps/web-admin-console/lib/admin-api.ts
@@ -1,0 +1,68 @@
+import type { DashboardSummary, Deal, DealsListResponse } from "./types";
+
+export const ADMIN_API_BASE =
+  process.env.NEXT_PUBLIC_ADMIN_API_BASE || "http://localhost:8787";
+
+export const ADMIN_INTERNAL_TOKEN =
+  process.env.ADMIN_INTERNAL_TOKEN ||
+  process.env.NEXT_PUBLIC_ADMIN_INTERNAL_TOKEN ||
+  "";
+
+const CLOSED_STATUSES = new Set([
+  "confirmed",
+  "expired",
+  "declined",
+  "cancelled",
+]);
+
+function adminHeaders(): HeadersInit {
+  return ADMIN_INTERNAL_TOKEN
+    ? { authorization: `Bearer ${ADMIN_INTERNAL_TOKEN}` }
+    : {};
+}
+
+export async function getDeals(): Promise<DealsListResponse> {
+  const response = await fetch(`${ADMIN_API_BASE}/v1/admin/deals/list-lite`, {
+    method: "GET",
+    headers: adminHeaders(),
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to load deals: ${response.status} ${text}`);
+  }
+
+  return (await response.json()) as DealsListResponse;
+}
+
+export async function getDealById(dealId: string): Promise<Deal> {
+  const { deals } = await getDeals();
+  const deal = deals.find((item) => item.deal_id === dealId);
+
+  if (!deal) {
+    throw new Error(`Deal not found: ${dealId}`);
+  }
+
+  return deal;
+}
+
+export async function getDashboardSummary(): Promise<DashboardSummary> {
+  const { deals } = await getDeals();
+
+  return {
+    open_deals: deals.filter((deal) => !CLOSED_STATUSES.has(deal.deal_status)).length,
+    needs_per: deals.filter(
+      (deal) =>
+        deal.deal_status === "needs_per_review" || deal.ai_requires_per_review,
+    ).length,
+    pending_payments: deals.filter((deal) =>
+      ["awaiting_payment", "payment_received"].includes(deal.deal_status),
+    ).length,
+    active_models: new Set(
+      deals
+        .map((deal) => deal.ai_top_model)
+        .filter((model): model is string => Boolean(model)),
+    ).size,
+  };
+}

--- a/apps/web-admin-console/lib/types.ts
+++ b/apps/web-admin-console/lib/types.ts
@@ -1,0 +1,50 @@
+export type ClientTier = "standard" | "premium" | "vip" | "svip" | "blackcard";
+export type Channel = "web" | "line" | "telegram" | "internal";
+export type DealStatus =
+  | "new_inquiry"
+  | "ai_processing"
+  | "needs_per_review"
+  | "awaiting_client_reply"
+  | "awaiting_payment"
+  | "payment_received"
+  | "ready_to_offer_model"
+  | "offer_sent_to_model"
+  | "model_accepted"
+  | "confirmed"
+  | "expired"
+  | "declined"
+  | "cancelled";
+
+export interface Deal {
+  deal_id: string;
+  client_id?: string;
+  client_name: string;
+  channel: Channel;
+  client_tier: ClientTier;
+  occasion?: string;
+  timing_label?: string;
+  venue_name?: string;
+  budget_amount_thb?: number;
+  budget_signal?: "low" | "standard" | "premium" | "high";
+  history_signal?: "none" | "low" | "medium" | "high";
+  high_value_client?: boolean;
+  specific_model_requested?: boolean;
+  ai_top_model?: string;
+  ai_reply_draft?: string;
+  ai_requires_per_review?: boolean;
+  deal_status: DealStatus;
+  urgency_level?: "low" | "normal" | "high" | "fast_lane";
+}
+
+export interface DealsListResponse {
+  ok: true;
+  deals: Deal[];
+  count: number;
+}
+
+export interface DashboardSummary {
+  open_deals: number;
+  needs_per: number;
+  pending_payments: number;
+  active_models: number;
+}

--- a/apps/web-admin-console/next-env.d.ts
+++ b/apps/web-admin-console/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web-admin-console/next.config.ts
+++ b/apps/web-admin-console/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/apps/web-admin-console/package-lock.json
+++ b/apps/web-admin-console/package-lock.json
@@ -1,0 +1,2076 @@
+{
+  "name": "web-admin-console",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "web-admin-console",
+      "version": "0.1.0",
+      "dependencies": {
+        "next": "15.2.0",
+        "react": "19.0.0",
+        "react-dom": "19.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.13.10",
+        "@types/react": "^19.0.10",
+        "@types/react-dom": "^19.0.4",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.5.3",
+        "tailwindcss": "^3.4.17",
+        "typescript": "^5.8.2"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.2.0.tgz",
+      "integrity": "sha512-eMgJu1RBXxxqqnuRJQh5RozhskoNUDHBFybvi+Z+yK9qzKeG7dadhv/Vp1YooSZmCnegf7JxWuapV77necLZNA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.2.0.tgz",
+      "integrity": "sha512-rlp22GZwNJjFCyL7h5wz9vtpBVuCt3ZYjFWpEPBGzG712/uL1bbSkS675rVAUCRZ4hjoTJ26Q7IKhr5DfJrHDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.2.0.tgz",
+      "integrity": "sha512-DiU85EqSHogCz80+sgsx90/ecygfCSGl5P3b4XDRVZpgujBm5lp4ts7YaHru7eVTyZMjHInzKr+w0/7+qDrvMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.2.0.tgz",
+      "integrity": "sha512-VnpoMaGukiNWVxeqKHwi8MN47yKGyki5q+7ql/7p/3ifuU2341i/gDwGK1rivk0pVYbdv5D8z63uu9yMw0QhpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.2.0.tgz",
+      "integrity": "sha512-ka97/ssYE5nPH4Qs+8bd8RlYeNeUVBhcnsNUmFM6VWEob4jfN9FTr0NBhXVi1XEJpj3cMfgSRW+LdE3SUZbPrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.2.0.tgz",
+      "integrity": "sha512-zY1JduE4B3q0k2ZCE+DAF/1efjTXUsKP+VXRtrt/rJCTgDlUyyryx7aOgYXNc1d8gobys/Lof9P9ze8IyRDn7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.2.0.tgz",
+      "integrity": "sha512-QqvLZpurBD46RhaVaVBepkVQzh8xtlUN00RlG4Iq1sBheNugamUNPuZEH1r9X1YGQo1KqAe1iiShF0acva3jHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.2.0.tgz",
+      "integrity": "sha512-ODZ0r9WMyylTHAN6pLtvUtQlGXBL9voljv6ujSlcsjOxhtXPI1Ag6AhZK0SE8hEpR1374WZZ5w33ChpJd5fsjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.2.0.tgz",
+      "integrity": "sha512-8+4Z3Z7xa13NdUuUAcpVNA6o76lNPniBd9Xbo02bwXQXnZgFvEopwY2at5+z7yHl47X9qbZpvwatZ2BRo3EdZw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.360",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
+      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.2.0.tgz",
+      "integrity": "sha512-VaiM7sZYX8KIAHBrRGSFytKknkrexNfGb8GlG6e93JqueCspuGte8i4ybn8z4ww1x3f2uzY4YpTaBEW4/hvsoQ==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/CVE-2025-66478 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.2.0",
+        "@swc/counter": "0.1.3",
+        "@swc/helpers": "0.5.15",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.2.0",
+        "@next/swc-darwin-x64": "15.2.0",
+        "@next/swc-linux-arm64-gnu": "15.2.0",
+        "@next/swc-linux-arm64-musl": "15.2.0",
+        "@next/swc-linux-x64-gnu": "15.2.0",
+        "@next/swc-linux-x64-musl": "15.2.0",
+        "@next/swc-win32-arm64-msvc": "15.2.0",
+        "@next/swc-win32-x64-msvc": "15.2.0",
+        "sharp": "^0.33.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+      "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.25.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/web-admin-console/package.json
+++ b/apps/web-admin-console/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "web-admin-console",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.2.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "@types/react": "^19.0.10",
+    "@types/react-dom": "^19.0.4",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.5.3",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.8.2"
+  }
+}

--- a/apps/web-admin-console/postcss.config.js
+++ b/apps/web-admin-console/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web-admin-console/tailwind.config.ts
+++ b/apps/web-admin-console/tailwind.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./lib/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    extend: {
+      boxShadow: {
+        soft: "0 24px 80px rgba(0, 0, 0, 0.28)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/apps/web-admin-console/tsconfig.json
+++ b/apps/web-admin-console/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/docs/admin-console-local-smoke-test.md
+++ b/docs/admin-console-local-smoke-test.md
@@ -1,0 +1,51 @@
+# Admin Console Local Smoke Test
+
+Use this checklist to run the Admin Console and admin-worker together on a local machine.
+
+## Terminal 1
+
+```bash
+cd admin-worker
+npx wrangler dev --port 8787
+```
+
+## Terminal 2
+
+```bash
+cd apps/web-admin-console
+NEXT_PUBLIC_ADMIN_API_BASE=http://localhost:8787 ADMIN_INTERNAL_TOKEN=<YOUR_INTERNAL_TOKEN> npm run dev
+```
+
+## Browser
+
+Open:
+
+```text
+http://localhost:3000/admin/console/deals
+```
+
+## Curl Checks
+
+```bash
+curl http://localhost:8787/v1/admin/health
+```
+
+```bash
+curl http://localhost:8787/v1/admin/deals/list-lite \
+  -H "Authorization: Bearer <YOUR_INTERNAL_TOKEN>"
+```
+
+```bash
+curl -X POST http://localhost:8787/v1/admin/deals/upsert-ai \
+  -H "Authorization: Bearer <YOUR_INTERNAL_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "deal_id": "DL-001",
+    "client_name": "Test Client",
+    "channel": "web",
+    "client_tier": "premium",
+    "deal_status": "needs_per_review",
+    "ai_top_model": "Hito",
+    "ai_reply_draft": "We have a strong match in mind."
+  }'
+```

--- a/docs/architecture/MMD_R2_MODEL_ASSET_SETUP.md
+++ b/docs/architecture/MMD_R2_MODEL_ASSET_SETUP.md
@@ -43,6 +43,14 @@ models/{model_id}/gallery/{image_id}.jpg
 models/{model_id}/compcard/{image_id}.jpg
 ```
 
+Admin-worker now validates model asset prefixes before R2 list/count metadata calls. Public-safe metadata lookup is limited to:
+
+```text
+models/{model_id}/profile/
+models/{model_id}/gallery/
+models/{model_id}/compcard/
+```
+
 Do not guess public object keys during migration. If the clean key is unknown, leave a TODO in the relevant implementation or handoff note instead of replacing a private/signed URL.
 
 ## Protected Assets
@@ -90,15 +98,17 @@ Repo search found:
 
 - `admin-worker/wrangler.toml` already has an R2 binding for source-owner model library fallback lookup:
   - binding: `MMD_MODEL_ASSETS`
-  - bucket: `mmd-model-assets`
-- `admin-worker/src/index.js` uses `env.MMD_MODEL_ASSETS` for R2 source lookup, folder preview listing, and safe metadata responses.
+  - bucket: `mmd-models`
+- `admin-worker/README` documents the same R2 binding: `MMD_MODEL_ASSETS -> mmd-models`.
+- `admin-worker/index.js` uses `env.MMD_MODEL_ASSETS` for R2 source lookup and safe metadata responses, with public-safe prefix validation before R2 list/count calls.
+- `core/api-worker` also verifies model asset keys through `MMD_MODEL_ASSETS`, so its binding should also point at `mmd-models`.
 - `immigrate-worker/wrangler.toml` has an `EVIDENCE_BUCKET` binding to `mmd-sigil-evidence` for recovery/evidence upload work.
 - `docs/architecture/MODEL_IDENTITY_RESOLVER.md` already warns not to return R2 signed URLs or private media.
 - `docs/architecture/RECOVERY_LV8_ROUTE_READINESS.md` documents recovery evidence R2 setup for `mmd-sigil-evidence`.
 - No committed `models.mmdbkk.com` or `assets.mmdbkk.com` assumptions were found in the checked repo paths.
 - No committed frontend/Webflow `r2.cloudflarestorage.com`, `r2.dev`, or `X-Amz-Signature` URL was found in the checked repo paths.
 
-No `MMD_MODELS -> mmd-models` binding has been added in this patch because no worker currently reads `env.MMD_MODELS`, and Cloudflare custom-domain/bucket state has not been manually confirmed. Do not create `MMD_MODELS -> mmd-models` until Cloudflare confirms the intended bucket/domain contract. Do not add speculative R2 bindings to unrelated workers, and do not add an R2 binding to `jobs-worker` without explicit approval.
+Do not add speculative R2 bindings to unrelated workers, and do not add an R2 binding to `jobs-worker` without explicit approval.
 
 ## Deployment Doctrine
 

--- a/docs/architecture/MMD_R2_MODEL_ASSET_SETUP.md
+++ b/docs/architecture/MMD_R2_MODEL_ASSET_SETUP.md
@@ -1,0 +1,133 @@
+# MMD R2 Model Asset Setup
+
+This note records the current MMD R2 model asset direction without changing Cloudflare production. It keeps MMD PRIVÉ, MMD ACADEMY, and SIGIL / Trust-Inme media responsibilities separate.
+
+## Current Discovery
+
+- Current production-ish repo binding: `MMD_MODEL_ASSETS -> mmd-model-assets` in `admin-worker`
+- Discovered private/signed legacy/export R2 endpoint: `b176eda1172b741fd2e58904cc9d77c5.r2.cloudflarestorage.com`
+- Discovered legacy/export bucket from signed URL/CSV evidence: `mmd-models`
+- Evidence bucket: `EVIDENCE_BUCKET -> mmd-sigil-evidence` in `immigrate-worker`
+- Example private endpoint shape: `https://b176eda1172b741fd2e58904cc9d77c5.r2.cloudflarestorage.com/mmd-models/...`
+- This endpoint appears to be the Cloudflare R2 S3/API endpoint, not a custom public CDN domain.
+
+Do not assume `mmd-models` is the canonical production model asset bucket until Cloudflare R2 bucket/domain state is manually confirmed. It may be a legacy bucket, export batch, migration bucket, or a source from a different system era.
+
+Signed R2 URLs and URLs containing `X-Amz-Signature` must not be committed, pasted into Webflow, embedded in frontend code, or treated as stable public media URLs.
+
+## Public Model Assets
+
+Production public model assets should eventually use a custom R2 public domain:
+
+```text
+models.mmdbkk.com -> confirmed production public model asset bucket
+```
+
+The target bucket is not locked by this repo patch. Current candidates to confirm in Cloudflare are:
+
+- `mmd-model-assets`, because `admin-worker` currently binds `MMD_MODEL_ASSETS` to this bucket.
+- `mmd-models`, because it was discovered from legacy/export signed URL evidence.
+
+Only public-safe assets may be served through `models.mmdbkk.com`:
+
+- public model profile images
+- public compcards
+- public gallery images
+- public preview assets approved for frontend display
+
+Preferred object key pattern:
+
+```text
+models/{model_id}/profile/main.jpg
+models/{model_id}/gallery/{image_id}.jpg
+models/{model_id}/compcard/{image_id}.jpg
+```
+
+Do not guess public object keys during migration. If the clean key is unknown, leave a TODO in the relevant implementation or handoff note instead of replacing a private/signed URL.
+
+## Protected Assets
+
+These assets must not be served from the public R2 custom domain:
+
+- private model photos
+- Black Card assets
+- SIGIL assets
+- ID / verification files
+- payment slips
+- LINE Official Note screenshots
+- LINE evidence files
+- admin-only documents
+- sensitive client/model files
+
+Protected media access should go through `admin-worker` first, with admin auth, role/session checks, prefix allowlists, and safe response headers. A future `media-worker` may be proposed only if scope grows beyond admin-worker.
+
+Protected media routes must:
+
+- require authentication before reading R2
+- deny arbitrary object key traversal
+- allow only approved prefixes
+- return `401` or `403` when unauthorized
+- return `404` without revealing sensitive object structure
+- use `Cache-Control: private, max-age=300`
+- never leak signed URLs into public frontend responses
+
+The current `/ceo` surface is Webflow/static frontend plus SIGIL OS CDN asset. It must not talk directly to R2. Future `/ceo` private asset or evidence access must use authenticated admin-worker endpoints.
+
+## Worker Ownership
+
+- `chat-worker` remains the member-facing AI concierge / Kenji persona.
+- `telegram-worker` remains the internal/system Telegram gateway only.
+- `payments-worker` owns payment verification, slips, `payment_ref`, `session_id` idempotency, and `payment_type`.
+- `events-worker` owns session lifecycle/state machine.
+- `admin-worker` is the back-office / SIGIL admin surface and the best current place for protected admin/private asset access.
+- `jobs-worker` is immigration/migration bridge only. It must not become the canonical media layer unless explicitly approved.
+
+Core production contracts must stay separate from immigration/migration logic.
+
+## Repository State Checked
+
+Repo search found:
+
+- `admin-worker/wrangler.toml` already has an R2 binding for source-owner model library fallback lookup:
+  - binding: `MMD_MODEL_ASSETS`
+  - bucket: `mmd-model-assets`
+- `admin-worker/src/index.js` uses `env.MMD_MODEL_ASSETS` for R2 source lookup, folder preview listing, and safe metadata responses.
+- `immigrate-worker/wrangler.toml` has an `EVIDENCE_BUCKET` binding to `mmd-sigil-evidence` for recovery/evidence upload work.
+- `docs/architecture/MODEL_IDENTITY_RESOLVER.md` already warns not to return R2 signed URLs or private media.
+- `docs/architecture/RECOVERY_LV8_ROUTE_READINESS.md` documents recovery evidence R2 setup for `mmd-sigil-evidence`.
+- No committed `models.mmdbkk.com` or `assets.mmdbkk.com` assumptions were found in the checked repo paths.
+- No committed frontend/Webflow `r2.cloudflarestorage.com`, `r2.dev`, or `X-Amz-Signature` URL was found in the checked repo paths.
+
+No `MMD_MODELS -> mmd-models` binding has been added in this patch because no worker currently reads `env.MMD_MODELS`, and Cloudflare custom-domain/bucket state has not been manually confirmed. Do not create `MMD_MODELS -> mmd-models` until Cloudflare confirms the intended bucket/domain contract. Do not add speculative R2 bindings to unrelated workers, and do not add an R2 binding to `jobs-worker` without explicit approval.
+
+## Deployment Doctrine
+
+R2 and Cloudflare config changes must follow:
+
+```text
+Local -> GitHub -> Cloudflare
+```
+
+Do not deploy directly from local work. Do not silently modify DNS, R2 bucket settings, custom domains, or production Worker bindings.
+
+## Cloudflare Manual Checklist
+
+Manual Cloudflare steps that must be completed outside this repo patch and listed in the PR body:
+
+- Cloudflare Dashboard > R2 Object Storage
+- Confirm whether bucket `mmd-model-assets` exists and is the active admin-worker model asset source.
+- Confirm whether bucket `mmd-models` still exists and whether it is active production, legacy, export, or migration storage.
+- Decide which bucket should back `models.mmdbkk.com`: `mmd-model-assets`, `mmd-models`, or another explicitly approved bucket.
+- Settings > Custom Domains
+- Add/verify `models.mmdbkk.com`
+- Confirm DNS record in zone `mmdbkk.com`
+- Confirm whether `r2.dev` public access is enabled or disabled, and for which bucket.
+- Confirm caching/security/WAF rules for `models.mmdbkk.com`
+- Confirm which object prefixes are intended to be public
+- Keep `mmd-sigil-evidence` private.
+
+## Implementation TODOs
+
+- After `models.mmdbkk.com` and its backing bucket are verified, set public frontend image URLs only for approved public-safe keys.
+- If admin/private media serving is needed, add the minimal authenticated route in `admin-worker`, bind the exact bucket it reads, and enforce prefix allowlists before `bucket.get`.
+- If `mmd-models` becomes the canonical model asset bucket for admin-worker, update code/config together so the binding name and bucket name are explicit and tested.


### PR DESCRIPTION
This PR adds the initial Admin Console frontend and connects it to admin-worker deals APIs.

Included:
- New apps/web-admin-console Next.js app
- Admin Console routes for dashboard and deals
- Deal list/detail UI shell
- admin-worker deals Airtable helper
- admin-worker auth/airtable helper wiring
- admin-worker wrangler.toml updates for src entry and Deals table
- local smoke test documentation

Checks run:
- cd apps/web-admin-console && npm install
- cd apps/web-admin-console && npm run build
- cd admin-worker && npx tsc -p "tsconfig 2.json" --noEmit

Notes:
- No deploy performed
- No production secrets touched
- apps/dashboard and apps/web-client not modified
- Existing npm audit warnings remain: 1 moderate, 1 critical
- Repo has unrelated unstaged/untracked changes that were not included