### PR TITLE
Harden SIGIL admin login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@ node_modules
 dist
 .wrangler
 .DS_Store
+.dev.vars
+*.dev.vars
 .env
+.env.*

--- a/immigrate-worker/package-lock.json
+++ b/immigrate-worker/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20260301.0",
+        "esbuild": "^0.25.5",
         "typescript": "^5.7.3",
         "wrangler": "^4.10.0"
       }
@@ -156,9 +157,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
       "cpu": [
         "ppc64"
       ],
@@ -173,9 +174,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
       "cpu": [
         "arm"
       ],
@@ -190,9 +191,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
       "cpu": [
         "arm64"
       ],
@@ -207,9 +208,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
       "cpu": [
         "x64"
       ],
@@ -224,9 +225,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
       "cpu": [
         "arm64"
       ],
@@ -241,9 +242,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
       "cpu": [
         "x64"
       ],
@@ -258,9 +259,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
       "cpu": [
         "arm64"
       ],
@@ -275,9 +276,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
       "cpu": [
         "x64"
       ],
@@ -292,9 +293,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
       "cpu": [
         "arm"
       ],
@@ -309,9 +310,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
       "cpu": [
         "arm64"
       ],
@@ -326,9 +327,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
       "cpu": [
         "ia32"
       ],
@@ -343,9 +344,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
       "cpu": [
         "loong64"
       ],
@@ -360,9 +361,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
       "cpu": [
         "mips64el"
       ],
@@ -377,9 +378,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
       "cpu": [
         "ppc64"
       ],
@@ -394,9 +395,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
       "cpu": [
         "riscv64"
       ],
@@ -411,9 +412,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
       "cpu": [
         "s390x"
       ],
@@ -428,9 +429,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
       "cpu": [
         "x64"
       ],
@@ -445,9 +446,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
       "cpu": [
         "arm64"
       ],
@@ -462,9 +463,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
       "cpu": [
         "x64"
       ],
@@ -479,9 +480,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
       "cpu": [
         "arm64"
       ],
@@ -496,9 +497,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
       "cpu": [
         "x64"
       ],
@@ -513,9 +514,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
       "cpu": [
         "arm64"
       ],
@@ -530,9 +531,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
       "cpu": [
         "x64"
       ],
@@ -547,9 +548,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
       "cpu": [
         "arm64"
       ],
@@ -564,9 +565,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
       "cpu": [
         "ia32"
       ],
@@ -581,9 +582,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
       "cpu": [
         "x64"
       ],
@@ -1206,9 +1207,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1219,32 +1220,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/fsevents": {
@@ -1474,6 +1475,490 @@
         "@cloudflare/workers-types": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/ws": {

--- a/immigrate-worker/package.json
+++ b/immigrate-worker/package.json
@@ -6,10 +6,12 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "test": "node test/sigil-admin-login.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260301.0",
+    "esbuild": "^0.25.5",
     "typescript": "^5.7.3",
     "wrangler": "^4.10.0"
   }

--- a/immigrate-worker/src/index.ts
+++ b/immigrate-worker/src/index.ts
@@ -82,6 +82,15 @@ const CONTROL_ROOM = {
   sessionRefresh: "/internal/admin/control-room/sessions/refresh",
 } as const;
 
