### PR TITLE
docs(architecture): add phase 3 recommend, travel, and partner policy docs

### DIFF
--- a/docs/architecture/MODEL_RECOMMEND.md
+++ b/docs/architecture/MODEL_RECOMMEND.md
@@ -1,0 +1,175 @@
+# MODEL_RECOMMEND
+
+## Purpose
+
+This document defines the phase 3 **Model Recommend** surface.
+
+Model Recommend exists to help the client lane make a better next decision without turning protected talent into an open catalog.
+
+Rule:
+
+**Recommendation is a client-lane decision-support surface, not an open roster browser.**
+
+---
+
+## What Model Recommend is
+
+Model Recommend is a controlled interpretation layer.
+
+It may help a client understand:
+- which type of model may fit the request
+- what kind of session energy is appropriate
+- which constraints need clarification
+- whether manual review is needed
+- whether the request should move to booking, travel, or support
+
+It is not:
+- a public roster
+- a searchable model directory
+- a popularity ranking
+- a partner-facing shortlist
+- a way to reveal protected models
+- a way to bypass official booking or verification
+
+The recommendation output should guide the next step, not expose the full supply side.
+
+---
+
+## Lane ownership
+
+Model Recommend belongs primarily to the **Client Lane**.
+
+It may read model-side signals, but it should not become a model-side console.
+
+Allowed alignment:
+- Kenji guides the client through fit, expectation, and next step
+- TarT may inform model-side readiness logic behind the surface
+- Boss Per may appear only as a short authority note when standards or final approval need emphasis
+
+Not allowed:
+- Yuki owning the recommend surface by default
+- Ewvon being used for ordinary recommendations
+- partner users receiving raw recommendation visibility
+- clients seeing protected internal ranking logic
+
+Rule:
+
+**Kenji explains the fit. TarT helps prepare the model lane. The client never receives raw internal selection logic.**
+
+---
+
+## Input signals
+
+The recommendation layer may consider:
+- client intent
+- desired city or travel need
+- schedule window
+- budget class
+- session type
+- language needs
+- comfort and safety constraints
+- membership status
+- verification status
+- previous client context where approved
+- model availability class
+- manual operator notes where approved
+
+The surface should avoid collecting unnecessary personal details before the client has reached the proper trust or verification stage.
+
+---
+
+## Output rules
+
+Recommended outputs should be abstracted and useful.
+
+Good outputs:
+- fit category
+- recommended next step
+- suggested request refinement
+- availability class
+- manual review needed
+- "we can prepare a suitable option after verification"
+- "this request should be routed to travel review"
+
+Restricted outputs:
+- full protected model identity
+- direct personal contact
+- private model handle
+- internal model score
+- private availability pattern
+- model-side notes
+- protected image sets
+- partner-only assumptions
+
+Rule:
+
+**The client should receive confidence and direction, not unrestricted model visibility.**
+
+---
+
+## Protected model handling
+
+Some models must remain protected even when they are a strong fit.
+
+For protected models:
+- do not expose identity by default
+- do not show face-first cards in ordinary recommend surfaces
+- do not expose exact availability
+- do not expose direct contact
+- do not make the model reachable through partner or concierge shortcuts
+- route matching through official review
+
+Allowed client-facing framing:
+- "A protected option may fit this request."
+- "This request needs private review before confirmation."
+- "We can prepare a suitable match after verification."
+
+Not allowed:
+- "Here is the protected model."
+- "Contact him directly."
+- "This model is free at this exact time."
+- "Partner access can unlock this model."
+
+---
+
+## Confirmation boundary
+
+Recommendation is not confirmation.
+
+A recommendation can say:
+- likely fit
+- possible fit
+- needs review
+- request mismatch
+- route to booking
+
+A recommendation must not say:
+- officially confirmed
+- model assigned
+- payment verified
+- proof accepted
+- travel locked
+
+Confirmation happens only after official verification and matching.
+
+---
+
+## Suggested route family
+
+Examples:
+- `/recommend`
+- `/sigil/recommend`
+- `/sigil/client/recommend`
+- `/sigil/client/match-review`
+
+Model-facing follow-up routes must stay under the Model Lane route family:
+- `/sigil/model/console?t=TOKEN`
+- `/sigil/model/client-brief?t=TOKEN`
+
+Never put `?t=...` in a Webflow page name. Use token query parameters only in real system-generated links.
+
+---
+
+## One-line definition
+
+**Model Recommend helps the client understand fit and next step while keeping protected talent, internal logic, and final confirmation inside controlled MMD review.**

