### PR TITLE
fix: guard MMD model asset R2 prefixes

### DIFF
--- a/admin-worker/index.js
+++ b/admin-worker/index.js
@@ -990,9 +990,71 @@ function redactedPrefix(prefix) {
   return `${parts.slice(0, 3).join("/")}/.../`;
 }
 
+const PUBLIC_MODEL_ASSET_PREFIX_RE = /^models\/[^/]+\/(?:profile|gallery|compcard)\/$/;
+const PUBLIC_MODEL_ASSET_KEY_RE = /^models\/[^/]+\/(?:(?:profile\/main)|(?:gallery\/[^/]+)|(?:compcard\/[^/]+))\.jpg$/;
+const PROTECTED_MODEL_ASSET_PREFIXES = [
+  "private/",
+  "evidence/",
+  "line-notes/",
+  "sigil/",
+  "blackcard/",
+  "slips/",
+];
+
+function validateModelAssetPathSyntax(value) {
+  const raw = str(value);
+  if (!raw) return { ok: false, error: "missing_model_asset_path" };
+  if (/^https?:\/\//i.test(raw)) return { ok: false, error: "model_asset_path_must_not_be_url" };
+  if (raw.startsWith("/")) return { ok: false, error: "model_asset_path_must_not_start_with_slash" };
+  if (raw.includes("\\")) return { ok: false, error: "model_asset_path_must_not_contain_backslash" };
+  if (raw.includes("..")) return { ok: false, error: "model_asset_path_must_not_contain_dotdot" };
+
+  const clean = raw.replace(/\/+$/g, raw.endsWith("/") ? "/" : "");
+  const segmentPath = clean.endsWith("/") ? clean.slice(0, -1) : clean;
+  const parts = segmentPath.split("/");
+  if (parts.some((part) => part === "")) {
+    return { ok: false, error: "model_asset_path_must_not_contain_empty_segments" };
+  }
+
+  const lower = clean.toLowerCase();
+  if (PROTECTED_MODEL_ASSET_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+    return { ok: false, error: "protected_model_asset_prefix_not_allowed" };
+  }
+
+  return { ok: true, path: clean };
+}
+
+function validatePublicModelAssetPrefix(value) {
+  const syntax = validateModelAssetPathSyntax(value);
+  if (!syntax.ok) return syntax;
+  const prefix = normalizeR2Prefix(syntax.path);
+  if (!PUBLIC_MODEL_ASSET_PREFIX_RE.test(prefix)) {
+    return { ok: false, error: "model_asset_prefix_not_public_safe", path: prefix };
+  }
+  return { ok: true, prefix };
+}
+
+function validatePublicModelAssetKey(value) {
+  const syntax = validateModelAssetPathSyntax(value);
+  if (!syntax.ok) return syntax;
+  const key = syntax.path.replace(/\/+$/g, "");
+  if (!PUBLIC_MODEL_ASSET_KEY_RE.test(key)) {
+    return { ok: false, error: "model_asset_key_not_public_safe", path: key };
+  }
+  return { ok: true, key };
+}
+
+function assertPublicModelAssetPrefix(value) {
+  const validation = validatePublicModelAssetPrefix(value);
+  if (!validation.ok) {
+    throw new Error(validation.error || "invalid_model_asset_prefix");
+  }
+  return validation.prefix;
+}
+
 async function listR2ObjectCount(env, folderPrefix, limit = 1000) {
   const bucket = env.MMD_MODEL_ASSETS;
-  const prefix = normalizeR2Prefix(folderPrefix);
+  const prefix = assertPublicModelAssetPrefix(folderPrefix);
   if (!bucket || !prefix || typeof bucket.list !== "function") return { object_count: null, exists: false };
   const listing = await bucket.list({ prefix, limit });
   const objects = Array.isArray(listing?.objects) ? listing.objects : [];
@@ -1077,11 +1139,14 @@ async function searchR2ByConfiguredCategories(env, { q, sourceOwner, categoryPat
   }
 
   for (const basePrefix of uniqueStrings(bases)) {
-    const listing = await bucket.list({ prefix: basePrefix, limit: 1000 });
+    const validation = validatePublicModelAssetPrefix(basePrefix);
+    if (!validation.ok) continue;
+    const safeBasePrefix = validation.prefix;
+    const listing = await bucket.list({ prefix: safeBasePrefix, limit: 1000 });
     const objects = Array.isArray(listing?.objects) ? listing.objects : [];
     const folderCounts = new Map();
     for (const object of objects) {
-      const segment = segmentAfterBase(object?.key, basePrefix);
+      const segment = segmentAfterBase(object?.key, safeBasePrefix);
       if (!segment) continue;
       folderCounts.set(segment, (folderCounts.get(segment) || 0) + 1);
     }
@@ -1089,7 +1154,7 @@ async function searchR2ByConfiguredCategories(env, { q, sourceOwner, categoryPat
     for (const [folderName, objectCount] of folderCounts.entries()) {
       const folderToken = normalizeLooseToken(folderName);
       if (folderToken === queryToken || folderToken.includes(queryToken) || queryToken.includes(folderToken)) {
-        const matchedPrefix = joinR2Path(basePrefix, folderName);
+        const matchedPrefix = joinR2Path(safeBasePrefix, folderName);
         return {
           matched_name: folderName,
           matched_prefix: matchedPrefix,
@@ -1139,11 +1204,13 @@ async function searchR2ModelSource(env, { q, sourceOwner, categoryPath }) {
   const owner = getModelSourceOwner(env, sourceOwner);
   const exactCandidates = buildR2ExactPrefixCandidates({ q, sourceOwner: owner, categoryPath, env });
   for (const prefix of exactCandidates) {
-    const count = await listR2ObjectCount(env, prefix, 200);
+    const validation = validatePublicModelAssetPrefix(prefix);
+    if (!validation.ok) continue;
+    const count = await listR2ObjectCount(env, validation.prefix, 200);
     if (count.exists) {
       return {
         matched_name: str(q),
-        matched_prefix: normalizeR2Prefix(prefix),
+        matched_prefix: validation.prefix,
         category_path: normalizeCategoryPath(categoryPath || inferCategoryFromPrefix(prefix, owner)),
         object_count: count.object_count,
       };
@@ -1224,21 +1291,30 @@ async function stageModelFromSource(env, body = {}) {
   const modelName = str(body.model_name || body.name || body.q);
   const sourceOwner = getModelSourceOwner(env, body.source_owner);
   const categoryPath = normalizeCategoryPath(body.category_path);
-  const r2Prefix = normalizeR2Prefix(body.r2_prefix);
+  const rawR2Prefix = str(body.r2_prefix);
+  const r2Prefix = normalizeR2Prefix(rawR2Prefix);
   if (!modelName) throw new Error("missing_model_name");
 
   const resolved = r2Prefix
-    ? {
+    ? (() => {
+        const prefixValidation = validatePublicModelAssetPrefix(rawR2Prefix);
+        if (!prefixValidation.ok) throw new Error(prefixValidation.error || "invalid_model_asset_prefix");
+        return {
         ok: true,
-        found: (await listR2ObjectCount(env, r2Prefix, 200)).exists,
+        found: null,
         source: "r2",
         query: modelName,
         source_owner: sourceOwner,
         matched_name: modelName,
-        matched_prefix: r2Prefix,
-        category_path: categoryPath || inferCategoryFromPrefix(r2Prefix, sourceOwner),
-      }
+        matched_prefix: prefixValidation.prefix,
+        category_path: categoryPath || inferCategoryFromPrefix(prefixValidation.prefix, sourceOwner),
+      };
+      })()
     : await resolveModelSource(env, { q: modelName, sourceOwner, categoryPath });
+
+  if (r2Prefix && resolved.source === "r2") {
+    resolved.found = (await listR2ObjectCount(env, resolved.matched_prefix, 200)).exists;
+  }
 
   if (resolved.source === "airtable") return { ok: true, staged: false, reason: "already_exists_in_airtable", resolved };
   if (resolved.source !== "r2" || !resolved.found) return { ok: false, staged: false, reason: "r2_source_not_found", resolved };
@@ -2127,6 +2203,8 @@ export {
   calculateProvisionalPricing,
   choosePricingReplyStrategy,
   parseAdContextSignals,
+  validatePublicModelAssetKey,
+  validatePublicModelAssetPrefix,
 };
 
 /* =========================

--- a/admin-worker/model-asset-prefix.test.mjs
+++ b/admin-worker/model-asset-prefix.test.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  validatePublicModelAssetKey,
+  validatePublicModelAssetPrefix,
+} from "./index.js";
+
+test("accepts public-safe model asset prefixes", () => {
+  assert.equal(validatePublicModelAssetPrefix("models/mdl_123/profile/").ok, true);
+  assert.equal(validatePublicModelAssetPrefix("models/mdl_123/gallery/").ok, true);
+  assert.equal(validatePublicModelAssetPrefix("models/mdl_123/compcard/").ok, true);
+});
+
+test("accepts public-safe model asset object keys", () => {
+  assert.equal(validatePublicModelAssetKey("models/mdl_123/profile/main.jpg").ok, true);
+  assert.equal(validatePublicModelAssetKey("models/mdl_123/gallery/img_001.jpg").ok, true);
+  assert.equal(validatePublicModelAssetKey("models/mdl_123/compcard/front.jpg").ok, true);
+});
+
+test("rejects protected prefixes", () => {
+  for (const prefix of ["private/", "evidence/", "line-notes/", "sigil/", "blackcard/", "slips/"]) {
+    const validation = validatePublicModelAssetPrefix(`${prefix}abc/`);
+    assert.equal(validation.ok, false, prefix);
+    assert.equal(validation.error, "protected_model_asset_prefix_not_allowed");
+  }
+});
+
+test("rejects traversal and URL-looking paths", () => {
+  const cases = [
+    "../models/mdl_123/profile/",
+    "models/../mdl_123/profile/",
+    "models/mdl_123\\profile\\",
+    "models//mdl_123/profile/",
+    "/models/mdl_123/profile/",
+    "https://models.mmdbkk.com/models/mdl_123/profile/",
+    "http://models.mmdbkk.com/models/mdl_123/profile/",
+  ];
+
+  for (const value of cases) {
+    assert.equal(validatePublicModelAssetPrefix(value).ok, false, value);
+  }
+});
+
+test("rejects non-public model asset shapes", () => {
+  assert.equal(validatePublicModelAssetPrefix("models/mdl_123/private/").ok, false);
+  assert.equal(validatePublicModelAssetPrefix("models/mdl_123/").ok, false);
+  assert.equal(validatePublicModelAssetKey("models/mdl_123/profile/side.jpg").ok, false);
+  assert.equal(validatePublicModelAssetKey("models/mdl_123/gallery/img_001.png").ok, false);
+});

--- a/admin-worker/wrangler.toml
+++ b/admin-worker/wrangler.toml
@@ -90,7 +90,7 @@ TG_THREAD_PRICING_REVIEW = "61"
 # R2 bucket binding for source-owner model library fallback lookup.
 [[r2_buckets]]
 binding = "MMD_MODEL_ASSETS"
-bucket_name = "mmd-model-assets"
+bucket_name = "mmd-models"
 
 [[routes]]
 pattern = "admin-worker.mmdbkk.com"

--- a/docs/architecture/MMD_R2_MODEL_ASSET_SETUP.md
+++ b/docs/architecture/MMD_R2_MODEL_ASSET_SETUP.md
@@ -43,6 +43,14 @@ models/{model_id}/gallery/{image_id}.jpg
 models/{model_id}/compcard/{image_id}.jpg
 ```
 
+Admin-worker now validates model asset prefixes before R2 list/count metadata calls. Public-safe metadata lookup is limited to:
+
+```text
+models/{model_id}/profile/
+models/{model_id}/gallery/
+models/{model_id}/compcard/
+```
+
 Do not guess public object keys during migration. If the clean key is unknown, leave a TODO in the relevant implementation or handoff note instead of replacing a private/signed URL.
 
 ## Protected Assets
@@ -90,15 +98,17 @@ Repo search found:
 
 - `admin-worker/wrangler.toml` already has an R2 binding for source-owner model library fallback lookup:
   - binding: `MMD_MODEL_ASSETS`
-  - bucket: `mmd-model-assets`
-- `admin-worker/src/index.js` uses `env.MMD_MODEL_ASSETS` for R2 source lookup, folder preview listing, and safe metadata responses.
+  - bucket: `mmd-models`
+- `admin-worker/README` documents the same R2 binding: `MMD_MODEL_ASSETS -> mmd-models`.
+- `admin-worker/index.js` uses `env.MMD_MODEL_ASSETS` for R2 source lookup and safe metadata responses, with public-safe prefix validation before R2 list/count calls.
+- `core/api-worker` also verifies model asset keys through `MMD_MODEL_ASSETS`, so its binding should also point at `mmd-models`.
 - `immigrate-worker/wrangler.toml` has an `EVIDENCE_BUCKET` binding to `mmd-sigil-evidence` for recovery/evidence upload work.
 - `docs/architecture/MODEL_IDENTITY_RESOLVER.md` already warns not to return R2 signed URLs or private media.
 - `docs/architecture/RECOVERY_LV8_ROUTE_READINESS.md` documents recovery evidence R2 setup for `mmd-sigil-evidence`.
 - No committed `models.mmdbkk.com` or `assets.mmdbkk.com` assumptions were found in the checked repo paths.
 - No committed frontend/Webflow `r2.cloudflarestorage.com`, `r2.dev`, or `X-Amz-Signature` URL was found in the checked repo paths.
 
-No `MMD_MODELS -> mmd-models` binding has been added in this patch because no worker currently reads `env.MMD_MODELS`, and Cloudflare custom-domain/bucket state has not been manually confirmed. Do not create `MMD_MODELS -> mmd-models` until Cloudflare confirms the intended bucket/domain contract. Do not add speculative R2 bindings to unrelated workers, and do not add an R2 binding to `jobs-worker` without explicit approval.
+Do not add speculative R2 bindings to unrelated workers, and do not add an R2 binding to `jobs-worker` without explicit approval.
 
 ## Deployment Doctrine
 


### PR DESCRIPTION
## Summary

- Guard admin-worker R2 model asset metadata access with public-safe prefix/key validation.
- Align admin-worker `MMD_MODEL_ASSETS` binding to `mmd-models`.
- Document enforced public-safe prefix policy.

## Behavior changed

- R2 list/count metadata calls now fail closed unless prefixes match:
  - `models/{model_id}/profile/`
  - `models/{model_id}/gallery/`
  - `models/{model_id}/compcard/`
- Rejects traversal, URLs, leading slash, backslashes, empty path segments, and protected prefixes.
- No object-serving route added.
- No signed URLs emitted.
- `/ceo` unchanged.

## Files changed

- `admin-worker/index.js`
- `admin-worker/model-asset-prefix.test.mjs`
- `admin-worker/wrangler.toml`
- `docs/architecture/MMD_R2_MODEL_ASSET_SETUP.md`

## Safety

- No Cloudflare deploy.
- No DNS/R2 dashboard changes.
- No new R2 bindings.
- No object-serving routes.
- No signed URL emission.
- `/ceo` unchanged.

## Tests

- `node --test admin-worker/model-asset-prefix.test.mjs`
- `node --check admin-worker/index.js`
- `git diff origin/setup-web-admin-console..HEAD --check`

## Known local blockers / base-shape notes

- `core/api-worker/test/studio.test.mjs` is not present on `origin/setup-web-admin-console`, so that requested check could not be run in this clean worktree.
- This base uses `admin-worker/index.js`, not `admin-worker/src/index.js`, so the guard was applied to the active admin-worker entrypoint for this branch.

## Risk

Medium-low. This changes admin-worker validation/config for R2 metadata access, but does not serve objects publicly or deploy Cloudflare changes.

## Rollback

Revert the PR commit.