### PR TITLE
Add Kenji Board V7 gate helper for Webflow

### DIFF
--- a/webflow/sigil/board/README.md
+++ b/webflow/sigil/board/README.md
@@ -1,0 +1,31 @@
+# Kenji Board V5 Webflow Copy Override
+
+`kenji-board-v5-copy-override.js` is a copy-only Webflow helper for the live
+`/sigil/board` embed that contains `mmd-board-v5`.
+
+Load it after the existing Board V5 HTML/JS. It only updates visible copy,
+button labels, and local output guidance scoped to `[data-mmd-board-v5]`.
+
+It does not change routes, Worker endpoint contracts, token handling, payment
+logic, membership logic, SVIP logic, Black Card logic, or backend API behavior.
+It also does not include Airtable tokens, Worker secrets, admin keys, or private
+API keys.
+
+## Kenji Board V7.0 Gate Helper
+
+`kenji-board-v70-gate.js` is a Webflow-safe gate helper for the V7.0 board.
+Load it after the V7.0 board embed. It adds a delegated click handler for gate
+unlock controls and exposes `window.mmdBoardV70UnlockGate()` as a console
+fallback. The fallback prompts for the passphrase when called without arguments,
+or can be called as `window.mmdBoardV70UnlockGate("sigil")`.
+
+The mock passphrase is `sigil`. On unlock it only writes these local browser
+flags:
+
+```js
+localStorage.setItem("mmd_board_v70_gate", "unlocked");
+localStorage.setItem("mmd_board_v70_role", "boss_per");
+```
+
+This helper does not include secrets and does not send production writes from
+Webflow.