--- a/docs/architecture/PARTNER_ACCESS_POLICY.md
+++ b/docs/architecture/PARTNER_ACCESS_POLICY.md
@@ -1,0 +1,291 @@
+# PARTNER_ACCESS_POLICY
+
+## Purpose
+
+This document defines the phase 3 **Partner Access Policy** for MMD.
+
+The policy protects model visibility, client trust, and MMD authority when hotels, concierges, travel contacts, event partners, brand collaborators, or trusted introducers interact with the system.
+
+Rule:
+
+**Partner access should create controlled business opportunity without becoming a backdoor to protected models, direct deals, or internal authority.**
+
+---
+
+## Relationship to Partner Lane
+
+This policy extends `PARTNER_LANE.md`.
+
+Partner Lane defines the route and relationship category.
+
+Partner Access Policy defines:
+- what partner-side users may see
+- what partner-side users may request
+- what must remain hidden
+- how protected model visibility is limited
+- how direct-deal attempts are blocked
+- when partner requests require manual review
+
+---
+
+## Canonical character alignment
+
+### Yuki
+
+Yuki owns partner-facing evaluation.
+
+Use Yuki for:
+- partner approval
+- partner review
+- partner gatekeeping
+- partner value checks
+- collaboration boundaries
+- controlled negotiation tone
+
+Yuki should be polite but sharp, evaluative, and value-focused.
+
+### Ewvon
+
+Ewvon owns Black Card and trusted access oversight.
+
+Do not use Ewvon for ordinary partner access, payment flow, or normal member support.
+
+If partner access touches Black Card-level trust, Ewvon may protect the deeper access layer, but Yuki remains bounded to Partner Division review.
+
+### Kenji
+
+Kenji may explain SĪGIL core routing, booking expectations, and client-lane next steps.
+
+Kenji should not become the partner evaluator.
+
+### TarT
+
+TarT may support model-side readiness after an approved partner request becomes a model-facing brief.
+
+TarT should not own partner approval.
+
+---
+
+## Partner access classes
+
+Partner access should be classed before any visibility is granted.
+
+Suggested classes:
+- `lead`
+- `unverified_partner`
+- `verified_partner`
+- `approved_partner`
+- `restricted_partner`
+- `suspended_partner`
+- `internal_only`
+
+### Lead
+
+May submit interest and basic business context.
+
+May not see model visibility, pricing logic, protected routes, or request status beyond acknowledgement.
+
+### Unverified partner
+
+May answer screening questions.
+
+May not receive curated model options, direct contact, or availability signals.
+
+### Verified partner
+
+May submit structured requests and receive controlled follow-up.
+
+May see generalized service categories and approved request status.
+
+### Approved partner
+
+May receive partner-facing coordination paths and curated outcome options.
+
+May not receive raw roster visibility or protected model details unless separately approved.
+
+### Restricted partner
+
+May be limited to manual review only.
+
+Use when the partner has incomplete trust, unclear source, direct-deal risk, or inconsistent request behavior.
+
+### Suspended partner
+
+May not submit new requests or receive model-related visibility.
+
+Use when a partner violates access boundaries, attempts direct deals, misuses information, or creates safety risk.
+
+---
+
+## Allowed partner visibility
+
+Approved partner surfaces may show:
+- relationship status
+- approved request scope
+- controlled contact path
+- generalized service categories
+- high-level city or request coverage
+- approved business-facing information
+- curated outcome options
+- manual review status
+- next required action
+
+Partner surfaces should be useful, but not revealing.
+
+Rule:
+
+**Partner usefulness should come from controlled service, not raw model visibility.**
+
+---
+
+## Restricted partner visibility
+
+Partner surfaces must not show:
+- protected model roster
+- private model faces or identities
+- direct personal handles
+- direct contact details
+- private model availability
+- model-side console data
+- exact travel willingness
+- protected pricing logic
+- admin notes
+- operator notes
+- Black Card authority logic
+- internal exception workflows
+- client private data unrelated to the partner request
+
+Partners should not be able to infer hidden model supply from filters, empty states, timing patterns, filenames, image URLs, or route names.
+
+---
+
+## Anti-direct-deal rules
+
+Direct-deal attempts must be treated as policy violations.
+
+Direct-deal signals include:
+- asking for a model's personal contact
+- requesting off-platform negotiation
+- attempting to bypass MMD payment
+- asking a staff member to reveal private availability
+- asking for a lower price outside official scope
+- trying to continue a request without MMD mediation
+- using partner status to pressure protected visibility
+
+System response should:
+- refuse direct contact exposure
+- keep communication system-mediated
+- move the request to manual review where needed
+- flag repeated behavior
+- restrict or suspend partner access for serious violations
+
+Allowed framing:
+- "MMD keeps model coordination inside the official review path."
+- "We can continue through the approved partner channel."
+- "Direct model contact is not available through this access level."
+
+Not allowed:
+- "Here is his private contact."
+- "You can settle directly."
+- "Partner status unlocks the model."
+- "Payment can happen outside MMD."
+
+---
+
+## Protected model visibility limits
+
+Protected models require stronger visibility limits.
+
+Before explicit approval:
+- do not show identity
+- do not show face-first cards
+- do not show private handles
+- do not show direct contact
+- do not show exact availability
+- do not show movement patterns
+- do not show internal suitability notes
+
+After explicit approval:
+- reveal only the minimum needed for the approved partner-facing action
+- keep the audit trail of who approved the reveal
+- keep contact mediated by MMD unless separately authorized
+- avoid creating reusable links that expose protected identity beyond the approved window
+
+Rule:
+
+**Protected-model visibility is granted by approval, not by partner status alone.**
+
+---
+
+## Partner-originated request flow
+
+Recommended flow:
+
+```txt
+Partner inquiry
+-> partner screening
+-> Yuki review
+-> request scope approved or declined
+-> client lane or travel request created
+-> model fit review
+-> protected visibility decision
+-> official confirmation only after verification and matching
+```
+
+The partner may receive:
+- request acknowledgement
+- clarification questions
+- approved scope
+- next step
+- manual review status
+- controlled outcome
+
+The partner must not receive:
+- raw matching list
+- internal ranking
+- protected model details
+- unofficial confirmation
+- private client or model notes
+
+---
+
+## Escalation rules
+
+Escalate to manual or founder-level review when:
+- request involves protected model visibility
+- partner asks for direct contact
+- partner asks for off-platform payment
+- request involves travel or unusual location
+- request creates brand, legal, safety, or reputation risk
+- partner tries to use relationship pressure
+- request touches Black Card or trusted access authority
+
+Boss Per may be used only for a short authority note or final standard-setting moment.
+
+Ewvon may be used only when the request touches Black Card-level trusted access.
+
+---
+
+## Suggested route family
+
+Examples:
+- `/partner`
+- `/partner/inquiry`
+- `/partner/apply`
+- `/partner/status`
+- `/partner/request`
+- `/partner/review`
+
+Do not use Model Lane routes for partner access.
+
+Model-facing follow-up routes must stay under:
+- `/sigil/model/client-brief?t=TOKEN`
+- `/sigil/model/console?t=TOKEN`
+
+Never put `?t=...` in the Webflow page name. Use token query parameters only in real system-generated links.
+
+---
+
+## One-line definition
+
+**Partner Access Policy lets MMD work with external business relationships while blocking direct deals, preserving protected model visibility, and keeping authority inside controlled review.**