+const SIGIL_ADMIN = {
+  root: "/sigil/admin",
+  login: "/sigil/admin/login",
+  authMe: "/sigil/admin/auth/me",
+  logout: "/sigil/admin/logout",
+  controlRoom: "/sigil/admin/control-room",
+  dashboard: "/sigil/admin/dashboard",
+} as const;
+
 const ADMIN_JOBS = {
   createSession: "/internal/admin/create-session",
   createSessionLegacy: "/internal/admin/jobs/create-session",
@@ -104,7 +113,7 @@ const PUBLIC = {
 
 const ADMIN_GATE_SESSION_KEY = "mmd_admin_gate_v1";
 const ADMIN_GATE_TTL_MS = 8 * 60 * 60 * 1000;
-const ADMIN_GATE_DEFAULT_NEXT = CONTROL_ROOM.root;
+const ADMIN_GATE_DEFAULT_NEXT = SIGIL_ADMIN.dashboard;
 const ADMIN_GATE_ALLOWED_BASE_URLS = new Set([
   "https://mmdbkk.com",
   "https://mmdprive.webflow.io",
@@ -2376,11 +2385,40 @@ function isProtectedBrowserRoute(pathname: string): boolean {
   return true;
 }
 
+function isSigilAdminPath(pathname: string): boolean {
+  return pathname === SIGIL_ADMIN.root || pathname.startsWith(`${SIGIL_ADMIN.root}/`);
+}
+
+function isSigilProtectedBrowserRoute(pathname: string): boolean {
+  return (
+    pathname === SIGIL_ADMIN.controlRoom ||
+    pathname.startsWith(`${SIGIL_ADMIN.controlRoom}/`) ||
+    pathname === SIGIL_ADMIN.dashboard ||
+    pathname.startsWith(`${SIGIL_ADMIN.dashboard}/`)
+  );
+}
+
+function toInternalAdminPath(pathname: string): string {
+  if (pathname === SIGIL_ADMIN.dashboard || pathname.startsWith(`${SIGIL_ADMIN.dashboard}/`)) {
+    return CONTROL_ROOM.root + pathname.slice(SIGIL_ADMIN.dashboard.length);
+  }
+  if (pathname === SIGIL_ADMIN.controlRoom || pathname.startsWith(`${SIGIL_ADMIN.controlRoom}/`)) {
+    return CONTROL_ROOM.root + pathname.slice(SIGIL_ADMIN.controlRoom.length);
+  }
+  return pathname;
+}
+
+function makeRequestWithPath(request: Request, pathname: string): Request {
+  const url = new URL(request.url);
+  url.pathname = pathname;
+  return new Request(url.toString(), request);
+}
+
 function makeLoginRedirect(request: Request, pathname: string): Response {
   const url = new URL(request.url);
   const next = pathname + url.search;
-  const loginUrl = new URL(CONTROL_ROOM.login, url.origin);
-  loginUrl.searchParams.set("next", next);
+  const loginUrl = new URL(SIGIL_ADMIN.login, url.origin);
+  loginUrl.searchParams.set("next", normalizeSigilAdminNextPath(next));
   return redirect(loginUrl.toString(), 302);
 }
 
@@ -2465,32 +2503,32 @@ async function verifyAdminAuthority(
 }
 
 function makeGateSessionCookie(request: Request, session: AdminGateSession): string {
-  const isSecure = new URL(request.url).protocol === "https:";
   const parts = [
     `${ADMIN_GATE_SESSION_KEY}=${encodeURIComponent(encodeGateSession(session))}`,
     "Path=/",
+    "HttpOnly",
+    "Secure",
     "SameSite=Lax",
     `Max-Age=${Math.floor(ADMIN_GATE_TTL_MS / 1000)}`,
   ];
 
-  if (isSecure) parts.push("Secure");
   return parts.join("; ");
 }
 
 function clearGateSessionCookie(request: Request): string {
-  const isSecure = new URL(request.url).protocol === "https:";
   const parts = [
     `${ADMIN_GATE_SESSION_KEY}=`,
     "Path=/",
+    "HttpOnly",
+    "Secure",
     "SameSite=Lax",
     "Max-Age=0",
   ];
 
-  if (isSecure) parts.push("Secure");
   return parts.join("; ");
 }
 
-function normalizeAdminNextPath(value: unknown): string {
+function normalizeSigilAdminNextPath(value: unknown): string {
   const raw = toStr(value);
   if (!raw.startsWith("/") || raw.startsWith("//")) {
     return ADMIN_GATE_DEFAULT_NEXT;
@@ -2501,9 +2539,32 @@ function normalizeAdminNextPath(value: unknown): string {
     if (parsed.origin !== "https://mmdbkk.com") {
       return ADMIN_GATE_DEFAULT_NEXT;
     }
+    if (!isSigilAdminPath(parsed.pathname)) {
+      return ADMIN_GATE_DEFAULT_NEXT;
+    }
+    if (parsed.pathname === SIGIL_ADMIN.login || parsed.pathname === SIGIL_ADMIN.authMe || parsed.pathname === SIGIL_ADMIN.logout) {
+      return ADMIN_GATE_DEFAULT_NEXT;
+    }
     return `${parsed.pathname}${parsed.search}${parsed.hash}`;
   } catch {
     return ADMIN_GATE_DEFAULT_NEXT;
+  }
+}
+
+function normalizeAdminNextPath(value: unknown): string {
+  const raw = toStr(value);
+  if (!raw.startsWith("/") || raw.startsWith("//")) {
+    return CONTROL_ROOM.root;
+  }
+
+  try {
+    const parsed = new URL(raw, "https://mmdbkk.com");
+    if (parsed.origin !== "https://mmdbkk.com") {
+      return CONTROL_ROOM.root;
+    }
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return CONTROL_ROOM.root;
   }
 }
 
@@ -2540,80 +2601,34 @@ function adminGateBootstrapScript(session: AdminGateSession, next: string): stri
   return `
 <script>
 (() => {
-  const KEY = ${JSON.stringify(ADMIN_GATE_SESSION_KEY)};
-  const TTL_MS = ${String(ADMIN_GATE_TTL_MS)};
-  const LOGIN_PATH = ${JSON.stringify(CONTROL_ROOM.login)};
-  const serverSession = ${JSON.stringify(session)};
+  const LOGIN_PATH = ${JSON.stringify(SIGIL_ADMIN.login)};
+  const LOGOUT_PATH = ${JSON.stringify(SIGIL_ADMIN.logout)};
+  const AUTH_ME_PATH = ${JSON.stringify(SIGIL_ADMIN.authMe)};
   const defaultNext = ${JSON.stringify(next)};
-
-  function isValid(value) {
-    return !!value &&
-      value.ok === true &&
-      typeof value.at === "number" &&
-      Date.now() - value.at <= TTL_MS &&
-      typeof value.baseUrl === "string" &&
-      value.baseUrl.length > 0 &&
-      (value.bearer || value.confirmKey);
-  }
 
   function getNextUrl() {
     return location.pathname + location.search + location.hash;
   }
 
   function redirectToLogin() {
-    try { sessionStorage.removeItem(KEY); } catch {}
     location.replace(LOGIN_PATH + "?next=" + encodeURIComponent(getNextUrl() || defaultNext));
   }
 
-  let session = null;
-  try {
-    session = JSON.parse(sessionStorage.getItem(KEY) || "null");
-  } catch {
-    session = null;
-  }
-
-  if (!isValid(session) && isValid(serverSession)) {
-    session = serverSession;
-    try { sessionStorage.setItem(KEY, JSON.stringify(session)); } catch {}
-  }
-
-  if (!isValid(session)) {
-    redirectToLogin();
-    return;
-  }
-
-  const originalFetch = window.fetch.bind(window);
   window.__MMD_ADMIN_GATE__ = {
-    key: KEY,
-    session,
-    getSession() {
-      return session;
+    authenticated: true,
+    baseUrl: ${JSON.stringify(session.baseUrl)},
+    async check() {
+      const response = await fetch(AUTH_ME_PATH, { credentials: "same-origin" });
+      if (!response.ok) redirectToLogin();
+      return response;
     },
     buildHeaders(extraHeaders) {
-      const headers = new Headers(extraHeaders || {});
-      if (session.bearer) headers.set("Authorization", "Bearer " + session.bearer);
-      if (session.confirmKey) headers.set("X-Confirm-Key", session.confirmKey);
-      return headers;
+      return new Headers(extraHeaders || {});
     },
     logout() {
-      try { sessionStorage.removeItem(KEY); } catch {}
-      return originalFetch(${JSON.stringify(CONTROL_ROOM.loginSession)}, { method: "DELETE", credentials: "same-origin" })
+      return fetch(LOGOUT_PATH, { method: "POST", credentials: "same-origin" })
         .finally(() => location.replace(LOGIN_PATH + "?next=" + encodeURIComponent(defaultNext)));
     }
-  };
-
-  window.fetch = function(input, init) {
-    const raw = typeof input === "string" || input instanceof URL ? String(input) : "";
-    if (!raw) return originalFetch(input, init);
-
-    const url = new URL(raw, location.origin);
-    if (!url.pathname.startsWith("/v1/admin/")) {
-      return originalFetch(input, init);
-    }
-
-    const target = session.baseUrl.replace(/\\/+$/, "") + url.pathname + url.search + url.hash;
-    const headers = window.__MMD_ADMIN_GATE__.buildHeaders(init && init.headers);
-    return originalFetch(target, { ...init, headers });
   };
 })();
 </script>`;
@@ -2825,7 +2840,7 @@ function renderAdminLoginPage(request: Request): Response {
         }
 
         function storeSession(session) {
-          sessionStorage.setItem(KEY, JSON.stringify(session));
+          void session;
         }
 
         form.addEventListener("submit", async (event) => {
@@ -2875,6 +2890,199 @@ function renderAdminLoginPage(request: Request): Response {
       "content-type": "text/html; charset=utf-8",
       "cache-control": "no-store",
     },
+  });
+}
+
+type SigilLoginBody = {
+  baseUrl?: string;
+  identity?: string;
+  password?: string;
+  gate_code?: string;
+  otp?: string;
+  accessCode?: string;
+  bearer?: string;
+  confirmKey?: string;
+  next?: string;
+};
+
+async function readSigilLoginBody(request: Request): Promise<SigilLoginBody | null> {
+  const contentType = request.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    return (await request.json().catch(() => null)) as SigilLoginBody | null;
+  }
+
+  const form = await request.formData().catch(() => null);
+  if (!form) return null;
+
+  return {
+    baseUrl: toStr(form.get("baseUrl")),
+    identity: toStr(form.get("identity")),
+    password: toStr(form.get("password")),
+    gate_code: toStr(form.get("gate_code")),
+    otp: toStr(form.get("otp")),
+    accessCode: toStr(form.get("accessCode")),
+    bearer: toStr(form.get("bearer")),
+    confirmKey: toStr(form.get("confirmKey")),
+    next: toStr(form.get("next")),
+  };
+}
+
+function renderSigilAdminLoginPage(request: Request, init?: ResponseInit & { error?: string }): Response {
+  const url = new URL(request.url);
+  const next = normalizeSigilAdminNextPath(url.searchParams.get("next"));
+  const error = toStr(init?.error);
+  let defaultBaseUrl = "https://mmdbkk.com";
+  try {
+    defaultBaseUrl = normalizeAdminBaseUrl(url.origin, request);
+  } catch {}
+
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SIGIL Admin Login</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #050406;
+        --panel: rgba(15, 12, 18, .88);
+        --line: rgba(221, 184, 108, .22);
+        --text: #f8efe2;
+        --muted: #b9aa97;
+        --gold: #d7ad63;
+        --gold-strong: #f0cc83;
+        --danger: #ef9b9b;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        padding: 24px;
+        color: var(--text);
+        background:
+          radial-gradient(circle at top left, rgba(215,173,99,.18), transparent 30%),
+          linear-gradient(180deg, #111014 0%, #070609 58%, #030303 100%);
+        font-family: Baskerville, "Iowan Old Style", Palatino, Georgia, serif;
+      }
+      .sigil-admin-login-v1 {
+        width: min(100%, 720px);
+        padding: clamp(24px, 5vw, 40px);
+        border: 1px solid var(--line);
+        border-radius: 24px;
+        background: var(--panel);
+        box-shadow: 0 28px 90px rgba(0,0,0,.45);
+      }
+      .kicker {
+        margin: 0 0 12px;
+        color: var(--gold);
+        font: 700 .78rem/1.2 "Avenir Next Condensed", "Gill Sans", sans-serif;
+        letter-spacing: .2em;
+        text-transform: uppercase;
+      }
+      h1 {
+        margin: 0;
+        font-size: clamp(2.2rem, 9vw, 4.6rem);
+        line-height: .92;
+      }
+      .lead {
+        max-width: 44rem;
+        margin: 18px 0 0;
+        color: var(--muted);
+        line-height: 1.65;
+      }
+      form {
+        display: grid;
+        gap: 14px;
+        margin-top: 28px;
+      }
+      label {
+        display: grid;
+        gap: 8px;
+        color: var(--gold-strong);
+        font: 700 .78rem/1.2 "Avenir Next Condensed", "Gill Sans", sans-serif;
+        letter-spacing: .14em;
+        text-transform: uppercase;
+      }
+      input {
+        width: 100%;
+        min-height: 52px;
+        padding: 0 16px;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: rgba(5,4,6,.74);
+        color: var(--text);
+        font: inherit;
+      }
+      button {
+        min-height: 50px;
+        border: 1px solid rgba(240,204,131,.44);
+        border-radius: 12px;
+        background: linear-gradient(135deg, rgba(215,173,99,.32), rgba(96,72,28,.38));
+        color: var(--text);
+        font: 700 .88rem/1 "Avenir Next Condensed", "Gill Sans", sans-serif;
+        letter-spacing: .13em;
+        text-transform: uppercase;
+        cursor: pointer;
+      }
+      .error {
+        min-height: 1.25rem;
+        margin: 0;
+        color: var(--danger);
+      }
+      .meta {
+        margin: 0;
+        color: var(--muted);
+        font-size: .92rem;
+        overflow-wrap: anywhere;
+      }
+      @media (max-width: 520px) {
+        body { padding: 16px; }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="sigil-admin-login-v1">
+      <p class="kicker">SIGIL Internal Command</p>
+      <h1>Admin access.</h1>
+      <p class="lead">Enter the Gate Code / OTP to request a server-verified admin session.</p>
+
+      <form method="post" action="${SIGIL_ADMIN.login}" autocomplete="on">
+        <input type="hidden" name="next" value="${escapeHtml(next)}" />
+        <input type="hidden" name="baseUrl" value="${escapeHtml(defaultBaseUrl)}" />
+
+        <label>Operator
+          <input name="identity" type="text" autocomplete="username" inputmode="email" />
+        </label>
+
+        <label>Gate Code / OTP
+          <input name="gate_code" type="password" autocomplete="one-time-code" required />
+        </label>
+
+        <label>Password
+          <input name="password" type="password" autocomplete="current-password" />
+        </label>
+
+        <p class="meta">Next: ${escapeHtml(next)}</p>
+        <p class="error" role="alert">${escapeHtml(error)}</p>
+        <button type="submit">Unlock SIGIL</button>
+      </form>
+    </main>
+  </body>
+</html>`;
+
+  const headers = new Headers(init?.headers);
+  headers.set("content-type", "text/html; charset=utf-8");
+  headers.set("cache-control", "no-store");
+  headers.set("x-mmd-worker", "immigrate-worker");
+  headers.set("x-mmd-page", "sigil-admin-login");
+
+  return new Response(html, {
+    status: init?.status || 200,
+    statusText: init?.statusText,
+    headers,
   });
 }
 
@@ -3758,6 +3966,96 @@ async function handleAdminLoginSession(request: Request, env: Env): Promise<Resp
   );
 }
 
+async function handleSigilAdminLogin(request: Request, env: Env): Promise<Response> {
+  const body = await readSigilLoginBody(request);
+  const gateCode = toStr(body?.gate_code || body?.otp);
+  const password = toStr(body?.password || body?.accessCode);
+  const bearer = toStr(body?.bearer) || gateCode || password;
+  const confirmKey = toStr(body?.confirmKey);
+  const next = normalizeSigilAdminNextPath(body?.next);
+  let baseUrl = "";
+
+  try {
+    baseUrl = normalizeAdminBaseUrl(body?.baseUrl, request);
+  } catch {
+    return renderSigilAdminLoginPage(request, {
+      status: 401,
+      error: "Unable to verify SIGIL admin access.",
+    });
+  }
+
+  if (!bearer && !confirmKey) {
+    return renderSigilAdminLoginPage(request, {
+      status: 401,
+      error: "Gate Code / OTP is required.",
+    });
+  }
+
+  const headers = new Headers();
+  if (bearer) headers.set("Authorization", `Bearer ${bearer}`);
+  if (confirmKey) headers.set("X-Confirm-Key", confirmKey);
+
+  const verified = await verifyAdminAuthority(baseUrl, request, env, headers);
+  if (!verified) {
+    return renderSigilAdminLoginPage(request, {
+      status: 401,
+      error: "Unable to verify SIGIL admin access.",
+    });
+  }
+
+  const session: AdminGateSession = {
+    ok: true,
+    at: Date.now(),
+    baseUrl,
+    ...(bearer ? { bearer } : {}),
+    ...(confirmKey ? { confirmKey } : {}),
+  };
+
+  return redirect(next, 302, {
+    "set-cookie": makeGateSessionCookie(request, session),
+    "cache-control": "no-store",
+  });
+}
+
+function handleSigilAdminMe(request: Request): Response {
+  const session = getValidatedGateSession(request);
+  if (!session) {
+    return json(
+      { ok: false, error: { code: "ADMIN_SESSION_REQUIRED", message: "Admin session required" } },
+      { status: 401, headers: { "cache-control": "no-store" } },
+    );
+  }
+
+  return json(
+    { ok: true, data: { authenticated: true, baseUrl: session.baseUrl } },
+    { headers: { "cache-control": "no-store" } },
+  );
+}
+
+function handleSigilAdminLogout(request: Request): Response {
+  return redirect(SIGIL_ADMIN.login, 302, {
+    "set-cookie": clearGateSessionCookie(request),
+    "cache-control": "no-store",
+  });
+}
+
+function makeLegacyAdminRedirect(request: Request): Response | null {
+  const url = new URL(request.url);
+  if (url.pathname === "/admin/login" || url.pathname === CONTROL_ROOM.login) {
+    const target = new URL(SIGIL_ADMIN.login, url.origin);
+    target.searchParams.set("next", normalizeSigilAdminNextPath(url.searchParams.get("next")));
+    return redirect(target.toString(), 302);
+  }
+
+  if (url.pathname === CONTROL_ROOM.root || url.pathname.startsWith(`${CONTROL_ROOM.root}/`)) {
+    const target = new URL(request.url);
+    target.pathname = SIGIL_ADMIN.controlRoom + url.pathname.slice(CONTROL_ROOM.root.length);
+    return redirect(target.toString(), 302);
+  }
+
+  return null;
+}
+
 async function handleVerifyAccessCode(request: Request, env: Env): Promise<Response> {
   const meta = makeMeta(request);
 
@@ -3830,6 +4128,42 @@ export default {
 
       if (request.method === "POST" && isPublicCustomerConfirmRoute(url.pathname)) {
         return await handleCustomerConfirm(request, env);
+      }
+
+      const legacyAdminRedirect = makeLegacyAdminRedirect(request);
+      if (
+        legacyAdminRedirect &&
+        (request.method === "GET" || request.method === "HEAD")
+      ) {
+        return legacyAdminRedirect;
+      }
+
+      if ((request.method === "GET" || request.method === "HEAD") && url.pathname === SIGIL_ADMIN.login) {
+        if (request.method === "HEAD") {
+          return new Response(null, {
+            status: 200,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+              "cache-control": "no-store",
+              "x-mmd-worker": "immigrate-worker",
+              "x-mmd-page": "sigil-admin-login",
+            },
+          });
+        }
+
+        return renderSigilAdminLoginPage(request);
+      }
+
+      if (request.method === "POST" && url.pathname === SIGIL_ADMIN.login) {
+        return await handleSigilAdminLogin(request, env);
+      }
+
+      if (request.method === "GET" && url.pathname === SIGIL_ADMIN.authMe) {
+        return handleSigilAdminMe(request);
+      }
+
+      if ((request.method === "GET" || request.method === "POST") && url.pathname === SIGIL_ADMIN.logout) {
+        return handleSigilAdminLogout(request);
       }
 
       if ((request.method === "GET" || request.method === "HEAD") && url.pathname === CONTROL_ROOM.login) {
@@ -3920,6 +4254,25 @@ export default {
         }
 
         return await withInjectedAdminBootstrap(request, upstream, gateSession);
+      }
+
+      if ((request.method === "GET" || request.method === "HEAD") && isSigilProtectedBrowserRoute(url.pathname)) {
+        if (isAuthorized(request, env)) {
+          return fetch(makeRequestWithPath(request, toInternalAdminPath(url.pathname)));
+        }
+
+        const gateSession = getValidatedGateSession(request);
+        if (!gateSession) {
+          return makeLoginRedirect(request, url.pathname);
+        }
+
+        const upstreamRequest = makeRequestWithPath(request, toInternalAdminPath(url.pathname));
+        const upstream = await fetch(upstreamRequest);
+        if (request.method === "HEAD") {
+          return upstream;
+        }
+
+        return await withInjectedAdminBootstrap(upstreamRequest, upstream, gateSession);
       }
 
       if (!isAuthorized(request, env)) {

--- a/immigrate-worker/test/sigil-admin-login.test.mjs
+++ b/immigrate-worker/test/sigil-admin-login.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { build } from "esbuild";
+
+const tmp = await mkdtemp(join(tmpdir(), "sigil-admin-login-"));
+const outfile = join(tmp, "worker.mjs");
+
+await build({
+  entryPoints: ["src/index.ts"],
+  outfile,
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  conditions: ["worker", "browser"],
+  target: "es2022",
+});
+
+const worker = (await import(pathToFileURL(outfile).href)).default;
+const env = {};
+
+globalThis.fetch = async (input, init = {}) => {
+  const url = new URL(typeof input === "string" ? input : input.url);
+  if (url.pathname === "/v1/admin/ping") {
+    const authorization = new Headers(init.headers).get("authorization") || "";
+    return new Response(JSON.stringify({ ok: authorization === "Bearer valid-gate" }), {
+      status: authorization === "Bearer valid-gate" ? 200 : 401,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  return new Response("<!doctype html><title>control</title>", {
+    status: 200,
+    headers: { "content-type": "text/html; charset=utf-8" },
+  });
+};
+
+async function call(path, init) {
+  return worker.fetch(new Request(`https://mmdbkk.com${path}`, init), env);
+}
+
+try {
+  {
+    const response = await call("/sigil/admin/login");
+    const html = await response.text();
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-mmd-worker"), "immigrate-worker");
+    assert.equal(response.headers.get("x-mmd-page"), "sigil-admin-login");
+    assert.match(html, /class="sigil-admin-login-v1"/);
+    assert.match(html, /Gate Code \/ OTP/);
+    assert.match(html, /method="post" action="\/sigil\/admin\/login"/);
+    assert.match(html, /name="gate_code"/);
+    assert.doesNotMatch(html, /localStorage|sessionStorage|\?mock|name="token"/);
+  }
+
+  {
+    const form = new FormData();
+    form.set("gate_code", "wrong");
+    form.set("next", "/sigil/admin/dashboard");
+    const response = await call("/sigil/admin/login", { method: "POST", body: form });
+    const html = await response.text();
+    assert.equal(response.status, 401);
+    assert.equal(response.headers.get("set-cookie"), null);
+    assert.match(html, /Unable to verify SIGIL admin access/);
+  }
+
+  {
+    const form = new FormData();
+    form.set("gate_code", "valid-gate");
+    form.set("next", "/sigil/admin/control-room");
+    const response = await call("/sigil/admin/login", { method: "POST", body: form });
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get("location"), "/sigil/admin/control-room");
+    const cookie = response.headers.get("set-cookie") || "";
+    assert.match(cookie, /mmd_admin_gate_v1=/);
+    assert.match(cookie, /HttpOnly/);
+    assert.match(cookie, /Secure/);
+    assert.match(cookie, /SameSite=Lax/);
+  }
+
+  for (const next of [
+    "https://evil.example/sigil/admin/control-room",
+    "//evil.example/sigil/admin/control-room",
+    "/member/login",
+    "/pay/membership",
+    "/trust/inme",
+  ]) {
+    const form = new FormData();
+    form.set("gate_code", "valid-gate");
+    form.set("next", next);
+    const response = await call("/sigil/admin/login", { method: "POST", body: form });
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get("location"), "/sigil/admin/dashboard");
+  }
+
+  {
+    const response = await call("/member/login");
+    assert.notEqual(response.status, 302);
+    assert.notEqual(response.headers.get("location"), "/sigil/admin/login");
+  }
+
+  {
+    const response = await call("/pay/membership");
+    assert.notEqual(response.status, 302);
+    assert.notEqual(response.headers.get("location"), "/sigil/admin/login");
+  }
+
+  {
+    const response = await call("/admin/login?next=/sigil/admin/control-room");
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/sigil/admin/login?next=%2Fsigil%2Fadmin%2Fcontrol-room");
+  }
+
+  {
+    const response = await call("/internal/admin/control-room");
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/sigil/admin/control-room");
+  }
+} finally {
+  await rm(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary
- Move public admin login ownership to `/sigil/admin/login` with Gate Code / OTP field naming.
- Add server-verified SIGIL login, auth-me, and logout endpoints with `Secure`, `HttpOnly`, `SameSite=Lax` cookie handling.
- Restrict `next` redirects to internal `/sigil/admin/*` routes and redirect legacy admin URLs to SIGIL routes.
- Add focused SIGIL admin login tests and ignore local env/dev-vars files.

## Security notes
- No `.env` or `.dev.vars` files are tracked on `origin/main` or in this branch.
- Browser JS no longer stores or decides SIGIL admin session authority.
- Login success depends on worker verification and the server-set cookie.

## Checks
- `npm test`: PASS in `immigrate-worker`
- `npm run typecheck`: FAILS on current `origin/main` before this branch too, in unrelated model-promotion/public-renewal files.