--- a/webflow/sigil/board/kenji-board-v70-gate.js
+++ b/webflow/sigil/board/kenji-board-v70-gate.js
@@ -1,0 +1,139 @@
+(function () {
+  "use strict";
+
+  if (window.mmdBoardV70GateHandlerInstalled) return;
+  window.mmdBoardV70GateHandlerInstalled = true;
+
+  var GATE_KEY = "mmd_board_v70_gate";
+  var ROLE_KEY = "mmd_board_v70_role";
+  var UNLOCKED = "unlocked";
+  var ROLE = "boss_per";
+  var MOCK_PASSPHRASE = "sigil";
+
+  var ROOT_SELECTOR = [
+    "[data-mmd-board-v70]",
+    "[data-mmd-board-v7]",
+    "#mmd-board-v70",
+    "#mmd-board-v7",
+    ".mmd-board-v70",
+    ".mmd-board-v7"
+  ].join(",");
+
+  var GATE_SELECTOR = [
+    "[data-v70-action='unlock-gate']",
+    "[data-v7-action='unlock-gate']",
+    "[data-mmd-board-v70-unlock]",
+    "[data-mmd-board-v7-unlock]",
+    "[data-mmd-board-v70-gate]",
+    "[data-mmd-board-v7-gate]",
+    "[data-gate-action='unlock']",
+    "#mmdBoardV70Gate",
+    "#mmdBoardV70UnlockGate",
+    ".mmd-board-v70__gate"
+  ].join(",");
+
+  var PASSPHRASE_SELECTOR = [
+    "[data-v70-gate-passphrase]",
+    "[data-v7-gate-passphrase]",
+    "[name='mmd_board_v70_passphrase']",
+    "#mmdBoardV70Passphrase",
+    "[data-gate-passphrase]"
+  ].join(",");
+
+  var STATUS_SELECTOR = [
+    "[data-v70-gate-status]",
+    "[data-v7-gate-status]",
+    "#mmdBoardV70GateStatus",
+    "[data-gate-status]"
+  ].join(",");
+
+  function clean(value) {
+    return String(value || "").trim();
+  }
+
+  function findRoot(node) {
+    if (node && node.closest) {
+      var closest = node.closest(ROOT_SELECTOR);
+      if (closest) return closest;
+    }
+    return document.querySelector(ROOT_SELECTOR);
+  }
+
+  function readPassphrase(root, explicitPassphrase) {
+    var explicit = clean(explicitPassphrase);
+    if (explicit) return explicit;
+
+    var input = root && root.querySelector ? root.querySelector(PASSPHRASE_SELECTOR) : null;
+    if (!input) input = document.querySelector(PASSPHRASE_SELECTOR);
+    if (input) return clean(input.value || input.textContent);
+
+    return clean(window.prompt ? window.prompt("Gate passphrase") : "");
+  }
+
+  function setStatus(root, message, tone) {
+    var target = root && root.querySelector ? root.querySelector(STATUS_SELECTOR) : null;
+    if (!target) target = document.querySelector(STATUS_SELECTOR);
+    if (!target) return;
+
+    target.textContent = message;
+    target.setAttribute("data-gate-tone", tone || "neutral");
+  }
+
+  function applyUnlockedState(root) {
+    localStorage.setItem(GATE_KEY, UNLOCKED);
+    localStorage.setItem(ROLE_KEY, ROLE);
+
+    if (root) {
+      root.setAttribute("data-gate", UNLOCKED);
+      root.setAttribute("data-role", ROLE);
+      root.classList.add("is-gate-unlocked");
+    }
+
+    setStatus(root, "Gate unlocked for boss_per.", "ok");
+    document.dispatchEvent(new CustomEvent("mmd:board-v70-gate-unlocked", {
+      detail: {
+        gate: UNLOCKED,
+        role: ROLE
+      }
+    }));
+
+    return {
+      ok: true,
+      gate: UNLOCKED,
+      role: ROLE
+    };
+  }
+
+  function unlockGate(options) {
+    var detail = typeof options === "string" ? { passphrase: options } : options || {};
+    var root = detail.root || findRoot(detail.target);
+    var passphrase = readPassphrase(root, detail.passphrase);
+
+    if (passphrase !== MOCK_PASSPHRASE) {
+      setStatus(root, "Gate locked. Check passphrase.", "error");
+      return {
+        ok: false,
+        error: "invalid_passphrase"
+      };
+    }
+
+    return applyUnlockedState(root);
+  }
+
+  document.addEventListener("click", function (event) {
+    var gate = event.target && event.target.closest ? event.target.closest(GATE_SELECTOR) : null;
+    if (!gate) return;
+
+    var root = findRoot(gate);
+    if (root && !root.contains(gate)) return;
+
+    event.preventDefault();
+    unlockGate({
+      target: gate,
+      root: root,
+      passphrase: gate.getAttribute("data-passphrase")
+    });
+  });
+
+  window.mmdBoardV70UnlockGate = unlockGate;
+})();

--- a/webflow/sigil/board/kenji-board-v70-gate.test.mjs
+++ b/webflow/sigil/board/kenji-board-v70-gate.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const source = await readFile(new URL("./kenji-board-v70-gate.js", import.meta.url), "utf8");
+
+test("V7 gate helper uses delegated click handling and fallback unlock API", () => {
+  assert.match(source, /document\.addEventListener\("click"/);
+  assert.match(source, /window\.mmdBoardV70UnlockGate = unlockGate/);
+  assert.match(source, /typeof options === "string"/);
+  assert.match(source, /mmd_board_v70_gate/);
+  assert.match(source, /mmd_board_v70_role/);
+  assert.match(source, /boss_per/);
+});
+
+test("V7 gate helper keeps the mock passphrase client-only", () => {
+  assert.match(source, /MOCK_PASSPHRASE = "sigil"/);
+  assert.doesNotMatch(source, /\bfetch\s*\(/);
+  assert.doesNotMatch(source, /XMLHttpRequest/);
+  assert.doesNotMatch(source, /\bmethod\s*:\s*["']POST["']/i);
+});


### PR DESCRIPTION
## Summary
- Add Webflow-safe Kenji Board V7.0 gate unlock helper
- Persist unlocked gate and boss_per role in localStorage
- Add a node:test smoke test covering delegated click handling and client-only behavior

## Test
- node --test webflow/sigil/board/kenji-board-v70-gate.test.mjs