### PR TITLE
feat: add LINE OFC staging review tools

### DIFF
--- a/scripts/line-official-legacy/README.md
+++ b/scripts/line-official-legacy/README.md
@@ -1,0 +1,73 @@
+# LINE OFC Client Import
+
+This importer stages LINE Official rename/tag evidence before any Client or entitlement update.
+
+## Source Of Truth
+
+- LINE OFC rename/tag is the source of truth for canonical `parsed_client_level`, legacy `membership_status`, `membership_tier`, `membership_package`, `member_since`, and purchased flags.
+- Canonical client levels are `guest`, `7_days`, `standard`, `premium`, `vip`, `blackcard`, `svip`, `unknown`, and `review_required`.
+- Legacy `parsed_membership_tier` and `parsed_membership_package` remain staged for backward compatibility, but `parsed_client_level` is the canonical review field.
+- Gmail must not write membership fields.
+- Dry-run writes only to `LINE OFC Client Import Staging`.
+- Dry-run does not patch `Clients`, create Clients, merge Clients, or overwrite manual Airtable fields.
+
+## Airtable
+
+Base:
+
+```sh
+AIRTABLE_BASE_ID=appsV1ILPRfIjkaYg
+```
+
+Tables:
+
+```sh
+AIRTABLE_CLIENTS_TABLE_ID=tblVv58TCbwh5j1fS
+AIRTABLE_MEMBER_ENTITLEMENTS_TABLE_ID=tblNImdF9PKAxhXGi
+AIRTABLE_ACTIVITY_LOGS_TABLE_ID=tblbUWRoFL6OI6QMJ
+AIRTABLE_CONSOLE_INBOX_TABLE_ID=tblFHmfpB2TTrzO2e
+AIRTABLE_LINE_OFC_CLIENT_IMPORT_STAGING_TABLE_ID=tbl1u0foFBvgFpT9G
+```
+
+The dry-run importer uses only `Clients` for read-only matching and `LINE OFC Client Import Staging` for writes.
+
+Staging schema notes:
+
+- `parsed_client_level`: canonical single-select level parsed from LINE OFC rename/tag evidence.
+- `membership_parse_json.client_level`, `client_level_raw`, and `client_level_tokens`: evidence payload for review UI and audit.
+- `parsed_membership_tier` / `parsed_membership_package`: legacy compatibility fields, not the canonical level.
+
+Historical notes are parsed into staged points reconstruction evidence on the same staging table only. The importer does not write `MMD — Points Ledger`, `Payments`, `Members`, `Clients`, or `MMD — Member Entitlements`.
+
+Points policy:
+
+- Locked rate: `100 THB = 1 point`.
+- Service purchase through MMD can generate `proposed_points`.
+- Tips through MMD are stored as customer detail/generosity signal and do not generate points.
+- Direct hand tips never count as points.
+- Membership fees and renewal fees are review-required and do not auto-count.
+- Referral and promotion bonuses are review-required unless explicit campaign rules exist.
+- Ambiguous amounts are staged as `unknown_amount` and require review.
+
+## Command
+
+```sh
+npm run line-ofc:dry-run -- --file <path>
+```
+
+Until the LINE OFC CSV export is available, Console Inbox can be used as a dry-run source:
+
+```sh
+npm run line-ofc:dry-run -- --source console-inbox
+```
+
+Console Inbox maps `inbox_id` to a stable `line_ofc_console_<inbox_id>` import id, `member_name` to display/rename fallback, `legacy_tags` to raw tags, `line_user_id` to exact LINE matching, and `member_phone`/`member_email` to exact identity candidates. `raw_row_json` is redacted before staging.
+
+Optional stable batch id:
+
+```sh
+npm run line-ofc:dry-run -- --file <path> --batch-id line_ofc_2026_06_01
+npm run line-ofc:dry-run -- --source console-inbox --batch-id line_ofc_console_2026_06_01
+```
+
+Set `AIRTABLE_API_KEY` as an environment variable or shell secret before running.

