### PR TITLE
fix: guard chat-worker OpenAI text model config

### DIFF
--- a/chat-worker/src/index.js
+++ b/chat-worker/src/index.js
@@ -14,6 +14,18 @@
 //   OPENAI_MODEL (var) e.g. "gpt-4.1-mini" (example)
 //   CHAT_SESSIONS_KV (KV namespace)  // optional: store convo context per member_id
 
+const DEFAULT_OPENAI_TEXT_MODEL = "gpt-4.1-mini";
+const OPENAI_TEXT_MODEL_CONFIG_ERROR = "OPENAI_MODEL must be a text model for chat-worker /v1/responses.";
+const INVALID_OPENAI_TEXT_MODELS = new Set(["gpt-image-1", "gpt-image-2"]);
+
+function trimStr(value) {
+  return value === null || value === undefined ? "" : String(value).trim();
+}
+
+function isInvalidOpenAITextModel(value) {
+  return INVALID_OPENAI_TEXT_MODELS.has(trimStr(value).toLowerCase());
+}
+
 function corsHeaders(origin, allowedCsv) {
   const allowed = (allowedCsv || "")
     .split(",")
@@ -58,7 +70,11 @@ async function aiReplyMock(input) {
 async function aiReplyOpenAI(env, input) {
   // Minimal OpenAI REST call (no SDK) — keep it simple
   const apiKey = env.OPENAI_API_KEY;
-  const model = env.OPENAI_MODEL || "gpt-4.1-mini";
+  const model = trimStr(env.OPENAI_MODEL) || DEFAULT_OPENAI_TEXT_MODEL;
+  if (isInvalidOpenAITextModel(model)) {
+    console.warn(OPENAI_TEXT_MODEL_CONFIG_ERROR);
+    return { text: "ai_config_error", meta: { provider: "openai", error: "invalid_model" } };
+  }
   if (!apiKey) return { text: "ai_unconfigured", meta: { provider: "openai" } };
 
   const payload = {

--- a/chat-worker/test/openai-model-guard.test.mjs
+++ b/chat-worker/test/openai-model-guard.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import worker from "../src/index.js";
+
+const INTERNAL_TOKEN = "test-internal-token";
+const CONFIG_ERROR = "OPENAI_MODEL must be a text model for chat-worker /v1/responses.";
+const originalFetch = globalThis.fetch;
+const originalWarn = console.warn;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  console.warn = originalWarn;
+});
+
+function env(overrides = {}) {
+  return {
+    AI_PROVIDER: "openai",
+    INTERNAL_TOKEN,
+    OPENAI_API_KEY: "test-openai-api-key",
+    ...overrides,
+  };
+}
+
+function internalRequest(text = "hello") {
+  return new Request("https://chat-worker.test/v1/chat/internal", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Internal-Token": INTERNAL_TOKEN,
+    },
+    body: JSON.stringify({ member_id: "member-1", text }),
+  });
+}
+
+function captureWarnings() {
+  const warnings = [];
+  console.warn = (...args) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  return warnings;
+}
+
+function mockOpenAIResponse(calls) {
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), body: JSON.parse(String(init?.body || "{}")) });
+    return new Response(JSON.stringify({ output_text: "ok" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+}
+
+for (const rejectedModel of ["gpt-image-1", "gpt-image-2"]) {
+  test(`OPENAI_MODEL=${rejectedModel} is rejected without calling OpenAI`, async () => {
+    const calls = [];
+    const warnings = captureWarnings();
+    mockOpenAIResponse(calls);
+
+    const response = await worker.fetch(internalRequest(), env({ OPENAI_MODEL: rejectedModel }));
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.reply, "ai_config_error");
+    assert.deepEqual(body.meta, { provider: "openai", error: "invalid_model" });
+    assert.equal(calls.length, 0);
+    assert.equal(warnings.length, 1);
+    assert.equal(warnings[0], CONFIG_ERROR);
+    assert.doesNotMatch(warnings[0], /gpt-image-[12]/);
+  });
+}
+
+test("valid text OPENAI_MODEL calls /v1/responses with the configured model", async () => {
+  const calls = [];
+  mockOpenAIResponse(calls);
+
+  const response = await worker.fetch(internalRequest(), env({ OPENAI_MODEL: "gpt-4.1-mini" }));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.reply, "ok");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://api.openai.com/v1/responses");
+  assert.equal(calls[0].body.model, "gpt-4.1-mini");
+});
+
+for (const emptyValue of [undefined, "", "   "]) {
+  test(`empty OPENAI_MODEL value ${JSON.stringify(emptyValue)} uses the default text model`, async () => {
+    const calls = [];
+    mockOpenAIResponse(calls);
+
+    const response = await worker.fetch(internalRequest(), env({ OPENAI_MODEL: emptyValue }));
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.reply, "ok");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].body.model, "gpt-4.1-mini");
+  });
+}

--- a/chat-worker/test/text-loader.mjs
+++ b/chat-worker/test/text-loader.mjs
@@ -1,0 +1,3 @@
+export async function load(url, context, nextLoad) {
+  return nextLoad(url, context);
+}


### PR DESCRIPTION
This adds a defensive guard in chat-worker before calling OpenAI /v1/responses.

Context:
- Runtime OPENAI_MODEL may be set incorrectly outside the repo.
- chat-worker uses /v1/responses for text generation.
- Image models must not be used for this path.

Behavior:
- Rejects gpt-image-1 and gpt-image-2 before /v1/responses.
- Returns/logs a sanitized config error:
  OPENAI_MODEL must be a text model for chat-worker /v1/responses.
- Does not silently fall back when OPENAI_MODEL is explicitly invalid.
- Keeps existing missing/empty OPENAI_MODEL fallback to gpt-4.1-mini.
- Request body still cannot override the model.

Verification:
- Tests passed: 6/6
- gpt-image-2 appears only in denylist/test
- No secrets printed or changed
- No deploy run
- No * 2.* local duplicate files included
- No src/ai-core files included
- chat-worker/package.json not changed

Deployment note:
- This PR only adds protection.
- Production runtime OPENAI_MODEL should still be checked in Cloudflare and set to a valid text model.