--- a/docs/architecture/TRAVEL_MODEL_REQUEST.md
+++ b/docs/architecture/TRAVEL_MODEL_REQUEST.md
@@ -1,0 +1,184 @@
+# TRAVEL_MODEL_REQUEST
+
+## Purpose
+
+This document defines the phase 3 **Travel Model Request** flow.
+
+Travel requests are higher-risk than ordinary local requests because they combine client intent, model fit, schedule, city, cost, privacy, and safety into one controlled decision.
+
+Rule:
+
+**Travel model requests must be client-facing enough to collect intent, but protected enough to prevent direct-deal routing or exposed model visibility.**
+
+---
+
+## What the flow is
+
+The Travel Model Request flow is a controlled client-facing request path for sessions that may require a model to travel or meet outside the ordinary local operating context.
+
+It exists for:
+- destination requests
+- city-specific availability review
+- trip companion evaluation
+- event or booking context review
+- travel-window planning
+- manual operator review
+- protected model matching after verification
+
+It is not:
+- a travel roster
+- a direct booking shortcut
+- a partner marketplace
+- a public availability calendar
+- a way to negotiate with models directly
+- a way to bypass verification, payment, or official matching
+
+---
+
+## Lane ownership
+
+Travel Model Request belongs to the **Client Lane** until a model-facing brief is created.
+
+Primary voice:
+- Kenji for client guidance, expectation setting, verification reminders, and next-step clarity
+
+Supporting roles:
+- TarT for model-facing preparation after the request becomes an internal or model-side brief
+- Boss Per for short authority notes when policy, safety, or final approval needs a human standard
+- HYPE only for status or signal support, not as the main concierge
+
+Not default:
+- Yuki, unless the request is explicitly partner-originated and belongs to Partner Division review
+- Ewvon, unless the request touches Black Card or trusted access review
+
+---
+
+## Required request fields
+
+The request form or guided chat should collect only what is needed to evaluate the request.
+
+Recommended fields:
+- destination city or area
+- requested date window
+- expected duration
+- session type or context
+- number of guests where relevant
+- accommodation or transport responsibility
+- budget class
+- language preference
+- client verification status
+- special constraints
+- consent to official review
+
+Avoid asking for:
+- unnecessary personal identity details before the proper trust stage
+- direct model contact preferences
+- private model handles
+- payment proof as confirmation language
+- sensitive information unrelated to safety or booking review
+
+---
+
+## Decision states
+
+Travel requests should move through clear states.
+
+Suggested states:
+- `draft`
+- `submitted`
+- `needs_client_clarification`
+- `needs_verification`
+- `under_review`
+- `model_fit_review`
+- `travel_feasibility_review`
+- `quote_pending`
+- `awaiting_payment`
+- `payment_under_verification`
+- `matched`
+- `declined`
+- `expired`
+- `cancelled`
+
+Rule:
+
+**A travel request is not matched until official review, verification, and model fit are complete.**
+
+---
+
+## Client-facing language boundaries
+
+Allowed:
+- "Your request is under review."
+- "We may need to verify details before preparing options."
+- "Travel availability depends on model fit, schedule, and official approval."
+- "Proof is received as supporting evidence only."
+- "Confirmation happens after official verification and matching."
+
+Not allowed:
+- "This model is confirmed" before official matching
+- "Payment proof confirms the booking"
+- "You can contact the model directly"
+- "Partner can arrange it outside MMD"
+- "Any model can travel if the budget is high enough"
+
+---
+
+## Protected model visibility
+
+Travel requests must protect model visibility more strongly than ordinary requests.
+
+Before approval:
+- do not show protected model identity
+- do not show exact availability
+- do not show travel willingness as a public attribute
+- do not reveal private location or movement patterns
+- do not show model-side notes
+
+After approval:
+- reveal only the minimum needed for the client-facing stage
+- keep direct contact system-mediated unless a separate approved policy allows otherwise
+- preserve the audit trail for who approved the reveal
+
+---
+
+## Partner-originated travel requests
+
+If a hotel, concierge, travel contact, or external relationship source submits the request, route it through Partner Division first.
+
+Partner-originated requests may collect:
+- partner identity
+- business relationship context
+- client relationship to the partner
+- requested service scope
+- location and date window
+- review contact path
+
+Partner-originated requests must not receive:
+- protected roster access
+- direct model handles
+- private pricing logic
+- internal approval notes
+- Black Card authority logic
+
+Yuki may evaluate partner value and request legitimacy, but Yuki does not grant Black Card authority or protected model exposure by default.
+
+---
+
+## Suggested route family
+
+Examples:
+- `/sigil/client/travel-request`
+- `/sigil/client/travel-review`
+- `/sigil/client/request-status?t=TOKEN`
+
+Model-facing follow-up routes must stay under:
+- `/sigil/model/client-brief?t=TOKEN`
+- `/sigil/model/console?t=TOKEN`
+
+Never put `?t=...` in the Webflow page name. Use token query parameters only in real system-generated links.
+
+---
+
+## One-line definition
+
+**Travel Model Request is the controlled client-facing flow for destination or travel-based model requests, with official review protecting fit, safety, payment truth, and model visibility before any match is confirmed.**


### PR DESCRIPTION
## Summary

This PR adds phase 3 architecture docs for:
- model recommendation
- travel model request flow
- partner access policy

## Included

- `MODEL_RECOMMEND.md`
- `TRAVEL_MODEL_REQUEST.md`
- `PARTNER_ACCESS_POLICY.md`

## Key updates

- define recommendation as a client-lane decision-support surface, not an open roster browser
- define travel-company requests as a controlled client-facing flow
- define partner access boundaries, anti-direct-deal rules, and protected-model visibility limits

## Notes

This PR is documentation-only.
It does not change runtime behavior directly, but it gives clearer guidance for future product, UX, and policy decisions.