--- a/scripts/line-official-legacy/canonical-parser.js
+++ b/scripts/line-official-legacy/canonical-parser.js
@@ -1,0 +1,319 @@
+const MONTHS = {
+  jan: "01",
+  january: "01",
+  feb: "02",
+  february: "02",
+  mar: "03",
+  march: "03",
+  apr: "04",
+  april: "04",
+  may: "05",
+  jun: "06",
+  june: "06",
+  jul: "07",
+  july: "07",
+  aug: "08",
+  august: "08",
+  sep: "09",
+  sept: "09",
+  september: "09",
+  oct: "10",
+  october: "10",
+  nov: "11",
+  november: "11",
+  dec: "12",
+  december: "12",
+};
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function compactWhitespace(value) {
+  return clean(value).replace(/\s+/g, " ");
+}
+
+function unique(values) {
+  return Array.from(new Set(values.map(clean).filter(Boolean)));
+}
+
+const CLIENT_LEVEL_RANK = {
+  guest: 0,
+  "7_days": 1,
+  standard: 2,
+  premium: 3,
+  vip: 4,
+  blackcard: 5,
+  svip: 6,
+};
+
+function extractTags(...values) {
+  const text = values.map(clean).join(" ");
+  const matches = text.match(/#[a-z0-9_ก-๙]+|-svip-|-vip-|\bblack\s*card\b|\bblackcard\b|\blite\b/gi) || [];
+  return unique(matches);
+}
+
+function parseNameAndUsername(label) {
+  const raw = compactWhitespace(label);
+  const usernameMatch = raw.match(/\(([^)]+)\)/);
+  const username = usernameMatch ? clean(usernameMatch[1]).replace(/^@/, "") : "";
+  const withoutHandle = raw.replace(/\([^)]*\)/g, " ").replace(/#[a-z0-9_ก-๙]+/gi, " ");
+  const withoutTier = withoutHandle
+    .replace(/-svip-/gi, " ")
+    .replace(/-vip-/gi, " ")
+    .replace(/\bblack\s*card\b/gi, " ")
+    .replace(/\bblackcard\b/gi, " ")
+    .replace(/\blite\b/gi, " ");
+  const firstPart = compactWhitespace(withoutTier.split(/\s+-\s+| -|-/)[0]);
+  return {
+    normalized_name: firstPart,
+    username_candidate: username,
+    mmd_client_name_candidate: firstPart ? (firstPart.startsWith("คุณ") ? firstPart : `คุณ${firstPart}`) : "",
+  };
+}
+
+function normalizeYear(rawYear) {
+  if (/^\d{2}$/.test(rawYear)) return `20${rawYear}`;
+  if (/^\d{4}$/.test(rawYear)) return rawYear;
+  return "";
+}
+
+function parseMemberSinceToken(token) {
+  const raw = clean(token);
+  const body = raw.replace(/^#mem/i, "");
+  if (!body) {
+    return { value: "", raw, warning: "empty_member_since_token" };
+  }
+
+  const monthYear = body.match(/^([a-zA-Z]+)(\d{2}|\d{4})$/);
+  if (monthYear) {
+    const month = MONTHS[monthYear[1].toLowerCase()];
+    const year = normalizeYear(monthYear[2]);
+    if (month && year) return { value: `${year}-${month}`, raw, warning: "" };
+    return { value: "", raw, warning: "ambiguous_member_since_token" };
+  }
+
+  const year = normalizeYear(body);
+  if (year) return { value: year, raw, warning: "" };
+
+  return { value: "", raw, warning: "ambiguous_member_since_token" };
+}
+
+function selectMemberSinceToken(parsedTokens, warnings) {
+  const valid = parsedTokens.filter((item) => item.value);
+  if (warnings.length || parsedTokens.some((item) => item.warning)) {
+    return {
+      member_since: valid.map((item) => item.value).sort().at(-1) || "",
+      chosen_member_since_token: "",
+      chosen_member_since_strategy: "review_required",
+    };
+  }
+  if (!valid.length) {
+    return {
+      member_since: "",
+      chosen_member_since_token: "",
+      chosen_member_since_strategy: "review_required",
+    };
+  }
+  const selected = valid
+    .slice()
+    .sort((a, b) => a.value.localeCompare(b.value) || a.raw.localeCompare(b.raw))
+    .at(-1);
+  return {
+    member_since: selected.value,
+    chosen_member_since_token: selected.raw,
+    chosen_member_since_strategy: valid.length === 1 ? "only_valid_member_token" : "latest_valid_member_token",
+  };
+}
+
+function hasLiteDateSignal(text) {
+  const raw = clean(text);
+  if (!/\blite\b/i.test(raw)) return false;
+  return /\blite\b.{0,24}(#mem[a-z0-9]+|\d{1,2}[/-]\d{1,2}[/-]?\d{0,4}|\d{4}|\d{2})/i.test(raw)
+    || /(#mem[a-z0-9]+|\d{1,2}[/-]\d{1,2}[/-]?\d{0,4}|\d{4}|\d{2}).{0,24}\blite\b/i.test(raw);
+}
+
+function levelTokenPatterns() {
+  return [
+    { level: "guest", pattern: /#guest\b|\bguest\b|\bvisitor\b|\bno\s+membership\b|\bnon[-\s]?member\b/i },
+    { level: "7_days", pattern: /#?(?:7\s*days?|7days|7[-\s]?day|7d)\b|\btrial\b|7\s*วัน/i },
+    { level: "standard", pattern: /#standard\b|\bstandard\b|\blite\b/i },
+    { level: "premium", pattern: /#premium\b|\bpremium\b/i },
+    { level: "vip", pattern: /-vip-|#vip\b|\bvip\b/i },
+    { level: "blackcard", pattern: /#blackcard\b|\bblack\s*card\b|\bblack-card\b|\bblackcard\b/i },
+    { level: "svip", pattern: /-svip-|#svip\b|\bsvip\b/i },
+  ];
+}
+
+function detectClientLevelTokens(text, { hasContactEvidence = false, hasMemberSignal = false } = {}) {
+  const raw = clean(text);
+  const tokens = [];
+  for (const { level, pattern } of levelTokenPatterns()) {
+    const matches = raw.match(new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`)) || [];
+    for (const match of matches) tokens.push({ level, token: clean(match) });
+  }
+
+  const lower = raw.toLowerCase();
+  const ambiguous = /\b(?:maybe|possible|possibly|unclear|unknown|review)\b.{0,16}\b(?:guest|visitor|7\s*days?|7days|7d|trial|lite|standard|premium|vip|svip|black\s*card|blackcard)\b/i.test(raw)
+    || /\b(?:guest|visitor|7\s*days?|7days|7d|trial|lite|standard|premium|vip|svip|black\s*card|blackcard)\b.{0,8}\?/i.test(raw);
+  if (ambiguous) {
+    return {
+      client_level: "review_required",
+      client_level_raw: tokens.map((item) => item.token).join(", "),
+      client_level_tokens: tokens,
+      warning: "ambiguous_client_level_review_required",
+    };
+  }
+
+  if (!tokens.length && hasMemberSignal) {
+    return {
+      client_level: "premium",
+      client_level_raw: "",
+      client_level_tokens: [],
+      warning: "inferred_premium_from_member_signal",
+    };
+  }
+
+  if (!tokens.length && hasContactEvidence) {
+    return {
+      client_level: "guest",
+      client_level_raw: "",
+      client_level_tokens: [],
+      warning: "",
+    };
+  }
+
+  if (!tokens.length && lower) {
+    return {
+      client_level: "unknown",
+      client_level_raw: "",
+      client_level_tokens: [],
+      warning: "",
+    };
+  }
+
+  if (!tokens.length) {
+    return {
+      client_level: "unknown",
+      client_level_raw: "",
+      client_level_tokens: [],
+      warning: "",
+    };
+  }
+
+  const selected = tokens
+    .slice()
+    .sort((a, b) => CLIENT_LEVEL_RANK[a.level] - CLIENT_LEVEL_RANK[b.level])
+    .at(-1);
+  return {
+    client_level: selected.level,
+    client_level_raw: selected.token,
+    client_level_tokens: tokens,
+    warning: "",
+  };
+}
+
+function parseCanonicalLineOfc(input = {}) {
+  const nickname = clean(input.nickname || input.line_renamed_name || input.raw_display_label || input.label || input.name);
+  const explicitTags = Array.isArray(input.tags) ? input.tags.join(" ") : clean(input.tags || input.line_tags_raw || input.legacy_tags);
+  const note = clean(input.note || input.notes || input.memo || input.description);
+  const lineDisplayName = clean(input.line_display_name || input.display_name);
+  const lineUserId = clean(input.line_user_id || input.userId || input.user_id);
+  const hasContactEvidence = Boolean(lineUserId || clean(input.email || input.member_email || input.phone || input.member_phone || input.username || input.line_id || input.handle));
+  const text = [nickname, explicitTags, note].filter(Boolean).join(" ");
+  const tags = extractTags(text);
+  const lowerText = text.toLowerCase();
+  const nameParts = parseNameAndUsername(nickname || lineDisplayName);
+  const warnings = [];
+  const memberTokenWarnings = [];
+
+  const memberTokens = unique(tags.filter((tag) => /^#mem/i.test(tag)));
+  const parsedMemberTokens = memberTokens.map(parseMemberSinceToken);
+  for (const parsed of parsedMemberTokens) {
+    if (parsed.warning) {
+      const warning = `${parsed.warning}:${parsed.raw}`;
+      memberTokenWarnings.push(warning);
+      warnings.push(warning);
+    }
+  }
+
+  const hasClient = tags.some((tag) => /^#client$/i.test(tag));
+  const hasPurchased = tags.some((tag) => /^#purchased$/i.test(tag));
+  const hasMemberSignal = hasClient || parsedMemberTokens.some((item) => item.value);
+  const ambiguousMemberSignal = parsedMemberTokens.some((item) => item.warning);
+  const liteSignal = hasLiteDateSignal(text);
+  const clientLevel = detectClientLevelTokens(text, { hasContactEvidence, hasMemberSignal });
+  if (clientLevel.warning) warnings.push(clientLevel.warning);
+
+  let membershipTier = "none";
+  if (clientLevel.client_level === "blackcard") membershipTier = "blackcard";
+  else if (clientLevel.client_level === "svip") membershipTier = "svip";
+  else if (clientLevel.client_level === "vip") membershipTier = "vip";
+
+  let membershipPackage = "none";
+  if (liteSignal) membershipPackage = "standard_lite";
+  else if (clientLevel.client_level === "premium" || hasMemberSignal) membershipPackage = "premium";
+
+  let membershipStatus = "none";
+  if (ambiguousMemberSignal) membershipStatus = "review_required";
+  else if (hasClient || hasMemberSignal) membershipStatus = "member";
+  else if (hasPurchased) membershipStatus = "purchased";
+
+  if (/\bmem[a-z]+\b/i.test(lowerText) && !memberTokens.length) {
+    memberTokenWarnings.push("member_signal_missing_hash_review_required");
+    warnings.push("member_signal_missing_hash_review_required");
+    membershipStatus = "review_required";
+  }
+
+  const memberSinceSelection = selectMemberSinceToken(parsedMemberTokens, memberTokenWarnings);
+  const memberSince = memberSinceSelection.member_since;
+  const memberSinceRaw = memberSinceSelection.chosen_member_since_token
+    || parsedMemberTokens.map((item) => item.raw).filter(Boolean).sort().at(-1)
+    || "";
+  const memberSinceCandidates = parsedMemberTokens.map((item) => ({
+    token: item.raw,
+    member_since: item.value,
+    warning: item.warning,
+  }));
+  const parseConfidence = (() => {
+    if (warnings.length) return 0.45;
+    if (hasClient && (memberSince || hasPurchased || membershipTier !== "none" || membershipPackage !== "none")) return 0.92;
+    if (hasClient || memberSince || hasPurchased) return 0.82;
+    if (membershipTier !== "none" || liteSignal) return 0.65;
+    return 0.25;
+  })();
+
+  return {
+    client_level: clientLevel.client_level,
+    client_level_raw: clientLevel.client_level_raw,
+    client_level_tokens: clientLevel.client_level_tokens,
+    membership_status: membershipStatus,
+    membership_tier: membershipTier,
+    membership_package: membershipPackage,
+    member_since: memberSince,
+    member_since_raw: memberSinceRaw,
+    all_member_tokens: memberTokens,
+    chosen_member_since_token: memberSinceSelection.chosen_member_since_token,
+    chosen_member_since_strategy: memberSinceSelection.chosen_member_since_strategy,
+    member_since_candidates: memberSinceCandidates,
+    has_purchased: hasPurchased,
+    parse_confidence: parseConfidence,
+    parse_warnings: unique(warnings),
+    normalized_name: nameParts.normalized_name,
+    username_candidate: clean(input.username || input.line_id || input.handle) || nameParts.username_candidate,
+    mmd_client_name_candidate: nameParts.mmd_client_name_candidate,
+    line_user_id: lineUserId,
+    line_display_name: lineDisplayName,
+    line_renamed_name: nickname,
+    line_tags_raw: explicitTags,
+    detected_tags: tags,
+  };
+}
+
+module.exports = {
+  MONTHS,
+  clean,
+  extractTags,
+  parseCanonicalLineOfc,
+  parseMemberSinceToken,
+};

--- a/scripts/line-official-legacy/canonical-parser.test.js
+++ b/scripts/line-official-legacy/canonical-parser.test.js
@@ -1,0 +1,129 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { parseCanonicalLineOfc } = require("./canonical-parser.js");
+
+test("#client parses member status", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul #client" });
+  assert.equal(parsed.membership_status, "member");
+});
+
+test("#purchased parses has_purchased", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul #purchased" });
+  assert.equal(parsed.has_purchased, true);
+  assert.equal(parsed.membership_status, "purchased");
+});
+
+test("#memYY, #memYYYY, and #memMonYY parse member_since", () => {
+  assert.equal(parseCanonicalLineOfc({ nickname: "Paul #mem24" }).member_since, "2024");
+  assert.equal(parseCanonicalLineOfc({ nickname: "Paul #mem2025" }).member_since, "2025");
+  assert.equal(parseCanonicalLineOfc({ nickname: "Paul #memJan24" }).member_since, "2024-01");
+});
+
+test("guest variants parse guest", () => {
+  assert.equal(parseCanonicalLineOfc({ nickname: "Guest visitor" }).client_level, "guest");
+  assert.equal(parseCanonicalLineOfc({ nickname: "no membership" }).client_level, "guest");
+});
+
+test("contact evidence without membership signal parses guest", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Known contact", line_user_id: "U1" });
+  assert.equal(parsed.client_level, "guest");
+});
+
+test("7 Days variants parse 7_days", () => {
+  for (const label of ["7 days", "7days", "7-day", "7d", "trial", "7 วัน"]) {
+    assert.equal(parseCanonicalLineOfc({ nickname: label }).client_level, "7_days");
+  }
+});
+
+test("lite and standard parse standard client level", () => {
+  assert.equal(parseCanonicalLineOfc({ nickname: "Paul lite #client" }).client_level, "standard");
+  assert.equal(parseCanonicalLineOfc({ nickname: "Paul standard" }).client_level, "standard");
+});
+
+test("premium parses premium client level", () => {
+  assert.equal(parseCanonicalLineOfc({ nickname: "Paul premium" }).client_level, "premium");
+});
+
+test("multiple client levels choose highest by MMD hierarchy", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Guest 7 days standard premium -vip- black card -svip-" });
+  assert.equal(parsed.client_level, "svip");
+  assert.deepEqual(parsed.client_level_tokens.map((item) => item.level), ["guest", "7_days", "standard", "premium", "vip", "blackcard", "svip"]);
+  assert.equal(parsed.client_level_raw, "-svip-");
+});
+
+test("member signal without explicit level defaults premium with warning", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul #client #mem2025" });
+  assert.equal(parsed.client_level, "premium");
+  assert.ok(parsed.parse_warnings.includes("inferred_premium_from_member_signal"));
+});
+
+test("ambiguous client level becomes review_required", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul maybe vip?" });
+  assert.equal(parsed.client_level, "review_required");
+  assert.ok(parsed.parse_warnings.includes("ambiguous_client_level_review_required"));
+});
+
+test("multiple #mem tokens preserve evidence and select latest valid token clearly", () => {
+  const parsed = parseCanonicalLineOfc({
+    nickname: "เจ - SVIP - (Jjeune)",
+    tags: "#client #vip #purchased #memjan24 #mem2024 #mem2025 #memApr25",
+  });
+  assert.deepEqual(parsed.all_member_tokens, ["#memjan24", "#mem2024", "#mem2025", "#memApr25"]);
+  assert.equal(parsed.member_since, "2025-04");
+  assert.equal(parsed.member_since_raw, "#memApr25");
+  assert.equal(parsed.chosen_member_since_token, "#memApr25");
+  assert.equal(parsed.chosen_member_since_strategy, "latest_valid_member_token");
+  assert.ok(parsed.member_since_candidates.some((item) => item.token === "#memjan24" && item.member_since === "2024-01"));
+  assert.ok(parsed.member_since_candidates.some((item) => item.token === "#memApr25" && item.member_since === "2025-04"));
+  assert.deepEqual(parsed.parse_warnings, []);
+});
+
+test("single valid #mem token is marked as only valid token", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul #client #memJan24" });
+  assert.equal(parsed.member_since, "2024-01");
+  assert.equal(parsed.member_since_raw, "#memJan24");
+  assert.equal(parsed.chosen_member_since_token, "#memJan24");
+  assert.equal(parsed.chosen_member_since_strategy, "only_valid_member_token");
+});
+
+test("-vip- parses vip", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul -vip- #client" });
+  assert.equal(parsed.client_level, "vip");
+  assert.equal(parsed.membership_tier, "vip");
+});
+
+test("-svip- parses svip", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul -svip- #client" });
+  assert.equal(parsed.client_level, "svip");
+  assert.equal(parsed.membership_tier, "svip");
+});
+
+test("blackcard parses blackcard", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul blackcard #client" });
+  assert.equal(parsed.client_level, "blackcard");
+  assert.equal(parsed.membership_tier, "blackcard");
+});
+
+test("lite with date parses standard_lite", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul lite 12/05/24 #client" });
+  assert.equal(parsed.client_level, "standard");
+  assert.equal(parsed.membership_package, "standard_lite");
+});
+
+test("no lite with member signal parses premium", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul #client #mem2025" });
+  assert.equal(parsed.client_level, "premium");
+  assert.equal(parsed.membership_package, "premium");
+});
+
+test("ambiguous member tokens become review_required with raw token preserved", () => {
+  const parsed = parseCanonicalLineOfc({ nickname: "Paul #memFoo24" });
+  assert.equal(parsed.membership_status, "review_required");
+  assert.equal(parsed.member_since_raw, "#memFoo24");
+  assert.deepEqual(parsed.all_member_tokens, ["#memFoo24"]);
+  assert.equal(parsed.chosen_member_since_token, "");
+  assert.equal(parsed.chosen_member_since_strategy, "review_required");
+  assert.ok(parsed.member_since_candidates.some((item) => item.token === "#memFoo24" && item.warning));
+  assert.ok(parsed.parse_warnings.some((warning) => warning.includes("#memFoo24")));
+});

--- a/scripts/line-official-legacy/commit-gate.js
+++ b/scripts/line-official-legacy/commit-gate.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+const { AirtableClient } = require("./dry-run-import.js");
+const { summarizeRows } = require("./review-report.js");
+
+const STAGING_TABLE = process.env.AIRTABLE_LINE_OFC_CLIENT_IMPORT_STAGING_TABLE_ID || "tbl1u0foFBvgFpT9G";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--batch-id") out.batchId = argv[index + 1];
+  }
+  return out;
+}
+
+function encodeFormulaValue(value) {
+  return clean(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function duplicateImportIdCount(records) {
+  const counts = new Map();
+  for (const record of records) {
+    const importId = clean(record.fields?.import_id || record.import_id);
+    if (!importId) continue;
+    counts.set(importId, (counts.get(importId) || 0) + 1);
+  }
+  return Array.from(counts.values()).filter((count) => count > 1).length;
+}
+
+async function fetchBatchRows({ batchId, airtable }) {
+  return airtable.list(STAGING_TABLE, {
+    filterByFormula: `{import_batch_id}="${encodeFormulaValue(batchId)}"`,
+  });
+}
+
+function evaluateCommitGate(records) {
+  const summary = summarizeRows(records);
+  const duplicateCount = duplicateImportIdCount(records);
+  const blockers = {
+    unsafe_to_commit: summary.rows_unsafe_to_commit_now,
+    review_required: summary.review_required_rows,
+    multiple_match_review: summary.multiple_match_review_rows,
+    duplicate_staging_import_ids: duplicateCount,
+  };
+  const ok = Object.values(blockers).every((value) => value === 0);
+  return {
+    ok,
+    mode: "line_ofc_commit_gate",
+    hard_gate: blockers,
+    message: ok
+      ? "Commit gate passed. No commit implementation is executed by this staging gate."
+      : "Commit refused. Resolve all staging blockers before any Clients or Member Entitlements write path can run.",
+    summary,
+  };
+}
+
+async function runCommitGate({ batchId, airtable = new AirtableClient() }) {
+  if (!batchId) throw new Error("missing_batch_id");
+  const records = await fetchBatchRows({ batchId, airtable });
+  return evaluateCommitGate(records);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.batchId) {
+    console.error("Usage: npm run line-ofc:commit -- --batch-id <batch_id>");
+    process.exitCode = 1;
+    return;
+  }
+  const result = await runCommitGate({ batchId: args.batchId });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  duplicateImportIdCount,
+  evaluateCommitGate,
+  runCommitGate,
+};

--- a/scripts/line-official-legacy/dry-run-import.js
+++ b/scripts/line-official-legacy/dry-run-import.js
@@ -1,0 +1,785 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const {
+  clean,
+  parseCanonicalLineOfc,
+} = require("./canonical-parser.js");
+const { parseHistoricalNote } = require("./historical-note-parser.js");
+
+const AIRTABLE_API = "https://api.airtable.com/v0";
+const BASE_ID = process.env.AIRTABLE_BASE_ID || "appsV1ILPRfIjkaYg";
+const CLIENTS_TABLE = process.env.AIRTABLE_CLIENTS_TABLE_ID || "tblVv58TCbwh5j1fS";
+const STAGING_TABLE = process.env.AIRTABLE_LINE_OFC_CLIENT_IMPORT_STAGING_TABLE_ID || "tbl1u0foFBvgFpT9G";
+const CONSOLE_INBOX_TABLE = process.env.AIRTABLE_CONSOLE_INBOX_TABLE_ID || "tblFHmfpB2TTrzO2e";
+const CONSOLE_INBOX_SOURCE_TITLE = "airtable_console_inbox";
+
+const BLOCKED_FIELDS = [
+  "membership_status",
+  "membership_tier",
+  "membership_package",
+  "client_level",
+  "member_since",
+  "has_purchased",
+  "Status",
+  "Membership Status",
+  "Membership Tier",
+  "Membership Package",
+];
+
+function usage() {
+  console.error("Usage: npm run line-ofc:dry-run -- --file <export.csv|export.json>");
+  console.error("   or: npm run line-ofc:dry-run -- --source console-inbox");
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--file") out.file = argv[index + 1];
+    if (arg === "--batch-id") out.batchId = argv[index + 1];
+    if (arg === "--source") out.source = argv[index + 1];
+  }
+  return out;
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let quoted = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const next = text[index + 1];
+    if (quoted) {
+      if (char === '"' && next === '"') {
+        field += '"';
+        index += 1;
+      } else if (char === '"') quoted = false;
+      else field += char;
+      continue;
+    }
+    if (char === '"') quoted = true;
+    else if (char === ",") {
+      row.push(field);
+      field = "";
+    } else if (char === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else if (char !== "\r") field += char;
+  }
+  if (field || row.length) {
+    row.push(field);
+    rows.push(row);
+  }
+  const headers = (rows.shift() || []).map(clean);
+  return rows
+    .filter((items) => items.some((item) => clean(item)))
+    .map((items, index) => {
+      const out = { __row: index + 2 };
+      headers.forEach((header, headerIndex) => {
+        out[header || `column_${headerIndex + 1}`] = String(items[headerIndex] == null ? "" : items[headerIndex]);
+      });
+      return out;
+    });
+}
+
+function readRows(filePath) {
+  const text = fs.readFileSync(filePath, "utf8");
+  if (/\.json$/i.test(filePath)) {
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) return parsed;
+    if (Array.isArray(parsed.rows)) return parsed.rows;
+    throw new Error("JSON export must be an array or { rows: [] }");
+  }
+  return parseCsv(text);
+}
+
+function pick(row, names) {
+  const lowerMap = new Map(Object.keys(row || {}).map((key) => [key.toLowerCase(), key]));
+  for (const name of names) {
+    const key = lowerMap.get(name.toLowerCase());
+    if (key) return clean(row[key]);
+  }
+  return "";
+}
+
+function pickRaw(row, names) {
+  const lowerMap = new Map(Object.keys(row || {}).map((key) => [key.toLowerCase(), key]));
+  for (const name of names) {
+    const key = lowerMap.get(name.toLowerCase());
+    if (key) return String(row[key] == null ? "" : row[key]);
+  }
+  return "";
+}
+
+function normalizeEmail(value) {
+  return clean(value).toLowerCase();
+}
+
+function normalizePhone(value) {
+  const raw = clean(value);
+  if (!raw) return "";
+  let digits = raw.replace(/[^\d+]/g, "");
+  if (digits.startsWith("+")) digits = `+${digits.slice(1).replace(/\D/g, "")}`;
+  else digits = digits.replace(/\D/g, "");
+  const numeric = digits.startsWith("+") ? digits.slice(1) : digits;
+  if (/^0\d{8,9}$/.test(numeric)) return `+66${numeric.slice(1)}`;
+  if (/^66\d{8,9}$/.test(numeric)) return `+${numeric}`;
+  if (/^\d{8,15}$/.test(numeric)) return `+${numeric}`;
+  return "";
+}
+
+function redactValue(value) {
+  const raw = clean(value);
+  if (!raw) return "";
+  return "[redacted]";
+}
+
+function redactSourceRow(row) {
+  const out = {};
+  for (const [key, value] of Object.entries(row || {})) {
+    const lowerKey = key.toLowerCase();
+    if (lowerKey.includes("email") || lowerKey.includes("phone")) out[key] = redactValue(value);
+    else if (lowerKey === "payload_json") out[key] = value ? "[redacted_payload_json]" : "";
+    else out[key] = value;
+  }
+  return out;
+}
+
+function redactDebugFieldValue(key, value) {
+  const lowerKey = key.toLowerCase();
+  if (value === undefined) return undefined;
+  if (value === null || value === "") return value;
+  if (typeof value === "boolean" || typeof value === "number") return value;
+  if (Array.isArray(value)) return value.length ? `[redacted_array:${value.length}]` : [];
+  if (lowerKey.endsWith("_json") || lowerKey.includes("raw") || lowerKey.includes("note")) {
+    return "[redacted]";
+  }
+  if (
+    lowerKey.includes("email") ||
+    lowerKey.includes("phone") ||
+    lowerKey.includes("name") ||
+    lowerKey.includes("user") ||
+    lowerKey.includes("client") ||
+    lowerKey.includes("customer")
+  ) {
+    return "[redacted]";
+  }
+  return clean(value).slice(0, 120);
+}
+
+function redactDebugFields(fields) {
+  const out = {};
+  for (const [key, value] of Object.entries(fields || {})) {
+    out[key] = redactDebugFieldValue(key, value);
+  }
+  return out;
+}
+
+function extractAirtableErrorInfo(detail) {
+  const airtableError = detail?.error;
+  const type = typeof airtableError === "object" ? airtableError.type : "";
+  const message = typeof airtableError === "object" ? airtableError.message : clean(airtableError);
+  const text = JSON.stringify(detail || {});
+  const fieldName =
+    text.match(/Unknown field name:\s*\\"?([^"\\]+)\\"?/)?.[1] ||
+    text.match(/Field\s+\\"([^"\\]+)\\"/)?.[1] ||
+    text.match(/field\s+\\"([^"\\]+)\\"/i)?.[1] ||
+    "";
+  return { type, message, field_name: fieldName };
+}
+
+function buildDebugError(error) {
+  return {
+    error: error instanceof Error ? error.message : String(error),
+    airtable: extractAirtableErrorInfo(error?.detail),
+    detail: error?.detail || null,
+    staging_rows_written_before_failure: error?.stagingRowsWrittenBeforeFailure,
+    failing_import_id: error?.failingImportId,
+    failing_payload_fields_redacted: redactDebugFields(error?.failingFields || {}),
+  };
+}
+
+function safeImportToken(value) {
+  return clean(value).replace(/[^a-zA-Z0-9_-]+/g, "_").replace(/^_+|_+$/g, "") || "unknown";
+}
+
+function deriveLegacyTagsLabel(legacyTags) {
+  return clean(legacyTags)
+    .replace(/#[a-z0-9_ก-๙]+/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function encodeFormulaValue(value) {
+  return clean(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+class AirtableClient {
+  constructor({ apiKey = process.env.AIRTABLE_API_KEY, baseId = BASE_ID } = {}) {
+    this.apiKey = clean(apiKey);
+    this.baseId = clean(baseId);
+  }
+
+  async request(table, init = {}) {
+    if (!this.apiKey || !this.baseId) throw new Error("airtable_not_configured");
+    const recordPath = init.recordId ? `/${encodeURIComponent(init.recordId)}` : "";
+    const url = new URL(`${AIRTABLE_API}/${this.baseId}/${encodeURIComponent(table)}${recordPath}`);
+    for (const [key, value] of Object.entries(init.query || {})) url.searchParams.set(key, value);
+    const timeoutMs = Number(process.env.AIRTABLE_REQUEST_TIMEOUT_MS || 30000);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    let response;
+    try {
+      response = await fetch(url.toString(), {
+        method: init.method || "GET",
+        headers: {
+          authorization: `Bearer ${this.apiKey}`,
+          "content-type": "application/json",
+        },
+        body: init.body ? JSON.stringify(init.body) : undefined,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error?.name === "AbortError") throw new Error(`airtable_request_timeout:${timeoutMs}`);
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+    const data = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(`airtable_request_failed:${response.status}`);
+      error.detail = data;
+      throw error;
+    }
+    return data;
+  }
+
+  async requestWithFieldFallback(table, init) {
+    const body = { ...(init.body || {}) };
+    const fields = { ...(body.fields || {}) };
+    while (true) {
+      try {
+        return await this.request(table, { ...init, body: { ...body, fields } });
+      } catch (error) {
+        const detail = JSON.stringify(error.detail || {});
+        const unknown = detail.match(/Unknown field name:\s*\\"?([^"\\]+)\\"?/)?.[1];
+        if (unknown && Object.prototype.hasOwnProperty.call(fields, unknown)) {
+          delete fields[unknown];
+          if (Object.keys(fields).length) continue;
+        }
+        if (error.detail?.error?.type === "INVALID_MULTIPLE_CHOICE_OPTIONS") {
+          const message = clean(error.detail?.error?.message);
+          let removed = false;
+          for (const [fieldName, value] of Object.entries(fields)) {
+            if (typeof value === "string" && value && message.includes(value)) {
+              delete fields[fieldName];
+              removed = true;
+            }
+          }
+          if (removed && Object.keys(fields).length) continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  async requestBatchWithFieldFallback(table, init) {
+    const body = { ...(init.body || {}) };
+    const records = (body.records || []).map((record) => ({
+      ...(record.id ? { id: record.id } : {}),
+      fields: { ...(record.fields || {}) },
+    }));
+    while (true) {
+      try {
+        return await this.request(table, { ...init, body: { ...body, records } });
+      } catch (error) {
+        const detail = JSON.stringify(error.detail || {});
+        const unknown = detail.match(/Unknown field name:\s*\\"?([^"\\]+)\\"?/)?.[1];
+        if (unknown) {
+          let removed = false;
+          for (const record of records) {
+            if (Object.prototype.hasOwnProperty.call(record.fields, unknown)) {
+              delete record.fields[unknown];
+              removed = true;
+            }
+          }
+          if (removed && records.some((record) => Object.keys(record.fields).length)) continue;
+        }
+        if (error.detail?.error?.type === "INVALID_MULTIPLE_CHOICE_OPTIONS") {
+          const message = clean(error.detail?.error?.message);
+          let removed = false;
+          for (const record of records) {
+            for (const [fieldName, value] of Object.entries(record.fields)) {
+              if (typeof value === "string" && value && message.includes(value)) {
+                delete record.fields[fieldName];
+                removed = true;
+              }
+            }
+          }
+          if (removed && records.some((record) => Object.keys(record.fields).length)) continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  async list(table, query = {}) {
+    const records = [];
+    let offset = "";
+    do {
+      const data = await this.request(table, {
+        query: {
+          pageSize: "100",
+          ...query,
+          ...(offset ? { offset } : {}),
+        },
+      });
+      records.push(...(data.records || []));
+      offset = data.offset || "";
+    } while (offset);
+    return records;
+  }
+
+  async findOne(table, formula) {
+    const data = await this.request(table, { query: { maxRecords: "1", filterByFormula: formula } });
+    return data.records?.[0] || null;
+  }
+}
+
+async function matchClients(airtable, parsed, rawRow, { allowUsernameExact = true, cache = {} } = {}) {
+  const candidates = [];
+  const add = (records, reason) => {
+    for (const record of records) {
+      if (!candidates.some((item) => item.record.id === record.id && item.reason === reason)) {
+        candidates.push({ reason, record });
+      }
+    }
+  };
+
+  const lineUserId = clean(parsed.line_user_id || pick(rawRow, ["line_user_id", "line user id", "userId", "user_id"]));
+  if (lineUserId) {
+    add(cache.clientsAll ? cache.clientsAll.filter((record) => clean(record.fields?.line_user_id) === lineUserId) : await airtable.list(CLIENTS_TABLE, {
+      filterByFormula: `{line_user_id}="${encodeFormulaValue(lineUserId)}"`,
+    }), "line_user_id");
+  }
+
+  const phone = normalizePhone(pick(rawRow, ["phone", "Phone Number", "phone_number", "tel", "member_phone"]));
+  if (phone) {
+    if (!cache.clientsForPhoneMatch) cache.clientsForPhoneMatch = cache.clientsAll || await airtable.list(CLIENTS_TABLE);
+    const all = cache.clientsForPhoneMatch;
+    add(all.filter((record) => normalizePhone(record.fields?.["Phone Number"] || record.fields?.phone) === phone), "phone");
+  }
+
+  const email = normalizeEmail(pick(rawRow, ["email", "Contact Email", "primary_email", "member_email"]));
+  if (email) {
+    add(cache.clientsAll ? cache.clientsAll.filter((record) => {
+      return normalizeEmail(record.fields?.["Contact Email"] || record.fields?.email) === email;
+    }) : await airtable.list(CLIENTS_TABLE, {
+      filterByFormula: `OR(LOWER({Contact Email})="${encodeFormulaValue(email)}",LOWER({email})="${encodeFormulaValue(email)}")`,
+    }).catch(() => []), "email");
+  }
+
+  const username = clean(parsed.username_candidate);
+  if (allowUsernameExact && username) {
+    add(cache.clientsAll ? cache.clientsAll.filter((record) => {
+      return normalizeEmail(record.fields?.line_id || record.fields?.username) === username.toLowerCase();
+    }) : await airtable.list(CLIENTS_TABLE, {
+      filterByFormula: `OR(LOWER({line_id}&"")="${encodeFormulaValue(username.toLowerCase())}",LOWER({username}&"")="${encodeFormulaValue(username.toLowerCase())}")`,
+    }).catch(() => []), "username");
+  }
+
+  if (!candidates.length && parsed.normalized_name) {
+    const name = encodeFormulaValue(parsed.normalized_name.toLowerCase());
+    add(cache.clientsAll ? cache.clientsAll.filter((record) => {
+      const fields = record.fields || {};
+      return [
+        fields["Client Name"],
+        fields.nickname,
+        fields.line_display_name,
+      ].some((value) => normalizeEmail(value).includes(name));
+    }) : await airtable.list(CLIENTS_TABLE, {
+      maxRecords: "10",
+      filterByFormula: `OR(FIND("${name}",LOWER({Client Name}&""))>0,FIND("${name}",LOWER({nickname}&""))>0,FIND("${name}",LOWER({line_display_name}&""))>0)`,
+    }).catch(() => []), "fuzzy_name");
+  }
+
+  const strong = candidates.filter((item) => ["line_user_id", "phone", "email", "username"].includes(item.reason));
+  const uniqueStrongIds = Array.from(new Set(strong.map((item) => item.record.id)));
+  const uniqueCandidateIds = Array.from(new Set(candidates.map((item) => item.record.id)));
+  if (uniqueCandidateIds.length > 1) {
+    return { matchedClient: "", matchType: "multiple_candidates", matchConfidence: 0.5, reviewStatus: "review_required", candidates };
+  }
+  if (uniqueStrongIds.length === 1) {
+    const selected = strong.find((item) => item.record.id === uniqueStrongIds[0]);
+    return {
+      matchedClient: uniqueStrongIds[0],
+      matchType: `exact_${selected.reason}`,
+      matchConfidence: selected.reason === "line_user_id" ? 0.99 : 0.94,
+      reviewStatus: "ready_to_review",
+      candidates,
+    };
+  }
+  if (uniqueStrongIds.length > 1) {
+    return { matchedClient: "", matchType: "multiple_candidates", matchConfidence: 0.5, reviewStatus: "review_required", candidates };
+  }
+  if (candidates.length) {
+    return { matchedClient: "", matchType: "fuzzy_name", matchConfidence: 0.35, reviewStatus: "review_required", candidates };
+  }
+  return { matchedClient: "", matchType: "no_match", matchConfidence: 0, reviewStatus: "staging_only", candidates };
+}
+
+function buildStagingFields({ row, rowIndex, sourceFile, batchId, parsed, match }) {
+  const sourceTitle = row.__source_file_title || path.basename(sourceFile || CONSOLE_INBOX_SOURCE_TITLE);
+  const importId = row.__import_id || `line_ofc_${batchId}_${row.__row || rowIndex + 1}`;
+  const rawNote = pickRaw(row, ["raw_note", "note", "notes", "memo", "description", "admin_note"]);
+  const noteParse = parseHistoricalNote(rawNote);
+  const proposedClientUpdates = {
+    line_user_id: parsed.line_user_id,
+    line_display_name: parsed.line_display_name,
+    line_renamed_name: parsed.line_renamed_name,
+  };
+  const fields = {
+    import_id: importId,
+    import_batch_id: batchId,
+    source_file_title: sourceTitle,
+    line_user_id: parsed.line_user_id,
+    line_display_name: parsed.line_display_name,
+    line_renamed_name: parsed.line_renamed_name,
+    line_tags_raw: parsed.line_tags_raw || parsed.detected_tags.join(", "),
+    phone_candidate: normalizePhone(pick(row, ["phone", "Phone Number", "phone_number", "tel", "member_phone"])),
+    email_candidate: normalizeEmail(pick(row, ["email", "Contact Email", "primary_email", "member_email"])),
+    normalized_name: parsed.normalized_name,
+    parsed_client_level: parsed.client_level,
+    parsed_membership_status: parsed.membership_status,
+    parsed_membership_tier: parsed.membership_tier,
+    parsed_membership_package: parsed.membership_package,
+    parsed_member_since: parsed.member_since,
+    parsed_member_since_raw: parsed.member_since_raw,
+    parsed_has_purchased: parsed.has_purchased,
+    parse_confidence: parsed.parse_confidence,
+    membership_parse_json: JSON.stringify(parsed, null, 2),
+    matched_client: match.matchedClient ? [match.matchedClient] : undefined,
+    match_type: match.matchType,
+    match_confidence: match.matchConfidence,
+    review_status: match.reviewStatus,
+    proposed_client_updates_json: JSON.stringify(proposedClientUpdates, null, 2),
+    proposed_entitlement_json: JSON.stringify({
+      source: "line_ofc",
+      client_level: parsed.client_level,
+      client_level_raw: parsed.client_level_raw,
+      client_level_tokens: parsed.client_level_tokens,
+      membership_status: parsed.membership_status,
+      membership_tier: parsed.membership_tier,
+      membership_package: parsed.membership_package,
+      member_since: parsed.member_since,
+      member_since_raw: parsed.member_since_raw,
+      has_purchased: parsed.has_purchased,
+      review_required: match.reviewStatus !== "ready_to_review" || parsed.membership_status === "review_required" || parsed.client_level === "review_required",
+    }, null, 2),
+    blocked_fields_json: JSON.stringify(BLOCKED_FIELDS, null, 2),
+    raw_note: noteParse.raw_note,
+    note_detected_amounts: JSON.stringify(noteParse.note_detected_amounts, null, 2),
+    note_detected_dates: JSON.stringify(noteParse.note_detected_dates, null, 2),
+    note_detected_package: noteParse.note_detected_package,
+    note_detected_membership_action: noteParse.note_detected_membership_action,
+    note_detected_service_count: noteParse.note_detected_service_count,
+    note_detected_payment_refs: JSON.stringify(noteParse.note_detected_payment_refs, null, 2),
+    service_amount: noteParse.service_amount,
+    tip_amount_mmd: noteParse.tip_amount_mmd,
+    tip_amount_direct: noteParse.tip_amount_direct,
+    membership_fee_amount: noteParse.membership_fee_amount,
+    renewal_fee_amount: noteParse.renewal_fee_amount,
+    referral_bonus_candidate: String(noteParse.referral_bonus_candidate),
+    promotion_bonus_candidate: String(noteParse.promotion_bonus_candidate),
+    unknown_amount: noteParse.unknown_amount,
+    points_eligible_amount: noteParse.points_eligible_amount,
+    points_ineligible_amount: noteParse.points_ineligible_amount,
+    customer_detail_json: JSON.stringify(noteParse.customer_detail_json, null, 2),
+    model_review_incentive_signal: noteParse.model_review_incentive_signal,
+    historical_events_json: JSON.stringify(noteParse.historical_events_json, null, 2),
+    proposed_points: noteParse.proposed_points,
+    points_policy_basis: noteParse.points_policy_basis,
+    points_confidence: noteParse.points_confidence,
+    points_review_required: String(noteParse.points_review_required),
+    points_parse_warnings: JSON.stringify(noteParse.points_parse_warnings, null, 2),
+    dry_run_only: true,
+    raw_row_json: JSON.stringify(row.__raw_row_redacted || redactSourceRow(row), null, 2),
+    created_at: new Date().toISOString(),
+  };
+  if (!fields.parsed_member_since) delete fields.parsed_member_since;
+  for (const fieldName of ["parsed_membership_status", "parsed_membership_tier", "parsed_membership_package"]) {
+    if (!fields[fieldName] || fields[fieldName] === "none") delete fields[fieldName];
+  }
+  return fields;
+}
+
+async function writeStaging(airtable, fields) {
+  const existing = await airtable.findOne(STAGING_TABLE, `{import_id}="${encodeFormulaValue(fields.import_id)}"`);
+  if (existing?.id) {
+    return airtable.requestWithFieldFallback(STAGING_TABLE, {
+      method: "PATCH",
+      recordId: existing.id,
+      body: { fields },
+    });
+  }
+  return airtable.requestWithFieldFallback(STAGING_TABLE, {
+    method: "POST",
+    body: { fields },
+  });
+}
+
+function chunks(items, size) {
+  const out = [];
+  for (let index = 0; index < items.length; index += size) out.push(items.slice(index, index + size));
+  return out;
+}
+
+function duplicateImportIds(fieldsList) {
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const fields of fieldsList) {
+    const importId = clean(fields.import_id);
+    if (!importId) continue;
+    if (seen.has(importId)) duplicates.add(importId);
+    seen.add(importId);
+  }
+  return Array.from(duplicates).sort();
+}
+
+async function writeStagingRows(airtable, fieldsList, batchId) {
+  const duplicates = duplicateImportIds(fieldsList);
+  if (duplicates.length) {
+    const error = new Error(`duplicate_import_id:${duplicates.join(",")}`);
+    error.duplicates = duplicates;
+    throw error;
+  }
+
+  if (typeof airtable.requestBatchWithFieldFallback !== "function") {
+    const written = [];
+    for (const fields of fieldsList) written.push(await writeStaging(airtable, fields));
+    return written;
+  }
+
+  const existing = await airtable.list(STAGING_TABLE, {
+    filterByFormula: `{import_batch_id}="${encodeFormulaValue(batchId)}"`,
+  });
+  const existingByImportId = new Map(existing.map((record) => [clean(record.fields?.import_id), record.id]));
+  const written = Array(fieldsList.length);
+  const creates = [];
+  const updates = [];
+  fieldsList.forEach((fields, index) => {
+    const id = existingByImportId.get(fields.import_id);
+    if (id) updates.push({ index, id, fields });
+    else creates.push({ index, fields });
+  });
+
+  for (const group of chunks(creates, 10)) {
+    const data = await airtable.requestBatchWithFieldFallback(STAGING_TABLE, {
+      method: "POST",
+      body: { records: group.map((item) => ({ fields: item.fields })) },
+    });
+    (data.records || []).forEach((record, index) => {
+      written[group[index].index] = record;
+    });
+  }
+
+  for (const group of chunks(updates, 10)) {
+    const data = await airtable.requestBatchWithFieldFallback(STAGING_TABLE, {
+      method: "PATCH",
+      body: { records: group.map((item) => ({ id: item.id, fields: item.fields })) },
+    });
+    (data.records || []).forEach((record, index) => {
+      written[group[index].index] = record;
+    });
+  }
+
+  return written;
+}
+
+function normalizeConsoleInboxRecord(record, index) {
+  const fields = record?.fields ? record.fields : record;
+  const inboxId = pick(fields, ["inbox_id"]) || record?.id || `${index + 1}`;
+  const legacyTags = pick(fields, ["legacy_tags"]);
+  const memberName = pick(fields, ["member_name"]);
+  const explicitRenamedName = pick(fields, ["line_renamed_name"]);
+  const legacyLabel = deriveLegacyTagsLabel(legacyTags);
+  const lineRenamedName = explicitRenamedName || memberName || legacyLabel;
+  const row = {
+    __row: index + 1,
+    __record_id: record?.id || "",
+    __source: "console-inbox",
+    __source_file_title: CONSOLE_INBOX_SOURCE_TITLE,
+    __import_id: `line_ofc_console_${safeImportToken(inboxId)}`,
+    __line_renamed_name_source: explicitRenamedName ? "line_renamed_name" : memberName ? "member_name" : legacyLabel ? "legacy_tags" : "missing",
+    inbox_id: inboxId,
+    member_name: memberName,
+    member_email: pick(fields, ["member_email"]),
+    member_phone: pick(fields, ["member_phone"]),
+    line_user_id: pick(fields, ["line_user_id"]),
+    line_id: pick(fields, ["line_id"]),
+    legacy_tags: legacyTags,
+    admin_note: pick(fields, ["admin_note"]),
+    payload_json: pick(fields, ["payload_json"]),
+    canonical_client: pick(fields, ["Canonical Client", "canonical_client"]),
+    line_display_name: memberName,
+    line_renamed_name: lineRenamedName,
+    line_tags_raw: legacyTags,
+    username: pick(fields, ["line_id"]),
+    email: pick(fields, ["member_email"]),
+    phone: pick(fields, ["member_phone"]),
+  };
+  row.__raw_row_redacted = redactSourceRow({
+    inbox_id: row.inbox_id,
+    record_id: row.__record_id,
+    member_name: row.member_name,
+    member_email: row.member_email,
+    member_phone: row.member_phone,
+    line_user_id: row.line_user_id,
+    line_id: row.line_id,
+    legacy_tags: row.legacy_tags,
+    admin_note: row.admin_note,
+    payload_json: row.payload_json,
+    canonical_client: row.canonical_client,
+    line_renamed_name_source: row.__line_renamed_name_source,
+  });
+  return row;
+}
+
+async function readConsoleInboxRows(airtable) {
+  const records = await airtable.list(CONSOLE_INBOX_TABLE);
+  return records.map(normalizeConsoleInboxRecord);
+}
+
+function applyConsoleInboxParseGuard(parsed, row) {
+  if (row.__source !== "console-inbox" || row.__line_renamed_name_source === "line_renamed_name") return parsed;
+  const warnings = [...(parsed.parse_warnings || []), `line_renamed_name_fallback:${row.__line_renamed_name_source}`];
+  const confidenceCap = row.__line_renamed_name_source === "member_name" ? 0.72 : 0.45;
+  return {
+    ...parsed,
+    parse_confidence: Math.min(parsed.parse_confidence, confidenceCap),
+    parse_warnings: Array.from(new Set(warnings)),
+  };
+}
+
+async function loadRows({ source, file, airtable }) {
+  if (source === "console-inbox") return readConsoleInboxRows(airtable);
+  if (!file) throw new Error("missing_file");
+  return readRows(file);
+}
+
+async function runDryRunImport({
+  file,
+  source = "file",
+  batchId = `line_ofc_${source === "console-inbox" ? "console_" : ""}${Date.now().toString(36)}`,
+  airtable = new AirtableClient(),
+}) {
+  if (!["file", "console-inbox"].includes(source)) throw new Error(`unsupported_source:${source}`);
+  const rows = await loadRows({ source, file, airtable });
+  const matchCache = {};
+  if (source === "console-inbox") {
+    matchCache.clientsAll = await airtable.list(CLIENTS_TABLE);
+    matchCache.clientsForPhoneMatch = matchCache.clientsAll;
+  }
+  const pending = [];
+  for (let index = 0; index < rows.length; index += 1) {
+    const row = rows[index];
+    if (process.env.LINE_OFC_PROGRESS === "1") {
+      console.error(JSON.stringify({
+        progress: "line_ofc_console_dry_run",
+        row: index + 1,
+        total: rows.length,
+        import_id: row.__import_id || `line_ofc_${batchId}_${row.__row || index + 1}`,
+      }));
+    }
+    const parsed = applyConsoleInboxParseGuard(parseCanonicalLineOfc({
+      nickname: pick(row, ["nickname", "label", "display_label", "rename", "name", "display name", "customer"]),
+      line_renamed_name: pick(row, ["line_renamed_name", "rename", "label", "display_label", "nickname"]),
+      line_display_name: pick(row, ["line_display_name", "display_name", "display name"]),
+      line_user_id: pick(row, ["line_user_id", "line user id", "userId", "user_id"]),
+      username: pick(row, ["username", "line_id", "line id", "handle"]),
+      email: pick(row, ["email", "Contact Email", "primary_email", "member_email"]),
+      phone: pick(row, ["phone", "Phone Number", "phone_number", "tel", "member_phone"]),
+      tags: pick(row, ["line_tags_raw", "tags", "tag", "hashtags", "legacy_tags"]),
+      note: pick(row, ["note", "notes", "memo", "description"]),
+      raw_note: pick(row, ["raw_note", "note", "notes", "memo", "description", "admin_note"]),
+    }), row);
+    const match = await matchClients(airtable, parsed, row, {
+      allowUsernameExact: source !== "console-inbox",
+      cache: matchCache,
+    });
+    const fields = buildStagingFields({ row, rowIndex: index, sourceFile: file, batchId, parsed, match });
+    pending.push({
+      fields,
+      match,
+      parsed,
+    });
+  }
+
+  let stagingRows;
+  try {
+    stagingRows = await writeStagingRows(airtable, pending.map((item) => item.fields), batchId);
+  } catch (error) {
+    error.stagingRowsWrittenBeforeFailure = 0;
+    error.failingImportId = pending[0]?.fields?.import_id || "";
+    error.failingFields = pending[0]?.fields || {};
+    throw error;
+  }
+
+  const results = pending.map((item, index) => {
+    const staging = stagingRows[index] || {};
+    return {
+      import_id: item.fields.import_id,
+      staging_record_id: staging.id,
+      match_type: item.match.matchType,
+      review_status: item.match.reviewStatus,
+      parsed_membership_status: item.parsed.membership_status,
+      parsed_client_level: item.parsed.client_level,
+      parsed_membership_tier: item.parsed.membership_tier,
+      parsed_membership_package: item.parsed.membership_package,
+    };
+  });
+  return { ok: true, mode: "line_ofc_dry_run_import", source, batch_id: batchId, count: rows.length, results };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.file && args.source !== "console-inbox") {
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+  const result = await runDryRunImport({ file: args.file, source: args.source || "file", batchId: args.batchId });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    if (process.env.LINE_OFC_DEBUG_AIRTABLE_ERROR === "1") {
+      console.error(JSON.stringify(buildDebugError(error), null, 2));
+    } else {
+      console.error(error instanceof Error ? error.message : String(error));
+    }
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  AirtableClient,
+  BLOCKED_FIELDS,
+  CONSOLE_INBOX_TABLE,
+  buildStagingFields,
+  buildDebugError,
+  duplicateImportIds,
+  matchClients,
+  normalizeConsoleInboxRecord,
+  normalizeEmail,
+  normalizePhone,
+  parseArgs,
+  readRows,
+  runDryRunImport,
+};

--- a/scripts/line-official-legacy/dry-run-import.test.js
+++ b/scripts/line-official-legacy/dry-run-import.test.js
@@ -1,0 +1,622 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { buildStagingFields, duplicateImportIds, runDryRunImport } = require("./dry-run-import.js");
+const {
+  isNeverCommittableWithoutReview,
+  isPotentiallyReadyAfterManualReview,
+  normalizeRow,
+  summarizeRows,
+} = require("./review-report.js");
+const { buildBackfillPlan } = require("./member-token-backfill-plan.js");
+const { buildBackfillUpdates, runBackfill } = require("./member-token-backfill.js");
+
+function tempCsv(content) {
+  const file = path.join(os.tmpdir(), `line-ofc-${Date.now()}-${Math.random().toString(36).slice(2)}.csv`);
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+test("dry-run writes staging only and never patches Clients", async () => {
+  const file = tempCsv("nickname,line_user_id,tags\nPaul #client #mem24,U1,#client\n");
+  const calls = [];
+  const airtable = {
+    list: async (table, query) => {
+      calls.push({ action: "list", table, query });
+      if (table === "tblVv58TCbwh5j1fS") {
+        return [{ id: "recClient1", fields: { line_user_id: "U1", "Client Name": "Paul" } }];
+      }
+      return [];
+    },
+    findOne: async (table, formula) => {
+      calls.push({ action: "findOne", table, formula });
+      return null;
+    },
+    requestWithFieldFallback: async (table, init) => {
+      calls.push({ action: "requestWithFieldFallback", table, init });
+      return { id: "stg1", fields: init.body.fields };
+    },
+  };
+
+  const result = await runDryRunImport({ file, batchId: "batch_test", airtable });
+  assert.equal(result.count, 1);
+  assert.equal(result.results[0].match_type, "exact_line_user_id");
+  assert.equal(
+    calls.some((call) => call.table === "tblVv58TCbwh5j1fS" && ["PATCH", "POST"].includes(call.init?.method)),
+    false,
+  );
+  assert.ok(calls.some((call) => call.table === "tbl1u0foFBvgFpT9G" && call.init?.method === "POST"));
+  const stagingCall = calls.find((call) => call.table === "tbl1u0foFBvgFpT9G" && call.init?.method === "POST");
+  assert.equal(stagingCall.init.body.fields.dry_run_only, true);
+  assert.equal(stagingCall.init.body.fields.parsed_client_level, "premium");
+  assert.equal(stagingCall.init.body.fields.parsed_membership_status, "member");
+  const membershipParse = JSON.parse(stagingCall.init.body.fields.membership_parse_json);
+  assert.equal(membershipParse.client_level, "premium");
+  assert.ok(membershipParse.parse_warnings.includes("inferred_premium_from_member_signal"));
+  assert.deepEqual(membershipParse.all_member_tokens, ["#mem24"]);
+  assert.equal(membershipParse.chosen_member_since_token, "#mem24");
+  assert.equal(membershipParse.chosen_member_since_strategy, "only_valid_member_token");
+  assert.deepEqual(membershipParse.member_since_candidates, [{ token: "#mem24", member_since: "2024", warning: "" }]);
+  assert.equal(stagingCall.init.body.fields.proposed_points, 0);
+  assert.equal(stagingCall.init.body.fields.points_review_required, "false");
+  assert.match(stagingCall.init.body.fields.created_at, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("duplicate import_id remains impossible before staging writes", async () => {
+  const { airtable, calls } = consoleInboxAirtable({
+    sourceRecords: [
+      { id: "recDup1", fields: { inbox_id: "same", member_name: "One" } },
+      { id: "recDup2", fields: { inbox_id: "same", member_name: "Two" } },
+    ],
+  });
+
+  await assert.rejects(
+    () => runDryRunImport({ source: "console-inbox", batchId: "batch_dupe", airtable }),
+    /duplicate_import_id:line_ofc_console_same/,
+  );
+  assert.equal(calls.some((call) => call.table === "tbl1u0foFBvgFpT9G" && ["POST", "PATCH"].includes(call.init?.method)), false);
+  assert.deepEqual(duplicateImportIds([{ import_id: "a" }, { import_id: "b" }, { import_id: "a" }]), ["a"]);
+});
+
+test("dry-run staging fields do not introduce a field named token", () => {
+  const fields = buildStagingFields({
+    row: { __row: 1, nickname: "Paul #client", line_renamed_name: "Paul #client", tags: "#client" },
+    rowIndex: 0,
+    sourceFile: "sample.csv",
+    batchId: "batch_no_token",
+    parsed: {
+      line_user_id: "",
+      line_display_name: "",
+      line_renamed_name: "Paul #client",
+      line_tags_raw: "#client",
+      detected_tags: ["#client"],
+      normalized_name: "paul",
+      client_level: "premium",
+      client_level_raw: "#client",
+      client_level_tokens: [],
+      membership_status: "member",
+      membership_tier: "none",
+      membership_package: "none",
+      member_since: "",
+      member_since_raw: "",
+      has_purchased: false,
+      parse_confidence: 0.8,
+    },
+    match: { matchedClient: "", matchType: "no_match", matchConfidence: 0, reviewStatus: "staging_only" },
+  });
+  assert.equal(Object.prototype.hasOwnProperty.call(fields, "token"), false);
+});
+
+test("dry-run omits empty parsed_member_since date field", async () => {
+  const file = tempCsv("nickname,line_user_id,tags\nVisitor,U-empty,\n");
+  const calls = [];
+  const airtable = {
+    list: async (table, query) => {
+      calls.push({ action: "list", table, query });
+      return [];
+    },
+    findOne: async (table, formula) => {
+      calls.push({ action: "findOne", table, formula });
+      return null;
+    },
+    requestWithFieldFallback: async (table, init) => {
+      calls.push({ action: "requestWithFieldFallback", table, init });
+      return { id: "stgEmptyDate", fields: init.body.fields };
+    },
+  };
+
+  await runDryRunImport({ file, batchId: "batch_empty_date", airtable });
+  const stagingCall = calls.find((call) => call.table === "tbl1u0foFBvgFpT9G" && call.init?.method === "POST");
+  assert.equal(Object.prototype.hasOwnProperty.call(stagingCall.init.body.fields, "parsed_member_since"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(stagingCall.init.body.fields, "parsed_membership_status"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(stagingCall.init.body.fields, "parsed_membership_tier"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(stagingCall.init.body.fields, "parsed_membership_package"), false);
+  assert.equal(stagingCall.init.body.fields.parsed_client_level, "guest");
+  assert.equal(stagingCall.init.body.fields.parsed_member_since_raw, "");
+});
+
+test("dry-run stages historical note points evidence only", async () => {
+  const file = tempCsv("nickname,line_user_id,tags,note\nPaul #client,U1,#client,\"Booking service 12,000 THB plus MMD tip 1,000 THB\"\n");
+  const calls = [];
+  const airtable = {
+    list: async (table) => {
+      calls.push({ action: "list", table });
+      if (table === "tblVv58TCbwh5j1fS") return [{ id: "recClient1", fields: { line_user_id: "U1" } }];
+      return [];
+    },
+    findOne: async (table, formula) => {
+      calls.push({ action: "findOne", table, formula });
+      return null;
+    },
+    requestWithFieldFallback: async (table, init) => {
+      calls.push({ action: "requestWithFieldFallback", table, init });
+      return { id: "stgNote", fields: init.body.fields };
+    },
+  };
+
+  await runDryRunImport({ file, batchId: "batch_note", airtable });
+  assert.equal(
+    calls.some((call) => ["tbl5dfnwjUFMLbnWL", "tblWGGJJOx5eBvBZJ", "tblgWc5VRon5o8Mhk"].includes(call.table)),
+    false,
+  );
+  const stagingCall = calls.find((call) => call.table === "tbl1u0foFBvgFpT9G" && call.init?.method === "POST");
+  assert.equal(stagingCall.init.body.fields.raw_note, "Booking service 12,000 THB plus MMD tip 1,000 THB");
+  assert.equal(stagingCall.init.body.fields.service_amount, 12000);
+  assert.equal(stagingCall.init.body.fields.tip_amount_mmd, 1000);
+  assert.equal(stagingCall.init.body.fields.points_eligible_amount, 12000);
+  assert.equal(stagingCall.init.body.fields.proposed_points, 120);
+});
+
+test("dry-run preserves raw note exactly in staging", async () => {
+  const file = tempCsv("nickname,line_user_id,tags,note\nPaul,U1,,\"  Booking service 1,000 THB\nsecond line  \"\n");
+  const calls = [];
+  const airtable = {
+    list: async (table) => {
+      calls.push({ action: "list", table });
+      return [];
+    },
+    findOne: async (table, formula) => {
+      calls.push({ action: "findOne", table, formula });
+      return null;
+    },
+    requestWithFieldFallback: async (table, init) => {
+      calls.push({ action: "requestWithFieldFallback", table, init });
+      return { id: "stgRawNote", fields: init.body.fields };
+    },
+  };
+
+  await runDryRunImport({ file, batchId: "batch_raw_note", airtable });
+  const stagingCall = calls.find((call) => call.table === "tbl1u0foFBvgFpT9G" && call.init?.method === "POST");
+  assert.equal(stagingCall.init.body.fields.raw_note, "  Booking service 1,000 THB\nsecond line  ");
+  assert.equal(stagingCall.init.body.fields.service_amount, 1000);
+});
+
+test("fuzzy and multiple matches are review only", async () => {
+  const fuzzyFile = tempCsv("nickname,line_user_id,tags\nPaul #client,,#client\n");
+  const fuzzyCalls = [];
+  const fuzzyAirtable = {
+    list: async (table, query) => {
+      fuzzyCalls.push({ table, query });
+      if (table === "tblVv58TCbwh5j1fS") return [{ id: "recFuzzy", fields: { "Client Name": "Paul" } }];
+      return [];
+    },
+    findOne: async () => null,
+    requestWithFieldFallback: async (_table, init) => ({ id: "stgFuzzy", fields: init.body.fields }),
+  };
+  const fuzzy = await runDryRunImport({ file: fuzzyFile, batchId: "batch_fuzzy", airtable: fuzzyAirtable });
+  assert.equal(fuzzy.results[0].match_type, "fuzzy_name");
+  assert.equal(fuzzy.results[0].review_status, "review_required");
+
+  const multiFile = tempCsv("nickname,line_user_id,tags\nPaul #client,U2,#client\n");
+  const multiAirtable = {
+    list: async (table) => {
+      if (table === "tblVv58TCbwh5j1fS") {
+        return [
+          { id: "rec1", fields: { line_user_id: "U2" } },
+          { id: "rec2", fields: { line_user_id: "U2" } },
+        ];
+      }
+      return [];
+    },
+    findOne: async () => null,
+    requestWithFieldFallback: async (_table, init) => ({ id: "stgMulti", fields: init.body.fields }),
+  };
+  const multiple = await runDryRunImport({ file: multiFile, batchId: "batch_multi", airtable: multiAirtable });
+  assert.equal(multiple.results[0].match_type, "multiple_candidates");
+  assert.equal(multiple.results[0].review_status, "review_required");
+});
+
+function consoleInboxAirtable({ sourceRecords, clientRecords = [] } = {}) {
+  const calls = [];
+  return {
+    calls,
+    airtable: {
+      list: async (table, query) => {
+        calls.push({ action: "list", table, query });
+        if (table === "tblFHmfpB2TTrzO2e") return sourceRecords;
+        if (table === "tblVv58TCbwh5j1fS") return clientRecords;
+        return [];
+      },
+      findOne: async (table, formula) => {
+        calls.push({ action: "findOne", table, formula });
+        return null;
+      },
+      requestWithFieldFallback: async (table, init) => {
+        calls.push({ action: "requestWithFieldFallback", table, init });
+        return { id: `stg${calls.length}`, fields: init.body.fields };
+      },
+    },
+  };
+}
+
+test("console-inbox mode writes staging only and never patches Clients", async () => {
+  const { airtable, calls } = consoleInboxAirtable({
+    sourceRecords: [
+      {
+        id: "recInbox1",
+        fields: {
+          inbox_id: "inbox-001",
+          member_name: "Paul #client #memMay24",
+          member_email: "paul@example.com",
+          member_phone: "0812345678",
+          line_user_id: "U1",
+          line_id: "paul_line",
+          legacy_tags: "#client #purchased",
+          admin_note: "console note",
+          payload_json: "{\"phone\":\"0812345678\"}",
+          "Canonical Client": ["recClient1"],
+        },
+      },
+    ],
+    clientRecords: [{ id: "recClient1", fields: { line_user_id: "U1", "Client Name": "Paul" } }],
+  });
+
+  const result = await runDryRunImport({ source: "console-inbox", batchId: "batch_console", airtable });
+
+  assert.equal(result.source, "console-inbox");
+  assert.equal(result.count, 1);
+  assert.equal(result.results[0].match_type, "exact_line_user_id");
+  assert.equal(
+    calls.some((call) => call.table === "tblVv58TCbwh5j1fS" && ["PATCH", "POST"].includes(call.init?.method)),
+    false,
+  );
+  const stagingCall = calls.find((call) => call.table === "tbl1u0foFBvgFpT9G" && call.init?.method === "POST");
+  assert.ok(stagingCall);
+  assert.equal(stagingCall.init.body.fields.import_id, "line_ofc_console_inbox-001");
+  assert.equal(stagingCall.init.body.fields.import_batch_id, "batch_console");
+  assert.equal(stagingCall.init.body.fields.source_file_title, "airtable_console_inbox");
+  assert.equal(stagingCall.init.body.fields.line_user_id, "U1");
+  assert.equal(stagingCall.init.body.fields.line_display_name, "Paul #client #memMay24");
+  assert.equal(stagingCall.init.body.fields.line_renamed_name, "Paul #client #memMay24");
+  assert.equal(stagingCall.init.body.fields.line_tags_raw, "#client #purchased");
+  assert.equal(stagingCall.init.body.fields.phone_candidate, "+66812345678");
+  assert.equal(stagingCall.init.body.fields.email_candidate, "paul@example.com");
+  assert.equal(stagingCall.init.body.fields.parsed_membership_status, "member");
+  assert.equal(stagingCall.init.body.fields.parsed_client_level, "premium");
+  assert.equal(stagingCall.init.body.fields.parsed_has_purchased, true);
+  assert.equal(stagingCall.init.body.fields.parsed_member_since, "2024-05");
+  const raw = JSON.parse(stagingCall.init.body.fields.raw_row_json);
+  assert.equal(raw.member_email, "[redacted]");
+  assert.equal(raw.member_phone, "[redacted]");
+  assert.equal(raw.payload_json, "[redacted_payload_json]");
+});
+
+test("console-inbox legacy_tags client and purchased tags parse correctly", async () => {
+  const { airtable, calls } = consoleInboxAirtable({
+    sourceRecords: [
+      {
+        id: "recInboxTags",
+        fields: {
+          inbox_id: "inbox-tags",
+          member_name: "Nok",
+          legacy_tags: "#client #purchased",
+        },
+      },
+    ],
+  });
+
+  await runDryRunImport({ source: "console-inbox", batchId: "batch_tags", airtable });
+  const stagingCall = calls.find((call) => call.table === "tbl1u0foFBvgFpT9G" && call.init?.method === "POST");
+  assert.equal(stagingCall.init.body.fields.parsed_membership_status, "member");
+  assert.equal(stagingCall.init.body.fields.parsed_has_purchased, true);
+});
+
+test("console-inbox member_name mem month-year tag parses member_since", async () => {
+  const { airtable, calls } = consoleInboxAirtable({
+    sourceRecords: [
+      {
+        id: "recInboxMem",
+        fields: {
+          inbox_id: "inbox-mem",
+          member_name: "Mint #memJun25",
+        },
+      },
+    ],
+  });
+
+  await runDryRunImport({ source: "console-inbox", batchId: "batch_mem", airtable });
+  const stagingCall = calls.find((call) => call.table === "tbl1u0foFBvgFpT9G" && call.init?.method === "POST");
+  assert.equal(stagingCall.init.body.fields.parsed_member_since, "2025-06");
+  assert.equal(stagingCall.init.body.fields.parsed_membership_status, "member");
+  assert.ok(stagingCall.init.body.fields.parse_confidence <= 0.72);
+});
+
+test("console-inbox missing renamed name uses legacy tags and lowers confidence", async () => {
+  const { airtable, calls } = consoleInboxAirtable({
+    sourceRecords: [
+      {
+        id: "recInboxMissingRename",
+        fields: {
+          inbox_id: "inbox-missing-rename",
+          legacy_tags: "#client #memMay24",
+        },
+      },
+    ],
+  });
+
+  await runDryRunImport({ source: "console-inbox", batchId: "batch_missing_rename", airtable });
+  const stagingCall = calls.find((call) => call.table === "tbl1u0foFBvgFpT9G" && call.init?.method === "POST");
+  assert.equal(stagingCall.init.body.fields.parsed_member_since, "2024-05");
+  assert.ok(stagingCall.init.body.fields.parse_confidence <= 0.45);
+  assert.match(stagingCall.init.body.fields.membership_parse_json, /line_renamed_name_fallback:missing/);
+});
+
+test("console-inbox fuzzy and multiple matches are review only", async () => {
+  const fuzzy = consoleInboxAirtable({
+    sourceRecords: [
+      {
+        id: "recInboxFuzzy",
+        fields: {
+          inbox_id: "inbox-fuzzy",
+          member_name: "Paul #client",
+          legacy_tags: "#client",
+        },
+      },
+    ],
+    clientRecords: [{ id: "recFuzzy", fields: { "Client Name": "Paul" } }],
+  });
+  const fuzzyResult = await runDryRunImport({
+    source: "console-inbox",
+    batchId: "batch_console_fuzzy",
+    airtable: fuzzy.airtable,
+  });
+  assert.equal(fuzzyResult.results[0].match_type, "fuzzy_name");
+  assert.equal(fuzzyResult.results[0].review_status, "review_required");
+
+  const multiple = consoleInboxAirtable({
+    sourceRecords: [
+      {
+        id: "recInboxMulti",
+        fields: {
+          inbox_id: "inbox-multi",
+          member_name: "Paul #client",
+          line_user_id: "U2",
+          legacy_tags: "#client",
+        },
+      },
+    ],
+    clientRecords: [
+      { id: "rec1", fields: { line_user_id: "U2" } },
+      { id: "rec2", fields: { line_user_id: "U2" } },
+    ],
+  });
+  const multipleResult = await runDryRunImport({
+    source: "console-inbox",
+    batchId: "batch_console_multi",
+    airtable: multiple.airtable,
+  });
+  assert.equal(multipleResult.results[0].match_type, "multiple_candidates");
+  assert.equal(multipleResult.results[0].review_status, "review_required");
+});
+
+test("console-inbox line_id is not treated as a high-confidence exact match", async () => {
+  const { airtable } = consoleInboxAirtable({
+    sourceRecords: [
+      {
+        id: "recInboxLineId",
+        fields: {
+          inbox_id: "inbox-line-id",
+          line_id: "paul_line",
+          legacy_tags: "#client",
+        },
+      },
+    ],
+    clientRecords: [{ id: "recLineId", fields: { line_id: "paul_line" } }],
+  });
+
+  const result = await runDryRunImport({ source: "console-inbox", batchId: "batch_console_line_id", airtable });
+  assert.equal(result.results[0].match_type, "no_match");
+  assert.equal(result.results[0].review_status, "staging_only");
+});
+
+test("review report marks review-only queues as never committable", () => {
+  const records = [
+    {
+      id: "recReview",
+      fields: {
+        import_id: "line_ofc_console_review",
+        import_batch_id: "batch_review",
+        review_status: "review_required",
+        match_type: "fuzzy_name",
+        membership_parse_json: JSON.stringify({ membership_status: "member", membership_tier: "vip", membership_package: "premium" }),
+        proposed_entitlement_json: JSON.stringify({ source: "line_ofc", review_required: true }),
+      },
+    },
+    {
+      id: "recNoMatch",
+      fields: {
+        import_id: "line_ofc_console_no_match",
+        import_batch_id: "batch_review",
+        review_status: "staging_only",
+        match_type: "no_match",
+        membership_parse_json: JSON.stringify({ membership_status: "none", membership_tier: "none", membership_package: "none" }),
+        proposed_entitlement_json: JSON.stringify({ source: "line_ofc", review_required: true }),
+      },
+    },
+    {
+      id: "recMultiple",
+      fields: {
+        import_id: "line_ofc_console_multiple",
+        import_batch_id: "batch_review",
+        review_status: "review_required",
+        match_type: "multiple_candidates",
+        membership_parse_json: JSON.stringify({ membership_status: "none", membership_tier: "none", membership_package: "none" }),
+        proposed_entitlement_json: JSON.stringify({ source: "line_ofc", review_required: true }),
+      },
+    },
+    {
+      id: "recReady",
+      fields: {
+        import_id: "line_ofc_console_ready",
+        import_batch_id: "batch_review",
+        review_status: "ready_to_review",
+        match_type: "exact_line_user_id",
+        membership_parse_json: JSON.stringify({ membership_status: "none", membership_tier: "none", membership_package: "none" }),
+        proposed_entitlement_json: JSON.stringify({ source: "line_ofc", review_required: false }),
+      },
+    },
+  ];
+
+  const summary = summarizeRows(records);
+  assert.equal(summary.review_required_rows, 2);
+  assert.equal(summary.multiple_match_review_rows, 1);
+  assert.equal(summary.member_vip_premium_rows, 1);
+  assert.equal(summary.no_match_rows, 1);
+  assert.equal(summary.rows_potentially_ready_after_manual_review, 1);
+  assert.equal(summary.rows_unsafe_to_commit_now, 4);
+  assert.equal(isNeverCommittableWithoutReview(summary.redacted_samples.review_required[0]), true);
+
+  const normalized = records.map(normalizeRow);
+  assert.equal(isPotentiallyReadyAfterManualReview(normalized[0]), false);
+  assert.equal(isPotentiallyReadyAfterManualReview(normalized[1]), false);
+  assert.equal(isPotentiallyReadyAfterManualReview(normalized[2]), false);
+  assert.equal(isPotentiallyReadyAfterManualReview(normalized[3]), true);
+  assert.equal(isNeverCommittableWithoutReview(normalized[0]), true);
+  assert.equal(isNeverCommittableWithoutReview(normalized[1]), true);
+  assert.equal(isNeverCommittableWithoutReview(normalized[2]), true);
+});
+
+test("member token backfill plan is dry-run and preserves raw token evidence", () => {
+  const plan = buildBackfillPlan([
+    {
+      id: "recLegacy",
+      fields: {
+        import_id: "line_ofc_console_draft_jjeune_identity_immigration_20260512",
+        membership_parse_json: JSON.stringify({
+          membership_status: "member",
+          member_since: "2025-04",
+          member_since_raw: "#memjan24",
+        }),
+        parsed_member_since_raw: "#memjan24",
+        raw_row_json: JSON.stringify({
+          record_id: "recSource",
+          inbox_id: "draft_jjeune_identity_immigration_20260512",
+          member_name: "เจ - SVIP - (Jjeune)",
+          line_id: "jjeune16",
+          legacy_tags: "#client #vip #purchased #memjan24 #mem2024 #mem2025 #memApr25",
+          line_renamed_name_source: "member_name",
+        }),
+        line_renamed_name: "เจ - SVIP - (Jjeune)",
+        line_display_name: "เจ - SVIP - (Jjeune)",
+        line_tags_raw: "#client #vip #purchased #memjan24 #mem2024 #mem2025 #memApr25",
+      },
+    },
+  ]);
+
+  assert.equal(plan.dry_run_only, true);
+  assert.equal(plan.rows_needing_backfill, 1);
+  assert.equal(plan.redacted_samples[0].next_member_since, "2025-04");
+  assert.equal(plan.redacted_samples[0].next_member_since_raw, "#memApr25");
+  assert.deepEqual(plan.redacted_samples[0].all_member_tokens, ["#memjan24", "#mem2024", "#mem2025", "#memApr25"]);
+  assert.equal(plan.redacted_samples[0].chosen_member_since_token, "#memApr25");
+  assert.equal(plan.redacted_samples[0].chosen_member_since_strategy, "latest_valid_member_token");
+});
+
+test("member token backfill updates only allowed staging fields", () => {
+  const updates = buildBackfillUpdates([
+    {
+      id: "recLegacy",
+      fields: {
+        import_id: "line_ofc_console_draft",
+        review_status: "review_required",
+        match_type: "name_fuzzy_review",
+        matched_client: ["recClient"],
+        membership_parse_json: JSON.stringify({ member_since: "2025-04", member_since_raw: "#memjan24" }),
+        proposed_entitlement_json: JSON.stringify({ source: "line_ofc", member_since_raw: "#memjan24", review_required: true }),
+        parsed_member_since: "2025-04-01",
+        parsed_member_since_raw: "#memjan24",
+        line_renamed_name: "เจ - SVIP - (Jjeune)",
+        line_display_name: "เจ - SVIP - (Jjeune)",
+        line_tags_raw: "#client #vip #purchased #memjan24 #mem2024 #mem2025 #memApr25",
+      },
+    },
+  ]);
+
+  assert.equal(updates.length, 1);
+  assert.deepEqual(Object.keys(updates[0].fields).sort(), [
+    "membership_parse_json",
+    "parsed_member_since",
+    "parsed_member_since_raw",
+    "proposed_entitlement_json",
+  ]);
+  assert.equal(updates[0].fields.parsed_member_since, "2025-04-01");
+  assert.equal(updates[0].fields.parsed_member_since_raw, "#memApr25");
+  const parse = JSON.parse(updates[0].fields.membership_parse_json);
+  assert.equal(parse.chosen_member_since_token, "#memApr25");
+  assert.deepEqual(parse.all_member_tokens, ["#memjan24", "#mem2024", "#mem2025", "#memApr25"]);
+  const proposed = JSON.parse(updates[0].fields.proposed_entitlement_json);
+  assert.equal(proposed.source, "line_ofc");
+  assert.equal(proposed.member_since_raw, "#memApr25");
+  assert.equal(proposed.review_required, true);
+});
+
+test("member token backfill patches staging only and keeps review status untouched", async () => {
+  const calls = [];
+  const records = [
+    {
+      id: "recrwS2H0Qr61RSqf",
+      fields: {
+        import_id: "line_ofc_console_draft",
+        import_batch_id: "batch_backfill",
+        review_status: "review_required",
+        membership_parse_json: JSON.stringify({ member_since: "2025-04", member_since_raw: "#memjan24" }),
+        proposed_entitlement_json: JSON.stringify({ source: "line_ofc", member_since_raw: "#memjan24", review_required: true }),
+        parsed_member_since: "2025-04-01",
+        parsed_member_since_raw: "#memjan24",
+        line_renamed_name: "เจ - SVIP - (Jjeune)",
+        line_display_name: "เจ - SVIP - (Jjeune)",
+        line_tags_raw: "#client #vip #purchased #memjan24 #mem2024 #mem2025 #memApr25",
+      },
+    },
+  ];
+  const airtable = {
+    list: async (table, query) => {
+      calls.push({ action: "list", table, query });
+      return records;
+    },
+    requestBatchWithFieldFallback: async (table, init) => {
+      calls.push({ action: "requestBatchWithFieldFallback", table, init });
+      Object.assign(records[0].fields, init.body.records[0].fields);
+      return { records: [{ id: records[0].id, fields: records[0].fields }] };
+    },
+    request: async (table, init) => {
+      calls.push({ action: "request", table, init });
+      return records[0];
+    },
+  };
+
+  const result = await runBackfill({ batchId: "batch_backfill", airtable });
+  assert.equal(result.rows_updated, 1);
+  assert.equal(result.verification.review_status, "review_required");
+  assert.equal(result.verification.parsed_member_since, "2025-04-01");
+  assert.equal(result.verification.parsed_member_since_raw, "#memApr25");
+  assert.equal(result.verification.chosen_member_since_token, "#memApr25");
+  assert.equal(calls.every((call) => call.table === "tbl1u0foFBvgFpT9G"), true);
+  const patchCall = calls.find((call) => call.action === "requestBatchWithFieldFallback");
+  assert.equal(patchCall.init.method, "PATCH");
+  assert.equal(Object.prototype.hasOwnProperty.call(patchCall.init.body.records[0].fields, "review_status"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(patchCall.init.body.records[0].fields, "matched_client"), false);
+});

--- a/scripts/line-official-legacy/historical-note-parser.js
+++ b/scripts/line-official-legacy/historical-note-parser.js
@@ -1,0 +1,286 @@
+const { clean } = require("./canonical-parser.js");
+
+const POINT_RATE_THB = 100;
+const THAI_MONTH_PATTERN = [
+  "ม.ค.",
+  "มกราคม",
+  "ก.พ.",
+  "กุมภาพันธ์",
+  "มี.ค.",
+  "มีนาคม",
+  "เม.ย.",
+  "เมษายน",
+  "พ.ค.",
+  "พฤษภาคม",
+  "มิ.ย.",
+  "มิถุนายน",
+  "ก.ค.",
+  "กรกฎาคม",
+  "ส.ค.",
+  "สิงหาคม",
+  "ก.ย.",
+  "กันยายน",
+  "ต.ค.",
+  "ตุลาคม",
+  "พ.ย.",
+  "พฤศจิกายน",
+  "ธ.ค.",
+  "ธันวาคม",
+].map((month) => month.replace(/\./g, "\\.")).join("|");
+
+function unique(values) {
+  return Array.from(new Set(values.map(clean).filter(Boolean)));
+}
+
+function numberFromAmount(value) {
+  const raw = clean(value).replace(/,/g, "");
+  const match = raw.match(/\d+(?:\.\d+)?/);
+  return match ? Number(match[0]) : 0;
+}
+
+function detectAmounts(note) {
+  const raw = clean(note);
+  const patterns = [
+    /(?:฿|thb|บาท)\s*([0-9][0-9,]*(?:\.\d+)?)/gi,
+    /([0-9][0-9,]*(?:\.\d+)?)\s*(?:thb|บาท|฿)/gi,
+  ];
+  const amounts = [];
+  for (const pattern of patterns) {
+    let match = pattern.exec(raw);
+    while (match) {
+      const token = match[0];
+      const amount = numberFromAmount(match[1] || token);
+      if (amount > 0) {
+        amounts.push({
+          amount,
+          token,
+          index: match.index,
+          end: match.index + token.length,
+          pre: raw.slice(Math.max(0, match.index - 36), match.index),
+          post: raw.slice(match.index + token.length, Math.min(raw.length, match.index + token.length + 24)),
+          context: contextWindow(raw, match.index, token.length),
+        });
+      }
+      match = pattern.exec(raw);
+    }
+  }
+
+  const seen = new Set();
+  return amounts.filter((item) => {
+    const key = `${item.amount}:${item.index}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function detectBareAmbiguousAmounts(note, knownAmounts) {
+  const raw = clean(note);
+  const ambiguous = [];
+  const pattern = /(?<![A-Za-z0-9_\/])(?:\d{1,3}(?:,\d{3})+|\d{4,7})(?:\.\d+)?(?![A-Za-z0-9_\/])/g;
+  let match = pattern.exec(raw);
+  while (match) {
+    const overlapsKnown = knownAmounts.some((item) => match.index >= item.index && match.index < item.end);
+    if (!overlapsKnown) {
+      const amount = numberFromAmount(match[0]);
+      if (amount > 0) {
+        ambiguous.push({
+          amount,
+          token: match[0],
+          index: match.index,
+          context: contextWindow(raw, match.index, match[0].length),
+        });
+      }
+    }
+    match = pattern.exec(raw);
+  }
+  return ambiguous;
+}
+
+function contextWindow(text, index, length) {
+  const start = Math.max(0, index - 48);
+  const end = Math.min(text.length, index + length + 48);
+  return text.slice(start, end);
+}
+
+function detectDates(note) {
+  const raw = clean(note);
+  const dates = [
+    ...(raw.match(/\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b/g) || []),
+    ...(raw.match(/\b\d{4}[/-]\d{1,2}[/-]\d{1,2}\b/g) || []),
+    ...(raw.match(/\b(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\s+\d{1,2},?\s+\d{2,4}\b/gi) || []),
+    ...(raw.match(new RegExp(`\\b\\d{1,2}\\s*(?:${THAI_MONTH_PATTERN})\\s*\\d{2,4}\\b`, "gi")) || []),
+  ];
+  return unique(dates);
+}
+
+function detectPaymentRefs(note) {
+  const raw = clean(note);
+  const refs = raw.match(/\b(?:ref|reference|txn|tx|slip|payment)\s*[:#-]?\s*([a-z0-9_-]{4,40})\b/gi) || [];
+  return unique(refs);
+}
+
+function hasAny(text, patterns) {
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function classifyAmount(amountItem) {
+  const pre = String(amountItem.pre || "").toLowerCase();
+  const post = String(amountItem.post || "").toLowerCase();
+  const local = `${pre} ${post}`;
+  const context = amountItem.context.toLowerCase();
+  if (hasAny(pre, [/direct\s+hand/, /\bhand\s+tip\b/, /\bcash\s+tip\b/, /tip\s+direct/, /ให้มือ/, /ทิปมือ/])) {
+    return "tip_direct";
+  }
+  if (hasAny(pre, [/\btip\b/, /\btips\b/, /ทิป/])) {
+    return "tip_mmd";
+  }
+  if (hasAny(pre, [/renew/, /renewal/, /ต่ออายุ/])) {
+    return "renewal_fee";
+  }
+  if (hasAny(pre, [/membership\s+fee/, /member\s+fee/, /สมัครสมาชิก/, /ค่าสมาชิก/])) {
+    return "membership_fee";
+  }
+  if (hasAny(pre, [/service/, /booking/, /\bjob\b/, /session/, /model/, /mmd confirmation/, /purchase/, /ใช้บริการ/, /งาน/])
+    || hasAny(context, [/mmd confirmation/])) {
+    return "service";
+  }
+  if (hasAny(local, [/direct\s+hand/, /\bhand\s+tip\b/, /\bcash\s+tip\b/, /tip\s+direct/, /ให้มือ/, /ทิปมือ/])) {
+    return "tip_direct";
+  }
+  if (hasAny(local, [/\btip\b/, /\btips\b/, /ทิป/])) return "tip_mmd";
+  if (hasAny(local, [/renew/, /renewal/, /ต่ออายุ/])) return "renewal_fee";
+  if (hasAny(local, [/membership\s+fee/, /member\s+fee/, /สมัครสมาชิก/, /ค่าสมาชิก/])) return "membership_fee";
+  if (hasAny(local, [/service/, /booking/, /\bjob\b/, /session/, /model/, /purchase/, /ใช้บริการ/, /งาน/])) return "service";
+  return "unknown";
+}
+
+function sumBy(events, type) {
+  return events
+    .filter((event) => event.type === type)
+    .reduce((sum, event) => sum + event.amount, 0);
+}
+
+function parseHistoricalNote(note) {
+  const rawNote = String(note == null ? "" : note);
+  const parseNote = clean(rawNote);
+  const lower = parseNote.toLowerCase();
+  const warnings = [];
+  const amounts = detectAmounts(parseNote);
+  const bareAmbiguous = detectBareAmbiguousAmounts(parseNote, amounts);
+  const amountEvents = amounts.map((item) => ({
+    type: classifyAmount(item),
+    amount: item.amount,
+    token: item.token,
+    context: item.context,
+  }));
+
+  for (const item of bareAmbiguous) {
+    amountEvents.push({
+      type: "unknown",
+      amount: item.amount,
+      token: item.token,
+      context: item.context,
+    });
+  }
+
+  const dates = detectDates(parseNote);
+  const paymentRefs = detectPaymentRefs(parseNote);
+  const referralBonusCandidate = hasAny(lower, [/referral/, /\brefer\b/, /แนะนำ/]);
+  const promotionBonusCandidate = hasAny(lower, [/promotion/, /\bpromo\b/, /campaign/, /แคมเปญ/, /โปรโมชั่น/]);
+  const membershipAction = hasAny(lower, [/renew/, /renewal/, /ต่ออายุ/])
+    ? "renewal"
+    : hasAny(lower, [/membership\s+fee/, /member\s+fee/, /สมัครสมาชิก/, /ค่าสมาชิก/])
+      ? "membership_signup"
+      : "";
+  const detectedPackage = hasAny(lower, [/\blite\b/, /standard/])
+    ? "standard_lite"
+    : hasAny(lower, [/premium/])
+      ? "premium"
+      : hasAny(lower, [/blackcard/, /black card/])
+        ? "blackcard"
+        : hasAny(lower, [/svip/])
+          ? "svip"
+          : hasAny(lower, [/\bvip\b/])
+            ? "vip"
+            : "";
+
+  const serviceAmount = sumBy(amountEvents, "service");
+  const tipAmountMmd = sumBy(amountEvents, "tip_mmd");
+  const tipAmountDirect = sumBy(amountEvents, "tip_direct");
+  const membershipFeeAmount = sumBy(amountEvents, "membership_fee");
+  const renewalFeeAmount = sumBy(amountEvents, "renewal_fee");
+  const unknownAmount = sumBy(amountEvents, "unknown");
+  const pointsEligibleAmount = serviceAmount;
+  const pointsIneligibleAmount = tipAmountMmd + tipAmountDirect + membershipFeeAmount + renewalFeeAmount + unknownAmount;
+  const proposedPoints = pointsEligibleAmount / POINT_RATE_THB;
+
+  if (unknownAmount > 0) warnings.push("ambiguous_amount_requires_review");
+  if (membershipFeeAmount > 0) warnings.push("membership_fee_not_auto_counted");
+  if (renewalFeeAmount > 0) warnings.push("renewal_fee_not_auto_counted");
+  if (referralBonusCandidate) warnings.push("referral_bonus_review_required");
+  if (promotionBonusCandidate) warnings.push("promotion_bonus_review_required");
+  if (parseNote && dates.length && !amountEvents.length) warnings.push("date_without_classified_amount_review_required");
+
+  const pointsReviewRequired = warnings.length > 0;
+  const customerDetails = {
+    generosity_signal: tipAmountMmd > 0 || tipAmountDirect > 0,
+    tip_amount_mmd: tipAmountMmd,
+    tip_amount_direct: tipAmountDirect,
+    direct_hand_tip_points_policy: "never_counts_for_points",
+    mmd_tip_points_policy: "detail_only_no_points",
+  };
+  const historicalEvents = {
+    raw_note_present: Boolean(rawNote),
+    amounts: amountEvents,
+    dates,
+    payment_refs: paymentRefs,
+    referral_bonus_candidate: referralBonusCandidate,
+    promotion_bonus_candidate: promotionBonusCandidate,
+  };
+
+  return {
+    raw_note: rawNote,
+    note_detected_amounts: amountEvents.map((event) => ({
+      amount: event.amount,
+      type: event.type,
+      token: event.token,
+      context: event.context,
+    })),
+    note_detected_dates: dates,
+    note_detected_package: detectedPackage,
+    note_detected_membership_action: membershipAction,
+    note_detected_service_count: amountEvents.filter((event) => event.type === "service").length,
+    note_detected_payment_refs: paymentRefs,
+    service_amount: serviceAmount,
+    tip_amount_mmd: tipAmountMmd,
+    tip_amount_direct: tipAmountDirect,
+    membership_fee_amount: membershipFeeAmount,
+    renewal_fee_amount: renewalFeeAmount,
+    referral_bonus_candidate: referralBonusCandidate,
+    promotion_bonus_candidate: promotionBonusCandidate,
+    unknown_amount: unknownAmount,
+    points_eligible_amount: pointsEligibleAmount,
+    points_ineligible_amount: pointsIneligibleAmount,
+    customer_detail_json: customerDetails,
+    model_review_incentive_signal: referralBonusCandidate ? "referral_review" : promotionBonusCandidate ? "promotion_review" : "",
+    historical_events_json: historicalEvents,
+    proposed_points: proposedPoints,
+    points_policy_basis: [
+      "Locked rate: 100 THB = 1 point.",
+      "Only service purchase through MMD generates staged proposed_points.",
+      "Tips through MMD are customer detail only and generate no points.",
+      "Direct hand tips never count as points.",
+      "Membership and renewal fees are review-required and not auto-counted.",
+      "Referral/promotion bonuses are review-required unless explicit campaign rules exist.",
+    ].join("\n"),
+    points_confidence: parseNote ? (pointsReviewRequired ? 0.5 : amountEvents.length ? 0.86 : 0.2) : 0,
+    points_review_required: pointsReviewRequired,
+    points_parse_warnings: unique(warnings),
+  };
+}
+
+module.exports = {
+  POINT_RATE_THB,
+  parseHistoricalNote,
+};

--- a/scripts/line-official-legacy/historical-note-parser.test.js
+++ b/scripts/line-official-legacy/historical-note-parser.test.js
@@ -1,0 +1,92 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { parseHistoricalNote } = require("./historical-note-parser.js");
+
+test("service purchase amount creates proposed_points", () => {
+  const parsed = parseHistoricalNote("Service purchase 12,000 THB on 12/05/2024 ref ABCD1234");
+  assert.equal(parsed.service_amount, 12000);
+  assert.equal(parsed.points_eligible_amount, 12000);
+  assert.equal(parsed.proposed_points, 120);
+  assert.equal(parsed.points_review_required, false);
+});
+
+test("MMD tip amount creates no points but adds customer_detail_json", () => {
+  const parsed = parseHistoricalNote("MMD tip 1,000 THB through system");
+  assert.equal(parsed.tip_amount_mmd, 1000);
+  assert.equal(parsed.proposed_points, 0);
+  assert.equal(parsed.points_ineligible_amount, 1000);
+  assert.equal(parsed.customer_detail_json.generosity_signal, true);
+});
+
+test("direct hand tip creates no points and is detail only", () => {
+  const parsed = parseHistoricalNote("Direct hand tip 2,000 THB to model");
+  assert.equal(parsed.tip_amount_direct, 2000);
+  assert.equal(parsed.proposed_points, 0);
+  assert.equal(parsed.customer_detail_json.direct_hand_tip_points_policy, "never_counts_for_points");
+});
+
+test("service plus tip counts only service amount", () => {
+  const parsed = parseHistoricalNote("Booking service 10,000 THB plus MMD tip 1,000 THB");
+  assert.equal(parsed.service_amount, 10000);
+  assert.equal(parsed.tip_amount_mmd, 1000);
+  assert.equal(parsed.points_eligible_amount, 10000);
+  assert.equal(parsed.proposed_points, 100);
+});
+
+test("renewal fee note is review-required and creates no points", () => {
+  const parsed = parseHistoricalNote("Renewal fee 3,000 THB paid");
+  assert.equal(parsed.renewal_fee_amount, 3000);
+  assert.equal(parsed.proposed_points, 0);
+  assert.equal(parsed.points_review_required, true);
+  assert.ok(parsed.points_parse_warnings.includes("renewal_fee_not_auto_counted"));
+});
+
+test("membership fee note is review-required and creates no points", () => {
+  const parsed = parseHistoricalNote("Membership fee 5,000 THB");
+  assert.equal(parsed.membership_fee_amount, 5000);
+  assert.equal(parsed.proposed_points, 0);
+  assert.equal(parsed.points_review_required, true);
+  assert.ok(parsed.points_parse_warnings.includes("membership_fee_not_auto_counted"));
+});
+
+test("referral note creates referral_bonus_candidate and review-required", () => {
+  const parsed = parseHistoricalNote("Referral bonus candidate for member");
+  assert.equal(parsed.referral_bonus_candidate, true);
+  assert.equal(parsed.points_review_required, true);
+  assert.ok(parsed.points_parse_warnings.includes("referral_bonus_review_required"));
+});
+
+test("promotion note creates promotion_bonus_candidate and review-required", () => {
+  const parsed = parseHistoricalNote("Promotion campaign bonus candidate");
+  assert.equal(parsed.promotion_bonus_candidate, true);
+  assert.equal(parsed.points_review_required, true);
+  assert.ok(parsed.points_parse_warnings.includes("promotion_bonus_review_required"));
+});
+
+test("ambiguous amount/date note requires review", () => {
+  const parsed = parseHistoricalNote("12/05/2024 paid 3000");
+  assert.equal(parsed.unknown_amount, 3000);
+  assert.equal(parsed.points_review_required, true);
+  assert.ok(parsed.points_parse_warnings.includes("ambiguous_amount_requires_review"));
+});
+
+test("Thai/common date formats are detected for review evidence", () => {
+  const parsed = parseHistoricalNote("ใช้บริการ 10,000 บาท วันที่ 12 พ.ค. 2567");
+  assert.deepEqual(parsed.note_detected_dates, ["12 พ.ค. 2567"]);
+  assert.equal(parsed.service_amount, 10000);
+  assert.equal(parsed.proposed_points, 100);
+});
+
+test("raw note is preserved exactly", () => {
+  const parsed = parseHistoricalNote("  Booking service 1,000 THB\n");
+  assert.equal(parsed.raw_note, "  Booking service 1,000 THB\n");
+  assert.equal(parsed.service_amount, 1000);
+});
+
+test("empty or no useful note creates no points", () => {
+  const parsed = parseHistoricalNote("");
+  assert.equal(parsed.proposed_points, 0);
+  assert.equal(parsed.points_eligible_amount, 0);
+  assert.equal(parsed.points_review_required, false);
+});

--- a/scripts/line-official-legacy/member-token-backfill-plan.js
+++ b/scripts/line-official-legacy/member-token-backfill-plan.js
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+const { AirtableClient } = require("./dry-run-import.js");
+const { parseCanonicalLineOfc } = require("./canonical-parser.js");
+
+const STAGING_TABLE = process.env.AIRTABLE_LINE_OFC_CLIENT_IMPORT_STAGING_TABLE_ID || "tbl1u0foFBvgFpT9G";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--batch-id") out.batchId = argv[index + 1];
+  }
+  return out;
+}
+
+function safeJson(value) {
+  try {
+    return value ? JSON.parse(value) : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseGuard(parsed, source) {
+  const renamedNameSource = clean(source);
+  if (!renamedNameSource || renamedNameSource === "line_renamed_name") return parsed;
+  const warnings = [...(parsed.parse_warnings || []), `line_renamed_name_fallback:${source}`];
+  const confidenceCap = renamedNameSource === "member_name" ? 0.72 : 0.45;
+  return {
+    ...parsed,
+    parse_confidence: Math.min(parsed.parse_confidence, confidenceCap),
+    parse_warnings: Array.from(new Set(warnings)),
+  };
+}
+
+function hasTokenEvidence(parseJson) {
+  return Array.isArray(parseJson.all_member_tokens)
+    && Object.prototype.hasOwnProperty.call(parseJson, "chosen_member_since_token")
+    && Object.prototype.hasOwnProperty.call(parseJson, "chosen_member_since_strategy")
+    && Array.isArray(parseJson.member_since_candidates);
+}
+
+function reconstructParse(record) {
+  const fields = record.fields || {};
+  const rawRow = safeJson(fields.raw_row_json);
+  const renamedName = clean(fields.line_renamed_name);
+  const displayName = clean(fields.line_display_name);
+  const lineTagsRaw = clean(fields.line_tags_raw);
+  return parseGuard(parseCanonicalLineOfc({
+    nickname: renamedName || displayName,
+    line_renamed_name: renamedName || displayName,
+    line_display_name: displayName,
+    line_user_id: clean(fields.line_user_id),
+    tags: lineTagsRaw,
+  }), rawRow.line_renamed_name_source);
+}
+
+function redactedPlanSample(record, nextParse) {
+  const fields = record.fields || {};
+  return {
+    staging_record_id: record.id ? `${record.id.slice(0, 6)}...${record.id.slice(-4)}` : "",
+    import_id: clean(fields.import_id).replace(/(line_ofc_console_).+/i, "$1[redacted]"),
+    would_update_fields: ["membership_parse_json", "parsed_member_since", "parsed_member_since_raw"],
+    current_member_since_raw: clean(fields.parsed_member_since_raw),
+    next_member_since: nextParse.member_since,
+    next_member_since_raw: nextParse.member_since_raw,
+    all_member_tokens: nextParse.all_member_tokens,
+    chosen_member_since_token: nextParse.chosen_member_since_token,
+    chosen_member_since_strategy: nextParse.chosen_member_since_strategy,
+  };
+}
+
+function buildBackfillPlan(records) {
+  const stale = [];
+  const blocked = [];
+  for (const record of records) {
+    const fields = record.fields || {};
+    const currentParse = safeJson(fields.membership_parse_json);
+    if (hasTokenEvidence(currentParse)) continue;
+    if (!fields.raw_row_json) {
+      blocked.push({ id: record.id, reason: "missing_raw_row_json" });
+      continue;
+    }
+    const nextParse = reconstructParse(record);
+    stale.push({ record, nextParse });
+  }
+  return {
+    total_rows_checked: records.length,
+    rows_already_hardened: records.length - stale.length - blocked.length,
+    rows_needing_backfill: stale.length,
+    rows_blocked: blocked.length,
+    blocked_reasons: blocked.reduce((acc, item) => {
+      acc[item.reason] = (acc[item.reason] || 0) + 1;
+      return acc;
+    }, {}),
+    dry_run_only: true,
+    redacted_samples: stale.slice(0, 5).map((item) => redactedPlanSample(item.record, item.nextParse)),
+  };
+}
+
+async function fetchBatchRows({ batchId, airtable = new AirtableClient() }) {
+  return airtable.list(STAGING_TABLE, {
+    filterByFormula: `{import_batch_id}="${clean(batchId).replace(/"/g, '\\"')}"`,
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.batchId) {
+    console.error("Usage: npm run line-ofc:member-token-backfill-plan -- --batch-id <batch_id>");
+    process.exitCode = 1;
+    return;
+  }
+  const records = await fetchBatchRows({ batchId: args.batchId });
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    mode: "line_ofc_member_token_backfill_plan",
+    batch_id: args.batchId,
+    ...buildBackfillPlan(records),
+  }, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildBackfillPlan,
+  hasTokenEvidence,
+  reconstructParse,
+};

--- a/scripts/line-official-legacy/member-token-backfill.js
+++ b/scripts/line-official-legacy/member-token-backfill.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+const {
+  AirtableClient,
+} = require("./dry-run-import.js");
+const {
+  buildBackfillPlan,
+  hasTokenEvidence,
+  reconstructParse,
+} = require("./member-token-backfill-plan.js");
+
+const STAGING_TABLE = process.env.AIRTABLE_LINE_OFC_CLIENT_IMPORT_STAGING_TABLE_ID || "tbl1u0foFBvgFpT9G";
+const VERIFY_RECORD_ID = "recrwS2H0Qr61RSqf";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function parseArgs(argv) {
+  const out = { plan: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--batch-id") out.batchId = argv[index + 1];
+    if (argv[index] === "--plan" || argv[index] === "--dry-run") out.plan = true;
+  }
+  return out;
+}
+
+function chunks(items, size) {
+  const out = [];
+  for (let index = 0; index < items.length; index += size) out.push(items.slice(index, index + size));
+  return out;
+}
+
+function airtableDate(value) {
+  const raw = clean(value);
+  if (!raw) return "";
+  if (/^\d{4}-\d{2}$/.test(raw)) return `${raw}-01`;
+  if (/^\d{4}$/.test(raw)) return `${raw}-01-01`;
+  return raw;
+}
+
+function buildProposedEntitlement(fields, parsed) {
+  const existing = (() => {
+    try {
+      return fields.proposed_entitlement_json ? JSON.parse(fields.proposed_entitlement_json) : {};
+    } catch {
+      return {};
+    }
+  })();
+  return {
+    ...existing,
+    source: "line_ofc",
+    client_level: parsed.client_level,
+    client_level_raw: parsed.client_level_raw,
+    client_level_tokens: parsed.client_level_tokens,
+    membership_status: parsed.membership_status,
+    membership_tier: parsed.membership_tier,
+    membership_package: parsed.membership_package,
+    member_since: parsed.member_since,
+    member_since_raw: parsed.member_since_raw,
+    has_purchased: parsed.has_purchased,
+    review_required: true,
+  };
+}
+
+function buildBackfillUpdates(records) {
+  const updates = [];
+  for (const record of records) {
+    const fields = record.fields || {};
+    const currentParse = (() => {
+      try {
+        return fields.membership_parse_json ? JSON.parse(fields.membership_parse_json) : {};
+      } catch {
+        return {};
+      }
+    })();
+    const parsed = reconstructParse(record);
+    const nextFields = {
+      membership_parse_json: JSON.stringify(parsed, null, 2),
+      parsed_member_since_raw: parsed.member_since_raw,
+      proposed_entitlement_json: JSON.stringify(buildProposedEntitlement(fields, parsed), null, 2),
+    };
+    if (parsed.member_since) nextFields.parsed_member_since = airtableDate(parsed.member_since);
+    if (
+      !hasTokenEvidence(currentParse)
+      || clean(fields.parsed_member_since_raw) !== parsed.member_since_raw
+      || clean(fields.parsed_member_since) !== nextFields.parsed_member_since
+    ) {
+      updates.push({ id: record.id, fields: nextFields });
+    }
+  }
+  return updates;
+}
+
+function redactedUpdateSample(update) {
+  const parse = JSON.parse(update.fields.membership_parse_json);
+  return {
+    staging_record_id: update.id ? `${update.id.slice(0, 6)}...${update.id.slice(-4)}` : "",
+    update_fields: Object.keys(update.fields),
+    parsed_member_since: update.fields.parsed_member_since || "",
+    parsed_member_since_raw: update.fields.parsed_member_since_raw,
+    all_member_tokens: parse.all_member_tokens || [],
+    chosen_member_since_token: parse.chosen_member_since_token || "",
+    chosen_member_since_strategy: parse.chosen_member_since_strategy || "",
+  };
+}
+
+async function fetchBatchRows({ batchId, airtable }) {
+  return airtable.list(STAGING_TABLE, {
+    filterByFormula: `{import_batch_id}="${clean(batchId).replace(/"/g, '\\"')}"`,
+  });
+}
+
+async function applyUpdates({ airtable, updates }) {
+  let updated = 0;
+  for (const group of chunks(updates, 10)) {
+    const data = await airtable.requestBatchWithFieldFallback(STAGING_TABLE, {
+      method: "PATCH",
+      body: { records: group },
+    });
+    updated += (data.records || []).length;
+  }
+  return updated;
+}
+
+function redactedVerification(record) {
+  const fields = record.fields || {};
+  const parse = JSON.parse(fields.membership_parse_json || "{}");
+  const proposed = JSON.parse(fields.proposed_entitlement_json || "{}");
+  return {
+    staging_record_id: record.id ? `${record.id.slice(0, 6)}...${record.id.slice(-4)}` : "",
+    parsed_member_since: fields.parsed_member_since || "",
+    parsed_member_since_raw: fields.parsed_member_since_raw || "",
+    chosen_member_since_token: parse.chosen_member_since_token || "",
+    all_member_tokens: parse.all_member_tokens || [],
+    proposed_entitlement_member_since_raw: proposed.member_since_raw || "",
+    review_status: fields.review_status || "",
+  };
+}
+
+async function runBackfill({ batchId, plan = false, airtable = new AirtableClient() }) {
+  const records = await fetchBatchRows({ batchId, airtable });
+  const planSummary = buildBackfillPlan(records);
+  const updates = buildBackfillUpdates(records);
+  if (plan) {
+    return {
+      ok: true,
+      mode: "line_ofc_member_token_backfill_plan",
+      batch_id: batchId,
+      ...planSummary,
+      rows_that_would_update: updates.length,
+      redacted_update_samples: updates.slice(0, 5).map(redactedUpdateSample),
+    };
+  }
+
+  const rowsUpdated = await applyUpdates({ airtable, updates });
+  const verification = await airtable.request(STAGING_TABLE, {
+    recordId: VERIFY_RECORD_ID,
+  });
+  return {
+    ok: true,
+    mode: "line_ofc_member_token_backfill",
+    batch_id: batchId,
+    rows_checked: records.length,
+    rows_updated: rowsUpdated,
+    updated_fields_only: [
+      "membership_parse_json",
+      "parsed_member_since",
+      "parsed_member_since_raw",
+      "proposed_entitlement_json",
+    ],
+    verification: redactedVerification(verification),
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.batchId) {
+    console.error("Usage: npm run line-ofc:member-token-backfill -- --batch-id <batch_id> [--plan]");
+    process.exitCode = 1;
+    return;
+  }
+  const result = await runBackfill({ batchId: args.batchId, plan: args.plan });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  airtableDate,
+  buildBackfillUpdates,
+  buildProposedEntitlement,
+  runBackfill,
+};

--- a/scripts/line-official-legacy/normalize-line-official-export.js
+++ b/scripts/line-official-legacy/normalize-line-official-export.js
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+/**
+ * LINE Official legacy export normalizer.
+ *
+ * Preview-only tool:
+ * - reads CSV or JSON rows exported from LINE Official / manual sheets
+ * - normalizes labels, tags, and notes into review records
+ * - writes JSON preview to stdout
+ * - does not write Airtable
+ * - does not send LINE
+ * - does not create Sessions or Payments automatically
+ */
+
+const fs = require("fs");
+const path = require("path");
+const {
+  clean,
+  extractTags,
+  parseCanonicalLineOfc,
+  parseMemberSinceToken,
+} = require("./canonical-parser.js");
+
+function usage() {
+  console.error("Usage: node scripts/line-official-legacy/normalize-line-official-export.js <export.csv|export.json>");
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let quoted = false;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const next = text[index + 1];
+
+    if (quoted) {
+      if (char === '"' && next === '"') {
+        field += '"';
+        index += 1;
+      } else if (char === '"') {
+        quoted = false;
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      quoted = true;
+    } else if (char === ",") {
+      row.push(field);
+      field = "";
+    } else if (char === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else if (char !== "\r") {
+      field += char;
+    }
+  }
+
+  if (field || row.length) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  const headers = (rows.shift() || []).map((header) => clean(header));
+  return rows
+    .filter((items) => items.some((item) => clean(item)))
+    .map((items, index) => {
+      const out = { __row: index + 2 };
+      headers.forEach((header, headerIndex) => {
+        out[header || `column_${headerIndex + 1}`] = clean(items[headerIndex]);
+      });
+      return out;
+    });
+}
+
+function readRows(filePath) {
+  const text = fs.readFileSync(filePath, "utf8");
+  if (/\.json$/i.test(filePath)) {
+    const parsed = JSON.parse(text);
+    if (Array.isArray(parsed)) return parsed;
+    if (Array.isArray(parsed.rows)) return parsed.rows;
+    throw new Error("JSON export must be an array or { rows: [] }");
+  }
+  return parseCsv(text);
+}
+
+function pick(row, names) {
+  const lowerMap = new Map(Object.keys(row).map((key) => [key.toLowerCase(), key]));
+  for (const name of names) {
+    const key = lowerMap.get(name.toLowerCase());
+    if (key) return clean(row[key]);
+  }
+  return "";
+}
+
+function parseLabel(label) {
+  const usernameMatch = label.match(/\(([^)]+)\)/);
+  const withoutHandle = label.replace(/\([^)]*\)/g, "").trim();
+  const firstPart = clean(withoutHandle.split("-")[0]);
+  return {
+    parsed_client_name: firstPart ? (firstPart.startsWith("คุณ") ? firstPart : `คุณ${firstPart}`) : "",
+    parsed_username: usernameMatch ? clean(usernameMatch[1]) : "",
+  };
+}
+
+function parseMemTag(tag) {
+  const parsed = parseMemberSinceToken(tag);
+  return parsed.value || parsed.raw;
+}
+
+function parseMoney(value) {
+  const match = clean(value).replace(/,/g, "").match(/(\d+(?:\.\d+)?)/);
+  return match ? Number(match[1]) : 0;
+}
+
+function noteField(note, label) {
+  const pattern = new RegExp(`^\\s*${label}\\s*:\\s*(.+)$`, "im");
+  const match = clean(note).match(pattern);
+  return match ? clean(match[1]) : "";
+}
+
+function parseServiceNote(note) {
+  const raw = clean(note);
+  if (!/MMD Confirmation/i.test(raw)) return [];
+
+  const timeLabel = noteField(raw, "Time");
+  const timeMatch = timeLabel.match(/(\d{1,2}:\d{2})\s*[-–]\s*(\d{1,2}:\d{2})/);
+  const service = {
+    source: "line_official_note",
+    raw_heading: "MMD Confirmation",
+    job_type: noteField(raw, "Job"),
+    model_label: noteField(raw, "Model"),
+    customer_name: noteField(raw, "Customer"),
+    date_label: noteField(raw, "Date"),
+    start_time: timeMatch ? timeMatch[1] : "",
+    end_time: timeMatch ? timeMatch[2] : "",
+    time_label: timeLabel,
+    location_name: noteField(raw, "Location"),
+    map_url: noteField(raw, "Google Maps") || noteField(raw, "Map URL"),
+    amount_thb: parseMoney(noteField(raw, "Amount")),
+    deposit_amount_thb: parseMoney(noteField(raw, "Deposit")),
+    balance_amount_thb: parseMoney(noteField(raw, "Balance")),
+    payment_ref: "",
+    session_id: "",
+    confidence: 0.9,
+  };
+
+  return [service];
+}
+
+function normalizeRow(row, sourceFile, index) {
+  const rawLabel = pick(row, ["label", "display_label", "rename", "name", "display name", "customer"]);
+  const lineId = pick(row, ["line_id", "line id", "handle", "username"]);
+  const lineUserId = pick(row, ["line_user_id", "line user id", "userId", "user_id"]);
+  const rawTags = pick(row, ["tags", "tag", "hashtags", "legacy_tags"]);
+  const note = pick(row, ["note", "notes", "memo", "description"]);
+  const tags = extractTags(rawLabel, rawTags, note);
+  const labelParts = parseLabel(rawLabel);
+  const canonical = parseCanonicalLineOfc({
+    nickname: rawLabel,
+    line_display_name: pick(row, ["line_display_name", "display_name", "display name"]),
+    line_user_id: lineUserId,
+    username: lineId || labelParts.parsed_username,
+    tags: rawTags,
+    note,
+  });
+  const memHints = tags
+    .filter((tag) => /^#mem/i.test(tag))
+    .map(parseMemTag)
+    .filter(Boolean)
+    .sort();
+  const serviceHistory = parseServiceNote(note);
+  const legacySvipHint = tags.some((tag) => /svip/i.test(tag)) || /svip/i.test(rawLabel);
+  const legacyVipHint = legacySvipHint || tags.some((tag) => /(^#vip$|-vip-)/i.test(tag)) || /\bvip\b/i.test(rawLabel);
+  const possiblePackageHint = legacySvipHint || legacyVipHint
+    ? "black_card_review"
+    : tags.some((tag) => /^lite$/i.test(tag))
+      ? "standard"
+      : "";
+
+  return {
+    source: "line_official_legacy",
+    source_file: path.basename(sourceFile),
+    source_row: row.__row || index + 1,
+    raw_display_label: rawLabel,
+    parsed_client_name: labelParts.parsed_client_name,
+    parsed_username: labelParts.parsed_username,
+    line_id: lineId || labelParts.parsed_username,
+    line_user_id: lineUserId,
+    legacy_tags: tags,
+    membership_start_hint: memHints[0] || "",
+    membership_latest_hint: memHints[memHints.length - 1] || "",
+    legacy_vip_hint: legacyVipHint,
+    legacy_svip_hint: legacySvipHint,
+    is_client_hint: tags.some((tag) => /^#client$/i.test(tag)),
+    is_purchased_hint: tags.some((tag) => /^#purchased$/i.test(tag)),
+    risk_discretion_hint: tags.some((tag) => /^#burn$/i.test(tag)),
+    opportunity_hint: tags.some((tag) => /^#potential$/i.test(tag)),
+    possible_package_hint: possiblePackageHint,
+    service_history: serviceHistory,
+    spend_total_verified: 0,
+    spend_total_unverified: serviceHistory.reduce((sum, item) => sum + Number(item.amount_thb || 0), 0),
+    points_estimated: 0,
+    points_verified: 0,
+    import_confidence: serviceHistory.length ? 0.78 : tags.length ? 0.4 : 0.2,
+    canonical_membership: canonical,
+    membership_status: canonical.membership_status,
+    membership_tier: canonical.membership_tier,
+    membership_package: canonical.membership_package,
+    member_since: canonical.member_since,
+    member_since_raw: canonical.member_since_raw,
+    has_purchased: canonical.has_purchased,
+    parse_confidence: canonical.parse_confidence,
+    parse_warnings: canonical.parse_warnings,
+    normalized_name: canonical.normalized_name,
+    username_candidate: canonical.username_candidate,
+    mmd_client_name_candidate: canonical.mmd_client_name_candidate,
+    recommended_actions: [
+      "create_internal_legacy_note",
+      lineUserId ? "upsert_client_review" : "needs_line_user_id",
+      serviceHistory.length ? "stage_service_history_review" : "preserve_identity_context",
+      "do_not_send_sigil_dashboard_card_yet",
+    ],
+    unknown_tags: tags.filter((tag) => {
+      return !/^#(client|purchased|vip|svip|burn|potential)$/i.test(tag)
+        && !/^#mem/i.test(tag)
+        && !/^-s?vip-$/i.test(tag)
+        && !/^lite$/i.test(tag);
+    }),
+    warnings: [
+      !lineUserId ? "line_user_id_missing" : "",
+      "session_id_missing",
+      "payment_ref_missing",
+      serviceHistory.length ? "payment_not_verified" : "",
+    ].filter(Boolean),
+  };
+}
+
+function main() {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    usage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const rows = readRows(filePath);
+  const normalized = rows.map((row, index) => normalizeRow(row, filePath, index));
+  process.stdout.write(`${JSON.stringify({ ok: true, count: normalized.length, records: normalized }, null, 2)}\n`);
+}
+
+if (require.main === module) main();
+
+// TODO: Future Airtable write phase should use explicit dry-run/apply modes,
+// idempotency keys, table-specific schema validation, and Per approval gates.
+
+module.exports = {
+  normalizeRow,
+  parseCsv,
+  readRows,
+};

--- a/scripts/line-official-legacy/patch-review-decisions.js
+++ b/scripts/line-official-legacy/patch-review-decisions.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const { AirtableClient } = require("./dry-run-import.js");
+
+const STAGING_TABLE = process.env.AIRTABLE_LINE_OFC_CLIENT_IMPORT_STAGING_TABLE_ID || "tbl1u0foFBvgFpT9G";
+const DECISION_SOURCE = "manual_review";
+const ALLOWED_DECISIONS = new Set([
+  "ignore",
+  "link_existing_client",
+  "create_new_client",
+  "needs_human",
+  "do_not_import",
+]);
+const ALLOWED_FIELDS = [
+  "decision",
+  "reviewed_by",
+  "reviewed_at",
+  "review_note",
+  "matched_client_id",
+  "decision_source",
+];
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function parseArgs(argv) {
+  const out = { apply: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--file") out.file = argv[index + 1];
+    if (arg === "--input") out.file = argv[index + 1];
+    if (arg === "--apply") out.apply = true;
+  }
+  return out;
+}
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = "";
+  let quoted = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    const next = text[index + 1];
+    if (quoted) {
+      if (char === '"' && next === '"') {
+        field += '"';
+        index += 1;
+      } else if (char === '"') quoted = false;
+      else field += char;
+      continue;
+    }
+    if (char === '"') quoted = true;
+    else if (char === ",") {
+      row.push(field);
+      field = "";
+    } else if (char === "\n") {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else if (char !== "\r") field += char;
+  }
+  if (field || row.length) {
+    row.push(field);
+    rows.push(row);
+  }
+  const headers = (rows.shift() || []).map(clean);
+  return rows
+    .filter((items) => items.some((item) => clean(item)))
+    .map((items) => Object.fromEntries(headers.map((header, index) => [header, items[index] || ""])));
+}
+
+function readDecisionFile(file) {
+  const text = fs.readFileSync(file, "utf8");
+  if (/\.csv$/i.test(file)) return parseCsv(text);
+  const parsed = JSON.parse(text);
+  if (Array.isArray(parsed)) return parsed;
+  if (Array.isArray(parsed.decisions)) return parsed.decisions;
+  throw new Error("decision_file_must_be_json_or_csv");
+}
+
+function encodeFormulaValue(value) {
+  return clean(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function normalizeDecision(input) {
+  const importId = clean(input.import_id);
+  const reviewDecision = clean(input.decision || input.review_decision);
+  if (!importId) throw new Error("missing_import_id");
+  if (!ALLOWED_DECISIONS.has(reviewDecision)) throw new Error(`invalid_review_decision:${importId}`);
+
+  const fields = {
+    decision: reviewDecision,
+    reviewed_by: clean(input.reviewed_by),
+    reviewed_at: clean(input.reviewed_at) || new Date().toISOString(),
+    review_note: clean(input.review_note),
+    matched_client_id: clean(input.matched_client_id),
+    decision_source: DECISION_SOURCE,
+  };
+
+  if (reviewDecision === "link_existing_client" && !fields.matched_client_id) {
+    throw new Error(`matched_client_id_required:${importId}`);
+  }
+
+  return { import_id: importId, fields };
+}
+
+function normalizeDecisions(items) {
+  const seen = new Set();
+  return items.map(normalizeDecision).map((item) => {
+    if (seen.has(item.import_id)) throw new Error(`duplicate_import_id:${item.import_id}`);
+    seen.add(item.import_id);
+    return item;
+  });
+}
+
+function chunks(items, size) {
+  const out = [];
+  for (let index = 0; index < items.length; index += size) out.push(items.slice(index, index + size));
+  return out;
+}
+
+async function buildPatchRecords(decisions, airtable) {
+  const records = [];
+  for (const decision of decisions) {
+    const found = await airtable.findOne(STAGING_TABLE, `{import_id}="${encodeFormulaValue(decision.import_id)}"`);
+    if (!found?.id) throw new Error(`staging_row_not_found:${decision.import_id}`);
+    records.push({ id: found.id, fields: decision.fields, import_id: decision.import_id });
+  }
+  return records;
+}
+
+async function patchReviewDecisions({ file, apply = false, airtable = new AirtableClient() }) {
+  if (!file) throw new Error("missing_file");
+  const decisions = normalizeDecisions(readDecisionFile(file));
+  const records = await buildPatchRecords(decisions, airtable);
+  const planned = records.map((record) => ({
+    table: STAGING_TABLE,
+    import_id: record.import_id,
+    record_id: record.id,
+    fields: Object.fromEntries(ALLOWED_FIELDS.map((field) => [field, record.fields[field]])),
+  }));
+
+  if (!apply) {
+    return {
+      ok: true,
+      mode: "line_ofc_review_decision_patch",
+      dry_run: true,
+      staging_table_only: true,
+      planned_count: planned.length,
+      planned,
+    };
+  }
+
+  const patched = [];
+  for (const group of chunks(records, 10)) {
+    const response = await airtable.request(STAGING_TABLE, {
+      method: "PATCH",
+      body: { records: group.map((record) => ({ id: record.id, fields: record.fields })) },
+    });
+    patched.push(...(response.records || []));
+  }
+
+  return {
+    ok: true,
+    mode: "line_ofc_review_decision_patch",
+    dry_run: false,
+    staging_table_only: true,
+    patched_count: patched.length,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.file) {
+    console.error("Usage: npm run line-ofc:patch-review-decisions -- --input decisions.json [--apply]");
+    process.exitCode = 1;
+    return;
+  }
+  const result = await patchReviewDecisions(args);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  ALLOWED_FIELDS,
+  DECISION_SOURCE,
+  parseArgs,
+  normalizeDecision,
+  normalizeDecisions,
+  patchReviewDecisions,
+};

--- a/scripts/line-official-legacy/review-decision-layer.test.js
+++ b/scripts/line-official-legacy/review-decision-layer.test.js
@@ -1,0 +1,176 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const { evaluateCommitGate } = require("./commit-gate.js");
+const {
+  ALLOWED_FIELDS,
+  normalizeDecision,
+  parseArgs,
+  patchReviewDecisions,
+} = require("./patch-review-decisions.js");
+
+function tempJson(payload) {
+  const file = path.join(os.tmpdir(), `line-ofc-decisions-${Date.now()}-${Math.random().toString(36).slice(2)}.json`);
+  fs.writeFileSync(file, `${JSON.stringify(payload, null, 2)}\n`);
+  return file;
+}
+
+test("review decision dry-run plans staging patches only", async () => {
+  const file = tempJson({
+    decisions: [
+      {
+        import_id: "line_ofc_console_review_1",
+        review_decision: "link_existing_client",
+        reviewed_by: "Per",
+        reviewed_at: "2026-06-02T00:00:00.000Z",
+        review_note: "matched manually",
+        matched_client_id: "recClient1",
+      },
+    ],
+  });
+  const calls = [];
+  const airtable = {
+    findOne: async (table, formula) => {
+      calls.push({ action: "findOne", table, formula });
+      return { id: "recStage1", fields: { import_id: "line_ofc_console_review_1" } };
+    },
+    requestBatchWithFieldFallback: async (table, init) => {
+      calls.push({ action: "requestBatchWithFieldFallback", table, init });
+      return { records: [] };
+    },
+  };
+
+  const result = await patchReviewDecisions({ file, airtable });
+  assert.equal(result.dry_run, true);
+  assert.equal(result.staging_table_only, true);
+  assert.equal(result.planned_count, 1);
+  assert.equal(result.planned[0].table, "tbl1u0foFBvgFpT9G");
+  assert.equal(result.planned[0].fields.decision_source, "manual_review");
+  assert.equal(result.planned[0].fields.decision, "link_existing_client");
+  assert.equal(Object.prototype.hasOwnProperty.call(result.planned[0].fields, "review_decision"), false);
+  assert.equal(calls.every((call) => call.table === "tbl1u0foFBvgFpT9G"), true);
+  assert.equal(calls.some((call) => call.action === "requestBatchWithFieldFallback"), false);
+});
+
+test("review decision apply patches only staging decision fields", async () => {
+  const file = tempJson([
+    {
+      import_id: "line_ofc_console_review_2",
+      review_decision: "needs_human",
+      reviewed_by: "Per",
+      review_note: "ambiguous",
+    },
+  ]);
+  const calls = [];
+  const airtable = {
+    findOne: async (table, formula) => {
+      calls.push({ action: "findOne", table, formula });
+      return { id: "recStage2", fields: { import_id: "line_ofc_console_review_2" } };
+    },
+    request: async (table, init) => {
+      calls.push({ action: "request", table, init });
+      return { records: [{ id: "recStage2", fields: init.body.records[0].fields }] };
+    },
+  };
+
+  const result = await patchReviewDecisions({ file, apply: true, airtable });
+  const patchCall = calls.find((call) => call.action === "request");
+  assert.equal(result.dry_run, false);
+  assert.equal(result.patched_count, 1);
+  assert.equal(patchCall.table, "tbl1u0foFBvgFpT9G");
+  assert.equal(patchCall.init.method, "PATCH");
+  assert.deepEqual(Object.keys(patchCall.init.body.records[0].fields).sort(), [
+    "decision",
+    "decision_source",
+    "matched_client_id",
+    "review_note",
+    "reviewed_at",
+    "reviewed_by",
+  ]);
+});
+
+test("review decision apply fails closed when Airtable schema fields are missing", async () => {
+  const file = tempJson([
+    {
+      import_id: "line_ofc_console_review_schema",
+      decision: "needs_human",
+      reviewed_by: "Per",
+    },
+  ]);
+  const calls = [];
+  const airtable = {
+    findOne: async (table, formula) => {
+      calls.push({ action: "findOne", table, formula });
+      return { id: "recStageSchema", fields: { import_id: "line_ofc_console_review_schema" } };
+    },
+    request: async (table, init) => {
+      calls.push({ action: "request", table, init });
+      const error = new Error("airtable_request_failed:422");
+      error.detail = { error: { type: "UNKNOWN_FIELD_NAME", message: 'Unknown field name: "decision"' } };
+      throw error;
+    },
+  };
+
+  await assert.rejects(
+    () => patchReviewDecisions({ file, apply: true, airtable }),
+    /airtable_request_failed:422/,
+  );
+  assert.equal(calls.filter((call) => call.action === "request").length, 1);
+});
+
+test("review decision layer accepts requested input alias and decision field", () => {
+  assert.deepEqual(ALLOWED_FIELDS, [
+    "decision",
+    "reviewed_by",
+    "reviewed_at",
+    "review_note",
+    "matched_client_id",
+    "decision_source",
+  ]);
+  assert.deepEqual(parseArgs(["--input", "decisions.json"]), { apply: false, file: "decisions.json" });
+  assert.deepEqual(parseArgs(["--file", "decisions.json"]), { apply: false, file: "decisions.json" });
+  const normalized = normalizeDecision({
+    import_id: "line_ofc_console_review_3",
+    decision: "do_not_import",
+    reviewed_by: "Per",
+  });
+  assert.equal(normalized.fields.decision, "do_not_import");
+  assert.equal(Object.prototype.hasOwnProperty.call(normalized.fields, "review_decision"), false);
+});
+
+test("commit refuses when unsafe_to_commit is greater than zero", () => {
+  const result = evaluateCommitGate([
+    {
+      id: "recUnsafe",
+      fields: {
+        import_id: "line_ofc_console_unsafe",
+        import_batch_id: "batch_commit",
+        review_status: "staging_only",
+        match_type: "no_match",
+        membership_parse_json: JSON.stringify({ membership_status: "none" }),
+        proposed_entitlement_json: JSON.stringify({ source: "line_ofc", review_required: true }),
+      },
+    },
+  ]);
+  assert.equal(result.ok, false);
+  assert.equal(result.hard_gate.unsafe_to_commit, 1);
+  assert.match(result.message, /Commit refused/);
+});
+
+test("review and dry-run scripts contain no Member Entitlements write path", () => {
+  const scriptDir = __dirname;
+  const files = [
+    "dry-run-import.js",
+    "review-page.js",
+    "patch-review-decisions.js",
+    "commit-gate.js",
+  ];
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(scriptDir, file), "utf8");
+    assert.equal(content.includes("tblNImdF9PKAxhXGi"), false, file);
+    assert.equal(/Member Entitlements[^\\n]*(PATCH|POST|DELETE)/i.test(content), false, file);
+  }
+});

--- a/scripts/line-official-legacy/review-page.js
+++ b/scripts/line-official-legacy/review-page.js
@@ -1,0 +1,614 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { AirtableClient } = require("./dry-run-import.js");
+
+const STAGING_TABLE = process.env.AIRTABLE_LINE_OFC_CLIENT_IMPORT_STAGING_TABLE_ID || "tbl1u0foFBvgFpT9G";
+const OUT_DIR = path.join(process.cwd(), "webflow/internal/line-ofc-review");
+const DATA_FILE = "review-data.redacted.json";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--batch-id") out.batchId = argv[index + 1];
+  }
+  return out;
+}
+
+function selectName(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) return clean(value.name || value.value || value.id);
+  return clean(value);
+}
+
+function safeJson(value, fallback = {}) {
+  try {
+    if (!value) return fallback;
+    if (typeof value === "object") return value;
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function scrubText(value) {
+  return clean(value)
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[redacted-email]")
+    .replace(/(?:\+?\d[\d\s().-]{7,}\d)/g, (match) => {
+      const digits = match.replace(/\D/g, "");
+      return match.trim().startsWith("+") || digits.length >= 9 ? "[redacted-phone]" : match;
+    });
+}
+
+function redactObject(value, key = "") {
+  const lowerKey = key.toLowerCase();
+  if (value == null) return value;
+  if (lowerKey.includes("email")) return clean(value) ? "[redacted-email]" : "";
+  if (lowerKey.includes("phone") || lowerKey.includes("tel")) return clean(value) ? "[redacted-phone]" : "";
+  if (lowerKey.includes("line_user_id") || lowerKey === "line_id" || lowerKey.includes("payload")) return clean(value) ? "[redacted]" : "";
+  if (Array.isArray(value)) return value.map((item) => redactObject(item, key));
+  if (typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([childKey, childValue]) => [childKey, redactObject(childValue, childKey)]));
+  }
+  return scrubText(value);
+}
+
+function fieldsOf(record) {
+  return record.fields || record.cellValuesByFieldId || record;
+}
+
+function field(fields, name, fallback = "") {
+  return fields[name] == null ? fallback : fields[name];
+}
+
+function arrayFrom(value) {
+  if (Array.isArray(value)) return value.map(clean).filter(Boolean);
+  if (!clean(value)) return [];
+  return clean(value).split(/[, ]+/).map(clean).filter(Boolean);
+}
+
+function numberValue(value) {
+  const n = Number(value || 0);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function normalizeReviewRecord(record) {
+  const fields = fieldsOf(record);
+  const membership = safeJson(field(fields, "membership_parse_json"), {});
+  const proposed = safeJson(field(fields, "proposed_entitlement_json"), {});
+  const raw = redactObject(safeJson(field(fields, "raw_row_json"), {}));
+  const parsedStatus = selectName(field(fields, "parsed_membership_status")) || clean(membership.membership_status) || "none";
+  const parsedClientLevel = selectName(field(fields, "parsed_client_level")) || clean(membership.client_level) || "unknown";
+  const parsedTier = selectName(field(fields, "parsed_membership_tier")) || clean(membership.membership_tier) || "none";
+  const parsedPackage = selectName(field(fields, "parsed_membership_package")) || clean(membership.membership_package) || "none";
+  const matchConfidence = numberValue(field(fields, "match_confidence"));
+  let matchType = selectName(field(fields, "match_type"));
+  if (!matchType) {
+    if (matchConfidence === 0) matchType = "no_match";
+    else if (matchConfidence === 0.5) matchType = "multiple_candidates";
+    else if (matchConfidence === 0.35) matchType = "fuzzy_name";
+    else if (matchConfidence >= 0.94) matchType = "exact_match";
+    else matchType = "unknown";
+  }
+  let reviewStatus = selectName(field(fields, "review_status"));
+  if (!reviewStatus) {
+    if (matchType === "no_match") reviewStatus = "staging_only";
+    else if (matchType === "multiple_candidates" || matchType === "fuzzy_name" || parsedStatus === "review_required") reviewStatus = "review_required";
+    else if (/^exact_/.test(matchType)) reviewStatus = "ready_to_review";
+    else reviewStatus = "unknown";
+  }
+  const parseWarnings = arrayFrom(membership.parse_warnings || field(fields, "points_parse_warnings"));
+  const allMemberTokens = arrayFrom(membership.all_member_tokens || membership.detected_tags).filter((token) => /^#mem/i.test(token));
+  const multipleMatch = matchType === "multiple_candidates";
+  const noMatch = matchType === "no_match" || reviewStatus === "staging_only";
+  const reviewRequired = reviewStatus === "review_required" || parsedStatus === "review_required";
+  const premiumHighAccess = ["premium", "vip", "blackcard", "svip"].includes(parsedClientLevel)
+    || ["premium", "vip", "svip", "blackcard"].includes(parsedTier)
+    || ["premium", "vip", "svip", "blackcard"].includes(parsedPackage);
+  const memberEvidence = parsedStatus === "member" || premiumHighAccess;
+  const potentiallyReady = reviewStatus === "ready_to_review" && /^exact_/.test(matchType);
+
+  let safetyState = "Not executable on this page";
+  if (multipleMatch) safetyState = "Choose client manually later";
+  else if (reviewRequired) safetyState = "Blocked until human review";
+  else if (noMatch) safetyState = "Staging only";
+
+  return {
+    record_id: record.id || "",
+    import_id: clean(field(fields, "import_id")),
+    import_batch_id: clean(field(fields, "import_batch_id")),
+    review_status: reviewStatus || "unknown",
+    match_type: matchType || "unknown",
+    match_confidence: matchConfidence,
+    parse_confidence: numberValue(field(fields, "parse_confidence")),
+    line_display_name: scrubText(field(fields, "line_display_name")),
+    line_renamed_name: scrubText(field(fields, "line_renamed_name")),
+    line_tags_raw: scrubText(field(fields, "line_tags_raw")),
+    parsed_client_level: parsedClientLevel,
+    client_level_raw: scrubText(membership.client_level_raw || ""),
+    client_level_tokens: redactObject(membership.client_level_tokens || []),
+    parsed_membership_status: parsedStatus,
+    parsed_membership_tier: parsedTier,
+    parsed_membership_package: parsedPackage,
+    parsed_member_since: scrubText(field(fields, "parsed_member_since") || membership.member_since),
+    parsed_member_since_raw: scrubText(field(fields, "parsed_member_since_raw") || membership.member_since_raw),
+    has_purchased: Boolean(field(fields, "parsed_has_purchased") || membership.has_purchased),
+    chosen_member_since_token: scrubText(membership.chosen_member_since_token || ""),
+    all_member_tokens: allMemberTokens.map(scrubText),
+    proposed_entitlement_summary: {
+      source: scrubText(proposed.source || "line_ofc"),
+      client_level: scrubText(proposed.client_level || parsedClientLevel),
+      membership_status: scrubText(proposed.membership_status || parsedStatus),
+      membership_tier: scrubText(proposed.membership_tier || parsedTier),
+      membership_package: scrubText(proposed.membership_package || parsedPackage),
+      member_since: scrubText(proposed.member_since || membership.member_since || ""),
+      member_since_raw: scrubText(proposed.member_since_raw || membership.member_since_raw || ""),
+      has_purchased: Boolean(proposed.has_purchased || membership.has_purchased),
+      review_required: Boolean(proposed.review_required || reviewRequired),
+    },
+    parse_warnings: parseWarnings.map(scrubText),
+    raw_debug_redacted: raw,
+    queue_flags: {
+      review_required: reviewRequired,
+      multiple_match: multipleMatch && reviewStatus === "review_required",
+      multiple_match_review: multipleMatch && reviewStatus === "review_required",
+      unknown_tier: parsedTier === "unknown" || parsedClientLevel === "unknown" || parsedPackage === "unknown",
+      member_vip_premium_evidence: memberEvidence,
+      premium_vip_svip_blackcard: premiumHighAccess,
+      no_match_staging: noMatch,
+      no_match_staging_only: noMatch,
+      ready_after_manual_review: potentiallyReady,
+      unsafe_to_commit: true,
+      all_staging: true,
+    },
+    safety_state: safetyState,
+    committable: false,
+    unsafe_to_commit: true,
+  };
+}
+
+function countBy(records, fn) {
+  return records.reduce((acc, record) => {
+    const key = fn(record) || "unknown";
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+function countDuplicateImportIds(rows) {
+  const counts = countBy(rows, (row) => row.import_id);
+  return Object.values(counts).filter((count) => count > 1).length;
+}
+
+function buildReviewData(records, batchId) {
+  const rows = records.map(normalizeReviewRecord);
+  const duplicateImportIdCount = countDuplicateImportIds(rows);
+  const summary = {
+    batch_id: batchId,
+    total_rows: rows.length,
+    review_required_count: rows.filter((row) => row.queue_flags.review_required).length,
+    multiple_match_count: rows.filter((row) => row.queue_flags.multiple_match).length,
+    unknown_tier_count: rows.filter((row) => row.queue_flags.unknown_tier).length,
+    member_vip_premium_count: rows.filter((row) => row.queue_flags.member_vip_premium_evidence).length,
+    no_match_count: rows.filter((row) => row.queue_flags.no_match_staging).length,
+    unsafe_to_commit_count: rows.filter((row) => row.unsafe_to_commit).length,
+    committable_count: rows.filter((row) => row.committable).length,
+    duplicate_import_id_count: duplicateImportIdCount,
+    ready_after_manual_review_count: rows.filter((row) => row.queue_flags.ready_after_manual_review).length,
+    counts: {
+      review_status: countBy(rows, (row) => row.review_status),
+      match_type: countBy(rows, (row) => row.match_type),
+      membership_status: countBy(rows, (row) => row.parsed_membership_status),
+      client_level: countBy(rows, (row) => row.parsed_client_level),
+      tier: countBy(rows, (row) => row.parsed_membership_tier),
+      package: countBy(rows, (row) => row.parsed_membership_package),
+    },
+  };
+  return {
+    generated_at: new Date().toISOString(),
+    guardrails: [
+      "Review only",
+      "No Clients patch",
+      "No Member Entitlements write",
+      "LINE OFC is membership source of truth",
+      "Gmail paused",
+    ],
+    summary,
+    rows,
+  };
+}
+
+function jsonForHtml(data) {
+  return JSON.stringify(data).replace(/</g, "\\u003c").replace(/>/g, "\\u003e").replace(/&/g, "\\u0026");
+}
+
+function renderHtml(data) {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LINE OFC Review - ${data.summary.batch_id}</title>
+  <link rel="stylesheet" href="./line-ofc-review.css">
+</head>
+<body>
+  <main class="line-ofc-review-page" data-line-ofc-review-root>
+    <script id="line-ofc-review-data" type="application/json">${jsonForHtml(data)}</script>
+  </main>
+  <script src="./line-ofc-review.js"></script>
+</body>
+</html>
+`;
+}
+
+function renderCss() {
+  return `.line-ofc-review-page{color-scheme:dark;min-height:100vh;background:#080807;color:#f5f0e6;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;letter-spacing:0}.line-ofc-review-shell{max-width:1180px;margin:0 auto;padding:28px 18px 42px}.line-ofc-review-top{display:flex;align-items:flex-start;justify-content:space-between;gap:18px;border-bottom:1px solid rgba(212,175,55,.28);padding-bottom:18px}.line-ofc-review-kicker{color:#d4af37;text-transform:uppercase;font-size:12px;font-weight:700}.line-ofc-review-title{font-size:clamp(26px,4vw,44px);line-height:1.05;margin:6px 0 8px}.line-ofc-review-subtitle{color:#b9b0a1;margin:0;max-width:760px}.line-ofc-review-summary{display:grid;grid-template-columns:repeat(7,minmax(0,1fr));gap:10px;margin:20px 0}.line-ofc-review-stat{border:1px solid rgba(212,175,55,.22);background:#11100e;border-radius:8px;padding:12px}.line-ofc-review-stat strong{display:block;font-size:24px;color:#fff}.line-ofc-review-stat span{font-size:12px;color:#b9b0a1}.line-ofc-review-actions{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}.line-ofc-review-actions button{border:1px solid rgba(212,175,55,.36);background:rgba(212,175,55,.12);color:#f5d36d;border-radius:8px;padding:10px 12px;font:inherit;font-weight:800;cursor:pointer}.line-ofc-review-guardrails{display:flex;flex-wrap:wrap;gap:8px;margin:18px 0}.line-ofc-review-chip{border:1px solid rgba(212,175,55,.34);color:#f5d36d;background:rgba(212,175,55,.08);border-radius:999px;padding:7px 10px;font-size:12px;font-weight:700}.line-ofc-review-controls{display:grid;grid-template-columns:1fr repeat(4,minmax(120px,170px));gap:10px;margin:18px 0}.line-ofc-review-input,.line-ofc-review-select{background:#12110f;color:#fff;border:1px solid rgba(255,255,255,.16);border-radius:8px;padding:10px 12px;font:inherit;min-width:0}.line-ofc-review-tabs{display:flex;gap:8px;overflow:auto;padding:3px 0 12px}.line-ofc-review-tab{border:1px solid rgba(255,255,255,.14);background:#13120f;color:#cfc7b8;border-radius:8px;padding:9px 11px;white-space:nowrap;cursor:pointer}.line-ofc-review-tab.is-active{border-color:#d4af37;color:#fff;background:rgba(212,175,55,.12)}.line-ofc-review-list{display:grid;gap:12px}.line-ofc-review-card{border:1px solid rgba(255,255,255,.12);background:#10100e;border-radius:8px;padding:14px}.line-ofc-review-card-head{display:flex;justify-content:space-between;gap:14px;align-items:flex-start}.line-ofc-review-name{font-size:18px;font-weight:800;color:#fff}.line-ofc-review-muted{color:#aaa193;font-size:13px}.line-ofc-review-badges{display:flex;gap:6px;flex-wrap:wrap;margin:10px 0}.line-ofc-review-badge{font-size:12px;border-radius:999px;background:#1c1a16;color:#e7ddc7;border:1px solid rgba(255,255,255,.12);padding:5px 8px}.line-ofc-review-badge-blocked{background:rgba(142,38,38,.18);border-color:rgba(255,100,100,.3);color:#ffb5a8}.line-ofc-review-badge-ready{background:rgba(212,175,55,.12);border-color:rgba(212,175,55,.3);color:#f5d36d}.line-ofc-review-decision{display:grid;grid-template-columns:minmax(150px,190px) minmax(130px,1fr) minmax(150px,1fr) minmax(240px,2fr);gap:9px;margin:12px 0;padding:12px;border:1px solid rgba(212,175,55,.2);border-radius:8px;background:#12110f}.line-ofc-review-decision label{display:grid;gap:5px;color:#958b7b;font-size:11px;text-transform:uppercase}.line-ofc-review-decision input,.line-ofc-review-decision select,.line-ofc-review-decision textarea{width:100%;border:1px solid rgba(255,255,255,.14);border-radius:8px;background:#080807;color:#fff;padding:9px 10px;font:inherit;text-transform:none}.line-ofc-review-decision .line-ofc-review-muted{grid-column:1/-1}.line-ofc-review-grid{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:9px;margin:12px 0}.line-ofc-review-field{background:#15130f;border-radius:8px;padding:9px;min-width:0}.line-ofc-review-field span{display:block;color:#958b7b;font-size:11px;text-transform:uppercase}.line-ofc-review-field b{display:block;overflow-wrap:anywhere;font-size:13px;margin-top:3px}.line-ofc-review-tags{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;color:#dec777;overflow-wrap:anywhere}.line-ofc-review-details{margin-top:10px;border-top:1px solid rgba(255,255,255,.09);padding-top:10px}.line-ofc-review-details summary{cursor:pointer;color:#d4af37;font-weight:700}.line-ofc-review-pre{white-space:pre-wrap;overflow:auto;background:#070707;border:1px solid rgba(255,255,255,.1);border-radius:8px;padding:10px;color:#d7d0c4;font-size:12px}.line-ofc-review-empty{border:1px dashed rgba(255,255,255,.2);border-radius:8px;padding:22px;color:#b9b0a1;text-align:center}.line-ofc-review-count{color:#b9b0a1;font-size:13px;margin:6px 0 12px}@media(max-width:900px){.line-ofc-review-summary{grid-template-columns:repeat(2,minmax(0,1fr))}.line-ofc-review-controls{grid-template-columns:1fr 1fr}.line-ofc-review-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.line-ofc-review-decision{grid-template-columns:1fr 1fr}}@media(max-width:560px){.line-ofc-review-shell{padding:20px 12px 30px}.line-ofc-review-top{display:block}.line-ofc-review-actions{justify-content:flex-start;margin-top:14px}.line-ofc-review-summary,.line-ofc-review-controls,.line-ofc-review-grid,.line-ofc-review-decision{grid-template-columns:1fr}.line-ofc-review-card-head{display:block}}`;
+}
+
+function renderJs() {
+  return `(() => {
+  const DECISIONS = ["", "ignore", "link_existing_client", "create_new_client", "needs_human", "do_not_import"];
+  const DECISION_SOURCE = "manual_review";
+  const root = document.querySelector("[data-line-ofc-review-root]");
+  const dataNode = document.getElementById("line-ofc-review-data");
+  if (!root || !dataNode) return;
+
+  const data = JSON.parse(dataNode.textContent);
+  const rows = data.rows.slice();
+  const summary = data.summary;
+  const storageKey = "line-ofc-review-decisions:" + summary.batch_id;
+  let activeQueue = "review_required";
+  let decisions = loadDecisions();
+
+  function text(value) {
+    return String(value == null ? "" : value);
+  }
+
+  function escapeHtml(value) {
+    return text(value).replace(/[&<>"']/g, (char) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    })[char]);
+  }
+
+  function percent(value) {
+    return Math.round(Number(value || 0) * 100) + "%";
+  }
+
+  function option(value, label) {
+    const el = document.createElement("option");
+    el.value = value;
+    el.textContent = label || value;
+    return el;
+  }
+
+  function unique(items, mapper) {
+    return Array.from(new Set(items.map(mapper).filter(Boolean))).sort();
+  }
+
+  function badge(value, className) {
+    return '<span class="line-ofc-review-badge ' + (className || "") + '">' + escapeHtml(value) + '</span>';
+  }
+
+  function stat(value, label) {
+    return '<div class="line-ofc-review-stat"><strong>' + escapeHtml(value) + '</strong><span>' + escapeHtml(label) + '</span></div>';
+  }
+
+  function localDecision(importId) {
+    return decisions[importId] || {
+      import_id: importId,
+      review_decision: "",
+      reviewed_by: "",
+      reviewed_at: "",
+      review_note: "",
+      matched_client_id: "",
+      decision_source: DECISION_SOURCE,
+    };
+  }
+
+  function normalizeDecision(row, patch) {
+    const previous = localDecision(row.import_id);
+    const next = {
+      import_id: row.import_id,
+      review_decision: text(patch.review_decision ?? previous.review_decision),
+      reviewed_by: text(patch.reviewed_by ?? previous.reviewed_by),
+      reviewed_at: text(patch.reviewed_at ?? previous.reviewed_at),
+      review_note: text(patch.review_note ?? previous.review_note),
+      matched_client_id: text(patch.matched_client_id ?? previous.matched_client_id),
+      decision_source: DECISION_SOURCE,
+    };
+    if (next.review_decision && !next.reviewed_at) next.reviewed_at = new Date().toISOString();
+    return next;
+  }
+
+  function saveDecision(row, patch) {
+    decisions[row.import_id] = normalizeDecision(row, patch);
+    localStorage.setItem(storageKey, JSON.stringify(decisions));
+    renderCount();
+  }
+
+  function loadDecisions() {
+    try {
+      const parsed = JSON.parse(localStorage.getItem(storageKey) || "{}");
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  function exportableDecisions() {
+    return Object.values(decisions)
+      .filter((item) => item && item.import_id && item.review_decision)
+      .map((item) => ({
+        import_id: item.import_id,
+        decision: item.review_decision,
+        reviewed_by: item.reviewed_by,
+        reviewed_at: item.reviewed_at,
+        review_note: item.review_note,
+        matched_client_id: item.matched_client_id,
+        decision_source: DECISION_SOURCE,
+      }));
+  }
+
+  function download(name, content, type) {
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = name;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  function csvEscape(value) {
+    const raw = text(value);
+    return /[",\\n]/.test(raw) ? '"' + raw.replace(/"/g, '""') + '"' : raw;
+  }
+
+  function exportJson() {
+    const payload = {
+      batch_id: summary.batch_id,
+      exported_at: new Date().toISOString(),
+      decision_source: DECISION_SOURCE,
+      writes: "local_export_only",
+      decisions: exportableDecisions(),
+    };
+    download(summary.batch_id + "-manual-review-decisions.json", JSON.stringify(payload, null, 2) + "\\n", "application/json");
+  }
+
+  function exportCsv() {
+    const headers = ["import_id", "decision", "reviewed_by", "reviewed_at", "review_note", "matched_client_id", "decision_source"];
+    const lines = [headers.join(",")].concat(exportableDecisions().map((item) => headers.map((key) => csvEscape(item[key])).join(",")));
+    download(summary.batch_id + "-manual-review-decisions.csv", lines.join("\\n") + "\\n", "text/csv");
+  }
+
+  function card(row) {
+    const safety = row.safety_state || "Review only";
+    const safetyClass = /Blocked|Choose|Staging/.test(safety) ? "line-ofc-review-badge-blocked" : "line-ofc-review-badge-ready";
+    const decision = localDecision(row.import_id);
+    const decisionOptions = DECISIONS.map((item) => '<option value="' + escapeHtml(item) + '"' + (item === decision.review_decision ? " selected" : "") + ">" + escapeHtml(item || "Choose decision") + "</option>").join("");
+    return '<article class="line-ofc-review-card" data-import-id="' + escapeHtml(row.import_id) + '">'
+      + '<div class="line-ofc-review-card-head"><div><div class="line-ofc-review-name">' + escapeHtml(row.line_display_name || row.line_renamed_name || "Unnamed LINE row") + '</div><div class="line-ofc-review-muted">Rename: ' + escapeHtml(row.line_renamed_name || "") + '</div><div class="line-ofc-review-muted">Import: ' + escapeHtml(row.import_id) + '</div></div><div>' + badge(safety, safetyClass) + '</div></div>'
+      + '<div class="line-ofc-review-badges">' + [row.review_status, row.match_type, row.parsed_client_level, row.parsed_membership_status, row.parsed_membership_tier, row.parsed_membership_package].map((item) => badge(item)).join("") + '</div>'
+      + '<div class="line-ofc-review-decision"><label><span>Decision</span><select data-decision-field="review_decision">' + decisionOptions + '</select></label><label><span>Reviewed by</span><input data-decision-field="reviewed_by" value="' + escapeHtml(decision.reviewed_by) + '" placeholder="reviewer name"></label><label><span>Matched client id</span><input data-decision-field="matched_client_id" value="' + escapeHtml(decision.matched_client_id) + '" placeholder="rec..."></label><label><span>Review note</span><textarea data-decision-field="review_note" rows="2" placeholder="local note">' + escapeHtml(decision.review_note) + '</textarea></label><div class="line-ofc-review-muted">reviewed_at: ' + escapeHtml(decision.reviewed_at || "set when decision is chosen") + ' · decision_source: manual_review</div></div>'
+      + '<div class="line-ofc-review-grid">' + [["Client level", row.parsed_client_level], ["Status", row.parsed_membership_status], ["Tier", row.parsed_membership_tier], ["Package", row.parsed_membership_package], ["Member since", row.parsed_member_since], ["Since raw", row.parsed_member_since_raw], ["Purchased", row.has_purchased ? "yes" : "no"], ["Review", row.review_status], ["Match", row.match_type], ["Match conf", percent(row.match_confidence)], ["Parse conf", percent(row.parse_confidence)], ["Chosen member evidence", row.chosen_member_since_token], ["Member evidence list", (row.all_member_tokens || []).join(", ")]].map((pair) => '<div class="line-ofc-review-field"><span>' + escapeHtml(pair[0]) + '</span><b>' + escapeHtml(pair[1] || "") + '</b></div>').join("") + '</div>'
+      + '<div class="line-ofc-review-field"><span>LINE tags raw</span><b class="line-ofc-review-tags">' + escapeHtml(row.line_tags_raw) + '</b></div>'
+      + '<div class="line-ofc-review-field"><span>Proposed entitlement summary</span><b>' + escapeHtml(JSON.stringify(row.proposed_entitlement_summary)) + '</b></div>'
+      + '<div class="line-ofc-review-badges">' + (row.parse_warnings || []).map((item) => badge(item, "line-ofc-review-badge-blocked")).join("") + '</div>'
+      + '<details class="line-ofc-review-details"><summary>raw/debug redacted</summary><pre class="line-ofc-review-pre">' + escapeHtml(JSON.stringify(row.raw_debug_redacted, null, 2)) + '</pre></details></article>';
+  }
+
+  root.innerHTML = '<div class="line-ofc-review-shell"><section class="line-ofc-review-top"><div><div class="line-ofc-review-kicker">MMD / SIGIL internal</div><h1 class="line-ofc-review-title">LINE OFC Review</h1><p class="line-ofc-review-subtitle">Batch ' + escapeHtml(summary.batch_id) + ' · review-only human decision layer · no commit action on this page</p></div><div class="line-ofc-review-actions"><button type="button" data-export-json>Export JSON</button><button type="button" data-export-csv>Export CSV</button></div></section><section class="line-ofc-review-summary">' + stat(summary.total_rows, "Total rows") + stat(summary.review_required_count, "Review required") + stat(summary.multiple_match_count, "Multiple match") + stat(summary.member_vip_premium_count, "Member / VIP / Premium") + stat(summary.no_match_count, "No match") + stat(summary.unsafe_to_commit_count, "Unsafe to commit") + '</section><section class="line-ofc-review-guardrails">' + data.guardrails.map((item) => '<span class="line-ofc-review-chip">' + escapeHtml(item) + '</span>').join("") + '</section><nav class="line-ofc-review-tabs"></nav><section class="line-ofc-review-controls"><input class="line-ofc-review-input" data-filter="search" placeholder="Search display, rename, import id"><select class="line-ofc-review-select" data-filter="status"></select><select class="line-ofc-review-select" data-filter="tier"></select><select class="line-ofc-review-select" data-filter="package"></select><select class="line-ofc-review-select" data-filter="match"></select></section><div class="line-ofc-review-count"></div><section class="line-ofc-review-list"></section></div>';
+
+  const tabs = root.querySelector(".line-ofc-review-tabs");
+  const list = root.querySelector(".line-ofc-review-list");
+  const count = root.querySelector(".line-ofc-review-count");
+  const filters = {
+    status: root.querySelector('[data-filter="status"]'),
+    tier: root.querySelector('[data-filter="tier"]'),
+    package: root.querySelector('[data-filter="package"]'),
+    match: root.querySelector('[data-filter="match"]'),
+    search: root.querySelector('[data-filter="search"]'),
+  };
+  const queues = {
+    review_required: "Review Required",
+    multiple_match_review: "Multiple Match",
+    member_vip_premium_evidence: "Member / VIP / Premium Evidence",
+    no_match_staging_only: "No Match Staging",
+    ready_after_manual_review: "Ready After Manual Review",
+    all_staging: "All Staging",
+  };
+
+  Object.entries(queues).forEach(([key, label]) => {
+    const button = document.createElement("button");
+    button.className = "line-ofc-review-tab";
+    button.type = "button";
+    button.dataset.queue = key;
+    button.textContent = label;
+    button.addEventListener("click", () => {
+      activeQueue = key;
+      renderRows();
+    });
+    tabs.appendChild(button);
+  });
+
+  function fillSelect(select, label, mapper) {
+    select.appendChild(option("", label));
+    unique(rows, mapper).forEach((item) => select.appendChild(option(item, item)));
+  }
+  fillSelect(filters.status, "All statuses", (row) => row.review_status);
+  fillSelect(filters.tier, "All tiers", (row) => row.parsed_membership_tier);
+  fillSelect(filters.package, "All packages", (row) => row.parsed_membership_package);
+  fillSelect(filters.match, "All match types", (row) => row.match_type);
+  Object.values(filters).forEach((item) => {
+    item.addEventListener("input", renderRows);
+    item.addEventListener("change", renderRows);
+  });
+  root.querySelector("[data-export-json]").addEventListener("click", exportJson);
+  root.querySelector("[data-export-csv]").addEventListener("click", exportCsv);
+
+  function visibleRows() {
+    const search = filters.search.value.toLowerCase();
+    return rows.filter((row) => {
+      const queueOk = !activeQueue || activeQueue === "all_staging" || (row.queue_flags && row.queue_flags[activeQueue]);
+      const statusOk = !filters.status.value || row.review_status === filters.status.value;
+      const tierOk = !filters.tier.value || row.parsed_membership_tier === filters.tier.value;
+      const packageOk = !filters.package.value || row.parsed_membership_package === filters.package.value;
+      const matchOk = !filters.match.value || row.match_type === filters.match.value;
+      const searchOk = !search || [row.line_display_name, row.line_renamed_name, row.import_id].join(" ").toLowerCase().includes(search);
+      return queueOk && statusOk && tierOk && packageOk && matchOk && searchOk;
+    });
+  }
+
+  function renderCount() {
+    const decisionCount = exportableDecisions().length;
+    count.textContent = visibleRows().length + " rows shown · " + decisionCount + " local decisions ready to export";
+  }
+
+  function bindDecisionControls() {
+    root.querySelectorAll("[data-import-id]").forEach((cardNode) => {
+      const row = rows.find((item) => item.import_id === cardNode.dataset.importId);
+      if (!row) return;
+      cardNode.querySelectorAll("[data-decision-field]").forEach((field) => {
+        field.addEventListener("change", () => saveDecision(row, { [field.dataset.decisionField]: field.value }));
+        field.addEventListener("input", () => {
+          if (field.tagName === "TEXTAREA" || field.type === "text") saveDecision(row, { [field.dataset.decisionField]: field.value });
+        });
+      });
+    });
+  }
+
+  function renderRows() {
+    Array.from(tabs.children).forEach((item) => item.classList.toggle("is-active", item.dataset.queue === activeQueue));
+    const shown = visibleRows();
+    list.innerHTML = shown.length ? shown.map(card).join("") : '<div class="line-ofc-review-empty">No rows match these filters.</div>';
+    bindDecisionControls();
+    renderCount();
+  }
+
+  renderRows();
+})();`;
+}
+
+function renderWebflowEmbed(data) {
+  return `<section class="line-ofc-review-page" data-line-ofc-review-root>
+  <script id="line-ofc-review-data" type="application/json">${jsonForHtml(data)}</script>
+</section>`;
+}
+
+function renderControlRoomIntegration(data) {
+  return `# LINE OFC Review - Control Room Integration
+
+## Recommendation
+
+- Add route/page: \`/control-room/line-ofc-review\`
+- Link label: \`LINE OFC Review\`
+- Access: internal/admin only
+- Mode: review-only
+- No commit action on this page
+- Data source: embedded \`review-data.redacted.json\` payload generated locally from \`${data.summary.batch_id}\`
+
+## Guardrails
+
+- Do not expose Airtable credentials in Webflow or frontend code.
+- Do not call Airtable from the frontend.
+- Do not patch Clients from this page.
+- Do not create or merge Clients from this page.
+- Do not write Member Entitlements from this page.
+- Keep Gmail paused and out of this workflow.
+- LINE OFC rename/tag evidence remains the membership source of truth.
+
+## Future Commit Path
+
+Future commit should be a separate guarded worker endpoint requiring \`t\`.
+That endpoint should accept a reviewed local decision export, validate \`import_id\`
+against staging, and apply only explicitly approved actions after a separate review
+gate. It should not be wired to buttons on this review page.
+
+## Webflow Paste Files
+
+- Head CSS: \`webflow-head.css\`
+- Embed block: \`webflow-embed.html\`
+- Before body JS: \`webflow-before-body.js\`
+
+The Webflow version reads only embedded redacted JSON. It has no Airtable API calls
+and no secret-bearing frontend configuration.
+`;
+}
+
+function writeReviewPage(data, outDir = OUT_DIR) {
+  fs.mkdirSync(outDir, { recursive: true });
+  const files = {
+    "index.html": renderHtml(data),
+    "line-ofc-review.css": renderCss(),
+    "line-ofc-review.js": renderJs(),
+    [DATA_FILE]: `${JSON.stringify(data, null, 2)}\n`,
+    "webflow-embed.html": `${renderWebflowEmbed(data)}\n`,
+    "webflow-head.css": `${renderCss()}\n`,
+    "webflow-before-body.js": `${renderJs()}\n`,
+    "control-room-integration.md": renderControlRoomIntegration(data),
+  };
+  for (const [file, content] of Object.entries(files)) fs.writeFileSync(path.join(outDir, file), content);
+  return Object.keys(files).map((file) => path.join(outDir, file));
+}
+
+async function fetchStagingBatch({ batchId, airtable = new AirtableClient() }) {
+  return airtable.list(STAGING_TABLE, {
+    filterByFormula: `{import_batch_id}="${clean(batchId).replace(/"/g, '\\"')}"`,
+  });
+}
+
+async function runReviewPage({ batchId, airtable = new AirtableClient(), outDir = OUT_DIR }) {
+  if (!process.env.AIRTABLE_API_KEY && airtable instanceof AirtableClient) throw new Error("airtable_not_configured");
+  const records = await fetchStagingBatch({ batchId, airtable });
+  const data = buildReviewData(records, batchId);
+  const generatedFiles = writeReviewPage(data, outDir);
+  return {
+    ok: true,
+    mode: "line_ofc_review_page",
+    batch_id: batchId,
+    generated_files: generatedFiles,
+    summary: data.summary,
+    sample_redacted_card_data: data.rows.slice(0, 3),
+    airtable_reads_only: true,
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.batchId) {
+    console.error("Usage: npm run line-ofc:review-page -- --batch-id <batch_id>");
+    process.exitCode = 1;
+    return;
+  }
+  const result = await runReviewPage({ batchId: args.batchId });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  buildReviewData,
+  normalizeReviewRecord,
+  redactObject,
+  renderCss,
+  renderHtml,
+  renderJs,
+  renderControlRoomIntegration,
+  runReviewPage,
+  writeReviewPage,
+};

--- a/scripts/line-official-legacy/review-page.test.js
+++ b/scripts/line-official-legacy/review-page.test.js
@@ -1,0 +1,194 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  buildReviewData,
+  renderCss,
+  renderControlRoomIntegration,
+  renderHtml,
+  renderJs,
+  writeReviewPage,
+} = require("./review-page.js");
+
+function sampleRecord(overrides = {}) {
+  const fields = {
+    import_id: "line_ofc_console_line_123",
+    import_batch_id: "batch_review",
+    review_status: "review_required",
+    match_type: "multiple_candidates",
+    match_confidence: 0.5,
+    parse_confidence: 0.72,
+    line_display_name: "VIP Name",
+    line_renamed_name: "VIP Name #client #memApr25",
+    line_tags_raw: "#client #vip #purchased #memApr25",
+    parsed_client_level: "vip",
+    parsed_membership_status: "member",
+    parsed_membership_tier: "vip",
+    parsed_membership_package: "premium",
+    parsed_member_since: "2025-04-01",
+    parsed_member_since_raw: "#memApr25",
+    parsed_has_purchased: true,
+    phone_candidate: "+66812345678",
+    email_candidate: "secret@example.com",
+    membership_parse_json: JSON.stringify({
+      membership_status: "member",
+      client_level: "vip",
+      client_level_raw: "#vip",
+      client_level_tokens: [{ level: "vip", token: "#vip" }],
+      membership_tier: "vip",
+      membership_package: "premium",
+      member_since: "2025-04",
+      member_since_raw: "#memApr25",
+      has_purchased: true,
+      chosen_member_since_token: "#memApr25",
+      all_member_tokens: ["#memJan24", "#memApr25"],
+      parse_warnings: ["line_renamed_name_fallback:member_name"],
+    }),
+    proposed_entitlement_json: JSON.stringify({
+      source: "line_ofc",
+      client_level: "vip",
+      membership_status: "member",
+      membership_tier: "vip",
+      membership_package: "premium",
+      member_since: "2025-04",
+      member_since_raw: "#memApr25",
+      has_purchased: true,
+      review_required: true,
+    }),
+    raw_row_json: JSON.stringify({
+      member_email: "secret@example.com",
+      member_phone: "+66812345678",
+      line_user_id: "Uabc123",
+      member_name: "VIP Name",
+    }),
+    ...overrides,
+  };
+  return { id: "recReview1", fields };
+}
+
+test("review page data redacts phone email and private identifiers", () => {
+  const data = buildReviewData([sampleRecord()], "batch_review");
+  const row = data.rows[0];
+  assert.equal(Object.prototype.hasOwnProperty.call(row, "phone_candidate"), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(row, "email_candidate"), false);
+  assert.equal(row.raw_debug_redacted.member_email, "[redacted-email]");
+  assert.equal(row.raw_debug_redacted.member_phone, "[redacted-phone]");
+  assert.equal(row.raw_debug_redacted.line_user_id, "[redacted]");
+});
+
+test("review page redaction preserves membership dates", () => {
+  const data = buildReviewData([sampleRecord({
+    parsed_member_since: "2025-04-01",
+    raw_row_json: JSON.stringify({
+      member_since: "2025-04-01",
+      member_phone: "+66812345678",
+    }),
+  })], "batch_review");
+  assert.equal(data.rows[0].parsed_member_since, "2025-04-01");
+  assert.equal(data.rows[0].raw_debug_redacted.member_since, "2025-04-01");
+  assert.equal(data.rows[0].raw_debug_redacted.member_phone, "[redacted-phone]");
+});
+
+test("review page blocks unsafe rows and never marks rows committable", () => {
+  const data = buildReviewData([
+    sampleRecord({ review_status: "review_required", match_type: "exact_line_user_id" }),
+    sampleRecord({ review_status: "review_required", match_type: "multiple_candidates" }),
+    sampleRecord({ review_status: "staging_only", match_type: "no_match" }),
+    sampleRecord({ review_status: "ready_to_review", match_type: "exact_line_user_id" }),
+  ], "batch_review");
+  assert.equal(data.rows.every((row) => row.committable === false), true);
+  assert.equal(data.rows.every((row) => row.unsafe_to_commit === true), true);
+  assert.equal(data.rows[0].safety_state, "Blocked until human review");
+  assert.equal(data.rows[1].safety_state, "Choose client manually later");
+  assert.equal(data.rows[2].safety_state, "Staging only");
+  assert.equal(data.rows[3].safety_state, "Not executable on this page");
+});
+
+test("review_required rows are blocked", () => {
+  const data = buildReviewData([
+    sampleRecord({ review_status: "review_required", match_type: "exact_line_user_id" }),
+  ], "batch_review");
+  assert.equal(data.rows[0].queue_flags.review_required, true);
+  assert.equal(data.rows[0].safety_state, "Blocked until human review");
+  assert.equal(data.rows[0].committable, false);
+});
+
+test("multiple_match rows are blocked", () => {
+  const data = buildReviewData([
+    sampleRecord({ review_status: "review_required", match_type: "multiple_candidates" }),
+  ], "batch_review");
+  assert.equal(data.rows[0].queue_flags.multiple_match, true);
+  assert.equal(data.rows[0].safety_state, "Choose client manually later");
+  assert.equal(data.rows[0].committable, false);
+});
+
+test("no_match rows are blocked as staging only", () => {
+  const data = buildReviewData([
+    sampleRecord({ review_status: "staging_only", match_type: "no_match" }),
+  ], "batch_review");
+  assert.equal(data.rows[0].queue_flags.no_match_staging, true);
+  assert.equal(data.rows[0].safety_state, "Staging only");
+  assert.equal(data.rows[0].committable, false);
+});
+
+test("review page exposes member token evidence when present", () => {
+  const data = buildReviewData([sampleRecord()], "batch_review");
+  assert.equal(data.rows[0].chosen_member_since_token, "#memApr25");
+  assert.deepEqual(data.rows[0].all_member_tokens, ["#memJan24", "#memApr25"]);
+  assert.equal(data.rows[0].parsed_client_level, "vip");
+  assert.equal(data.rows[0].proposed_entitlement_summary.client_level, "vip");
+  assert.equal(data.summary.member_vip_premium_count, 1);
+});
+
+test("generated UI includes required filters and scoped CSS", () => {
+  const js = renderJs();
+  const css = renderCss();
+  assert.equal(js.includes('data-filter="status"'), true);
+  assert.equal(js.includes('data-filter="tier"'), true);
+  assert.equal(js.includes('data-filter="package"'), true);
+  assert.equal(js.includes('data-filter="match"'), true);
+  assert.equal(js.includes("parsed_membership_tier"), true);
+  assert.equal(js.includes("parsed_membership_package"), true);
+  assert.equal(js.includes("Review Required"), true);
+  assert.equal(js.includes("Multiple Match"), true);
+  assert.equal(js.includes("Member / VIP / Premium Evidence"), true);
+  assert.equal(js.includes("No Match Staging"), true);
+  assert.equal(js.includes("Ready After Manual Review"), true);
+  assert.equal(js.includes("All Staging"), true);
+  assert.equal(css.includes(":root"), false);
+  assert.equal(css.includes(".line-ofc-review-page{color-scheme:dark"), true);
+});
+
+test("generated review assets contain no secrets or Airtable write endpoints", () => {
+  const data = buildReviewData([sampleRecord()], "batch_review");
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "line-ofc-review-"));
+  writeReviewPage(data, tempDir);
+  const html = fs.readFileSync(path.join(tempDir, "index.html"), "utf8");
+  const js = fs.readFileSync(path.join(tempDir, "line-ofc-review.js"), "utf8");
+  const renderedHtml = renderHtml(data);
+  const renderedJs = renderJs();
+  for (const content of [html, js, renderedHtml, renderedJs]) {
+    assert.equal(content.includes("AIRTABLE_API_KEY"), false);
+    assert.equal(content.includes("api.airtable.com"), false);
+    assert.equal(content.includes("tblVv58TCbwh5j1fS"), false);
+    assert.equal(content.includes("tblNImdF9PKAxhXGi"), false);
+    assert.equal(/\b(PATCH|POST|DELETE)\b/.test(content), false);
+    assert.equal(content.includes("/commit"), false);
+    assert.equal(content.includes("commitEndpoint"), false);
+    assert.equal(content.includes("api/commit"), false);
+  }
+});
+
+test("control room integration note keeps commit separate and guarded", () => {
+  const data = buildReviewData([sampleRecord()], "batch_review");
+  const note = renderControlRoomIntegration(data);
+  assert.equal(note.includes("/control-room/line-ofc-review"), true);
+  assert.equal(note.includes("LINE OFC Review"), true);
+  assert.equal(note.includes("internal/admin only"), true);
+  assert.equal(note.includes("review-only"), true);
+  assert.equal(note.includes("No commit action on this page"), true);
+  assert.equal(note.includes("separate guarded worker endpoint requiring `t`"), true);
+});

--- a/scripts/line-official-legacy/review-report.js
+++ b/scripts/line-official-legacy/review-report.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+const { AirtableClient } = require("./dry-run-import.js");
+
+const STAGING_TABLE = process.env.AIRTABLE_LINE_OFC_CLIENT_IMPORT_STAGING_TABLE_ID || "tbl1u0foFBvgFpT9G";
+
+function clean(value) {
+  return String(value == null ? "" : value).trim();
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--batch-id") out.batchId = argv[index + 1];
+  }
+  return out;
+}
+
+function selectName(value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) return clean(value.name || value.value || value.id);
+  return clean(value);
+}
+
+function safeJson(value) {
+  try {
+    return value ? JSON.parse(value) : {};
+  } catch {
+    return {};
+  }
+}
+
+function fieldsOf(record) {
+  return record.fields || record.cellValuesByFieldId || record;
+}
+
+function value(fields, name, fieldId) {
+  return fields[name] ?? fields[fieldId];
+}
+
+function normalizeRow(record) {
+  const fields = fieldsOf(record);
+  const membershipParse = safeJson(value(fields, "membership_parse_json", "fld9UIM1ldUmS1C9s"));
+  const proposedEntitlement = safeJson(value(fields, "proposed_entitlement_json", "fldzKw53nu4Y9LUOc"));
+  return {
+    id: record.id || "",
+    import_id: clean(value(fields, "import_id", "fld4WvEkUiPipY3Qd")),
+    import_batch_id: clean(value(fields, "import_batch_id", "fldAS82UT6oQAP691")),
+    review_status: selectName(value(fields, "review_status", "fldv0NAa6o6heJsQZ")),
+    match_type: selectName(value(fields, "match_type", "fldxYb9vQhguNd4VD")),
+    match_confidence: Number(value(fields, "match_confidence", "fld1yf8uzcfPDwJud") || 0),
+    parsed_client_level: selectName(value(fields, "parsed_client_level", "fldGMB64f5L3A4dUL")) || membershipParse.client_level || "unknown",
+    parsed_membership_status: selectName(value(fields, "parsed_membership_status", "fld5vhO0UUQ2KKBS6")) || membershipParse.membership_status || "none",
+    parsed_membership_tier: selectName(value(fields, "parsed_membership_tier", "flduz31xE0hpPQ9Au")) || membershipParse.membership_tier || "none",
+    parsed_membership_package: selectName(value(fields, "parsed_membership_package", "fldfQse3D2pBpSMPv")) || membershipParse.membership_package || "none",
+    membership_parse_json: membershipParse,
+    proposed_entitlement_json: proposedEntitlement,
+    error_message: clean(value(fields, "error_message", "fldM4rIADr6ewhdep")),
+    points_review_required: clean(value(fields, "points_review_required", "fldJ2fwB1znlO9Zaj")),
+    points_parse_warnings: safeJson(value(fields, "points_parse_warnings", "fldRlbvzmds1zJeSe")),
+  };
+}
+
+function isPotentiallyReadyAfterManualReview(row) {
+  if (row.error_message) return false;
+  if (row.review_status !== "ready_to_review") return false;
+  if (!row.match_type.startsWith("exact_")) return false;
+  return true;
+}
+
+function isNeverCommittableWithoutReview(row) {
+  return row.review_status === "review_required"
+    || row.review_status === "staging_only"
+    || row.match_type === "multiple_candidates"
+    || row.match_type === "no_match";
+}
+
+function countBy(rows, fn) {
+  return rows.reduce((acc, row) => {
+    const key = fn(row) || "unknown";
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+function redactImportId(importId) {
+  const raw = clean(importId);
+  if (!raw) return "";
+  if (/draft|memreq|bkreq|img|renewal|price/.test(raw)) return raw.replace(/(line_ofc_console_)[a-z0-9_:-]+/i, "$1[redacted]");
+  return raw.replace(/(line_ofc_console_)[a-z]+_[0-9]+/i, "$1[redacted]");
+}
+
+function redactedSample(row) {
+  return {
+    staging_record_id: row.id ? `${row.id.slice(0, 6)}...${row.id.slice(-4)}` : "",
+    import_id: redactImportId(row.import_id),
+    match_type: row.match_type,
+    review_status: row.review_status,
+    match_confidence: row.match_confidence,
+    parsed_membership_status: row.parsed_membership_status,
+    parsed_client_level: row.parsed_client_level,
+    parsed_membership_tier: row.parsed_membership_tier,
+    parsed_membership_package: row.parsed_membership_package,
+    member_since: row.membership_parse_json.member_since || "",
+    all_member_tokens: row.membership_parse_json.all_member_tokens || [],
+    chosen_member_since_token: row.membership_parse_json.chosen_member_since_token || "",
+    chosen_member_since_strategy: row.membership_parse_json.chosen_member_since_strategy || "",
+    proposed_entitlement_source: row.proposed_entitlement_json.source || "",
+    proposed_entitlement_review_required: Boolean(row.proposed_entitlement_json.review_required),
+  };
+}
+
+function summarizeRows(records) {
+  const rows = records.map(normalizeRow);
+  const reviewRequired = rows.filter((row) => row.review_status === "review_required");
+  const multipleMatch = rows.filter((row) => row.match_type === "multiple_candidates" && row.review_status === "review_required");
+  const noMatch = rows.filter((row) => row.match_type === "no_match" && row.review_status === "staging_only");
+  const memberVipPremium = rows.filter((row) => (
+    row.parsed_membership_status === "member"
+    && (row.parsed_client_level === "vip" || row.parsed_membership_tier === "vip")
+    && row.parsed_membership_tier === "vip"
+    && row.parsed_membership_package === "premium"
+  ));
+  const potentiallyReady = rows.filter(isPotentiallyReadyAfterManualReview);
+  const neverCommittableWithoutReview = rows.filter(isNeverCommittableWithoutReview);
+  return {
+    total_staging_rows: rows.length,
+    review_required_rows: reviewRequired.length,
+    multiple_match_review_rows: multipleMatch.length,
+    member_vip_premium_rows: memberVipPremium.length,
+    no_match_rows: noMatch.length,
+    rows_unsafe_to_commit_now: rows.length,
+    rows_never_committable_without_review: neverCommittableWithoutReview.length,
+    rows_potentially_ready_after_manual_review: potentiallyReady.length,
+    counts: {
+      review_status: countBy(rows, (row) => row.review_status),
+      match_type: countBy(rows, (row) => row.match_type),
+      membership_status: countBy(rows, (row) => row.parsed_membership_status),
+      client_level: countBy(rows, (row) => row.parsed_client_level),
+      membership_tier: countBy(rows, (row) => row.parsed_membership_tier),
+      membership_package: countBy(rows, (row) => row.parsed_membership_package),
+    },
+    queues: {
+      review_required: reviewRequired.length,
+      multiple_match: multipleMatch.length,
+      member_vip_premium_evidence: memberVipPremium.length,
+      no_match_staging: noMatch.length,
+      ready_to_commit_after_reviewer_resolution: potentiallyReady.length,
+    },
+    reason_summary: {
+      review_required_by_match_type: countBy(reviewRequired, (row) => row.match_type),
+      no_match_by_import_kind: countBy(noMatch, (row) => row.import_id.split("_").slice(3, 4)[0] || "unknown"),
+    },
+    redacted_samples: {
+      review_required: reviewRequired.slice(0, 3).map(redactedSample),
+      multiple_match: multipleMatch.slice(0, 3).map(redactedSample),
+      member_vip_premium: memberVipPremium.slice(0, 3).map(redactedSample),
+      no_match: noMatch.slice(0, 3).map(redactedSample),
+      potentially_ready_after_manual_review: potentiallyReady.slice(0, 3).map(redactedSample),
+    },
+  };
+}
+
+async function fetchBatchRows({ batchId, airtable = new AirtableClient() }) {
+  return airtable.list(STAGING_TABLE, {
+    filterByFormula: `{import_batch_id}="${clean(batchId).replace(/"/g, '\\"')}"`,
+  });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.batchId) {
+    console.error("Usage: npm run line-ofc:review-report -- --batch-id <batch_id>");
+    process.exitCode = 1;
+    return;
+  }
+  const records = await fetchBatchRows({ batchId: args.batchId });
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    mode: "line_ofc_review_report",
+    batch_id: args.batchId,
+    ...summarizeRows(records),
+  }, null, 2)}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  isNeverCommittableWithoutReview,
+  isPotentiallyReadyAfterManualReview,
+  normalizeRow,
+  summarizeRows,
+};


### PR DESCRIPTION
Adds LINE OFC staging-only review tools.

- Aligns manual decision field to Airtable staging field `decision`.
- Supports `--input` alias and `--file`.
- No Airtable writes were run.
- No Clients/Member Entitlements/Gmail/immigrate-worker touched.
- No production commit/import run.
- Final status remains SAFE TO REVIEW STAGING, NOT SAFE TO COMMIT.

Airtable staging fields still must be created/confirmed before patch:

```text
decision
reviewed_by
reviewed_at
review_note
matched_client_id
decision_source
```

Verification:

```text
node --test scripts/line-official-legacy/*.test.js
pass 64/64
```