### PR TITLE
Add Kenji member concierge Webflow layer

### DIFF
--- a/webflow/member/kenji-ai-20/README.md
+++ b/webflow/member/kenji-ai-20/README.md
@@ -1,0 +1,44 @@
+# Kenji Member Concierge
+
+Member-facing Webflow asset for `/member/kenji-ai-20`.
+
+Canonical route meaning:
+
+- `/member/dashboard` is Member Home / Status Hub.
+- `/member/kenji-ai-20` is Kenji AI / member-facing concierge.
+- `/sigil/board` remains the internal system, admin, rules, and control layer.
+
+## Usage
+
+Load `kenji-member-concierge.js` on the member-facing page and add optional bindings:
+
+```html
+<section data-kenji-concierge>
+  <div data-kenji-status></div>
+  <input data-kenji-input />
+  <button data-kenji-send>Ask Kenji</button>
+  <div data-kenji-intent></div>
+  <div data-kenji-reply></div>
+</section>
+```
+
+The browser global is `window.MMDKenjiMemberConcierge`.
+
+Available helpers:
+
+- `classifyIntent(input, memberSummary)`
+- `buildKenjiReply(input, memberSummary)`
+- `sanitizeMemberSummary(input)`
+- `loadSanitizedMemberSummary(options)`
+
+## Data Safety
+
+The frontend reads only sanitized member summary data. It uses query param `t` only and does not send or expose frontend secrets.
+
+If the backend member summary endpoint is unavailable, the asset falls back to `DEMO_ONLY_MEMBER_SUMMARY`, which is explicitly named demo-only and contains no real member data.
+
+Payment slips are supporting evidence only. Confirmation happens only after official verification and fund matching.
+
+SVIP is Boss Per manual-only, never points-based.
+
+Black Card is private review, not automatic approval.

--- a/webflow/member/kenji-ai-20/kenji-member-concierge.js
+++ b/webflow/member/kenji-ai-20/kenji-member-concierge.js
@@ -1,0 +1,266 @@
+/*
+  Kenji Member Concierge - Webflow-safe member layer
+  Route intent: /member/kenji-ai-20
+  Home/status context: /member/dashboard
+*/
+(function (global) {
+  "use strict";
+
+  const HIGH_POINTS_THRESHOLD = 1200;
+  const MEMBER_SUMMARY_ENDPOINT = "/member/api/summary";
+
+  const INTENTS = Object.freeze({
+    EMPTY: "empty",
+    BOOKING: "booking",
+    PAYMENT: "payment_slip",
+    POINTS: "points",
+    VIP: "vip",
+    SVIP: "svip",
+    BLACK_CARD: "black_card",
+    MEMBERSHIP: "membership_renewal",
+    HIGH_POINTS: "high_points_fallback",
+    GENERAL: "general"
+  });
+
+  const SAFE_COPY = Object.freeze({
+    payment:
+      "Payment slips are supporting evidence only. Confirmation happens only after official verification and fund matching.",
+    svip: "SVIP is Boss Per manual-only, never points-based.",
+    blackCard: "Black Card is private review, not automatic approval.",
+    vip: "Kenji can summarize VIP eligibility signals, but there is no automatic guarantee.",
+    booking: "Kenji can guide the booking flow, but membership and status should be checked first."
+  });
+
+  const DEMO_ONLY_MEMBER_SUMMARY = Object.freeze({
+    demo_only: true,
+    display_name: "Member",
+    membership_status: "demo_preview",
+    tier: "",
+    points_balance: null,
+    renewal_status: "unknown"
+  });
+
+  function toText(value) {
+    return value === null || value === undefined ? "" : String(value).trim();
+  }
+
+  function normalize(value) {
+    return toText(value).toLowerCase();
+  }
+
+  function asFiniteNumber(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+  }
+
+  function includesAny(text, terms) {
+    return terms.some((term) => text.includes(term));
+  }
+
+  function getPointsBalance(memberSummary) {
+    if (!memberSummary || typeof memberSummary !== "object") return null;
+    return asFiniteNumber(memberSummary.points_balance ?? memberSummary.points?.balance);
+  }
+
+  function sanitizeMemberSummary(input) {
+    const source = input && typeof input === "object" ? input : {};
+    const pointsBalance = getPointsBalance(source);
+    return {
+      demo_only: Boolean(source.demo_only),
+      display_name: toText(source.display_name || source.name),
+      membership_status: toText(source.membership_status || source.status),
+      tier: toText(source.tier || source.member_tier),
+      points_balance: pointsBalance,
+      points_updated_at: toText(source.points_updated_at),
+      renewal_status: toText(source.renewal_status),
+      last_verified_at: toText(source.last_verified_at)
+    };
+  }
+
+  function classifyIntent(input, memberSummary) {
+    const text = normalize(input);
+
+    if (!text) {
+      return { intent: INTENTS.EMPTY, priority: 100, confidence: 1 };
+    }
+
+    if (includesAny(text, ["จอง", "booking", "book", "reserve", "appointment", "session"])) {
+      return { intent: INTENTS.BOOKING, priority: 90, confidence: 0.95 };
+    }
+
+    if (includesAny(text, ["ส่งสลิป", "สลิป", "slip", "payment", "paid", "โอน", "ชำระ", "จ่าย"])) {
+      return { intent: INTENTS.PAYMENT, priority: 88, confidence: 0.95 };
+    }
+
+    if (includesAny(text, ["svip", "s vip", "super vip"])) {
+      return { intent: INTENTS.SVIP, priority: 86, confidence: 0.95 };
+    }
+
+    if (includesAny(text, ["black card", "blackcard", "บัตรดำ"])) {
+      return { intent: INTENTS.BLACK_CARD, priority: 84, confidence: 0.95 };
+    }
+
+    if (includesAny(text, ["สมาชิก", "ต่ออายุ", "renew", "renewal", "membership", "member", "status hub"])) {
+      return { intent: INTENTS.MEMBERSHIP, priority: 82, confidence: 0.9 };
+    }
+
+    if (includesAny(text, ["vip", "วีไอพี"])) {
+      return { intent: INTENTS.VIP, priority: 80, confidence: 0.9 };
+    }
+
+    if (includesAny(text, ["แต้ม", "points", "point", "คะแนน"])) {
+      return { intent: INTENTS.POINTS, priority: 70, confidence: 0.9 };
+    }
+
+    const pointsBalance = getPointsBalance(memberSummary);
+    if (pointsBalance !== null && pointsBalance >= HIGH_POINTS_THRESHOLD) {
+      return { intent: INTENTS.HIGH_POINTS, priority: 40, confidence: 0.7 };
+    }
+
+    return { intent: INTENTS.GENERAL, priority: 10, confidence: 0.5 };
+  }
+
+  function formatPoints(value) {
+    const number = asFiniteNumber(value);
+    if (number === null) return "not available";
+    return number.toLocaleString("en-US");
+  }
+
+  function memberStatusLine(memberSummary) {
+    const summary = sanitizeMemberSummary(memberSummary);
+    const parts = [];
+    if (summary.membership_status) parts.push(`status: ${summary.membership_status}`);
+    if (summary.tier) parts.push(`tier: ${summary.tier}`);
+    if (summary.points_balance !== null) parts.push(`points: ${formatPoints(summary.points_balance)}`);
+    return parts.length ? ` Current member summary: ${parts.join(", ")}.` : "";
+  }
+
+  function buildKenjiReply(input, memberSummary) {
+    const summary = sanitizeMemberSummary(memberSummary);
+    const classified = classifyIntent(input, summary);
+    const statusLine = memberStatusLine(summary);
+
+    switch (classified.intent) {
+      case INTENTS.EMPTY:
+        return "Kenji here. Tell me what you want help with today: booking, payment proof, points, VIP, SVIP, Black Card, or membership renewal.";
+      case INTENTS.BOOKING:
+        return `${SAFE_COPY.booking}${statusLine} I can help you move from Member Home / Status Hub into the right next step.`;
+      case INTENTS.PAYMENT:
+        return `${SAFE_COPY.payment} I can help you prepare the details for review without treating the slip as final confirmation.`;
+      case INTENTS.POINTS:
+        return `Your points summary is ${formatPoints(summary.points_balance)} points. Points can guide the next step, but they must not override booking, payment, SVIP, Black Card, or membership intent.`;
+      case INTENTS.VIP:
+        return `${SAFE_COPY.vip}${statusLine} I can help gather the visible signals for review.`;
+      case INTENTS.SVIP:
+        return `${SAFE_COPY.svip} I can summarize the case for the proper manual review path.`;
+      case INTENTS.BLACK_CARD:
+        return `${SAFE_COPY.blackCard} I can help prepare the member context for that private review.`;
+      case INTENTS.MEMBERSHIP:
+        return `I can help with membership status or renewal from Member Home / Status Hub.${statusLine} I will keep payment confirmation separate from official verification.`;
+      case INTENTS.HIGH_POINTS:
+        return `Your points look strong at ${formatPoints(summary.points_balance)} points. With no stronger intent detected, I can guide the next suitable member step without making automatic VIP, SVIP, or Black Card decisions.`;
+      default:
+        return `I can help from the member concierge layer. Ask me about booking, payment proof, points, VIP, SVIP, Black Card, or membership renewal.${statusLine}`;
+    }
+  }
+
+  function getAccessT(search) {
+    const params = new URLSearchParams(search || global.location?.search || "");
+    return toText(params.get("t"));
+  }
+
+  async function loadSanitizedMemberSummary(options) {
+    const config = options && typeof options === "object" ? options : {};
+    const t = toText(config.t || getAccessT(config.search));
+    if (!t) return sanitizeMemberSummary(config.demoSummary || DEMO_ONLY_MEMBER_SUMMARY);
+
+    const fetcher = config.fetch || global.fetch;
+    if (typeof fetcher !== "function") return sanitizeMemberSummary(config.demoSummary || DEMO_ONLY_MEMBER_SUMMARY);
+
+    const endpoint = toText(config.endpoint) || MEMBER_SUMMARY_ENDPOINT;
+    const url = new URL(endpoint, global.location?.origin || "https://www.mmdbkk.com");
+    url.searchParams.set("t", t);
+
+    try {
+      const response = await fetcher(url.toString(), {
+        method: "GET",
+        credentials: "same-origin",
+        headers: { Accept: "application/json" }
+      });
+      if (!response.ok) throw new Error("member_summary_unavailable");
+      const data = await response.json();
+      return sanitizeMemberSummary(data?.member || data?.summary || data);
+    } catch (error) {
+      return sanitizeMemberSummary(config.demoSummary || DEMO_ONLY_MEMBER_SUMMARY);
+    }
+  }
+
+  function setText(root, selector, value) {
+    const node = root.querySelector(selector);
+    if (node) node.textContent = value;
+  }
+
+  function bindWebflow(root, initialSummary) {
+    const input = root.querySelector("[data-kenji-input]");
+    const send = root.querySelector("[data-kenji-send]");
+    const reply = root.querySelector("[data-kenji-reply]");
+    const intent = root.querySelector("[data-kenji-intent]");
+    const state = { memberSummary: sanitizeMemberSummary(initialSummary) };
+
+    function render(value) {
+      const text = toText(value || input?.value);
+      const classified = classifyIntent(text, state.memberSummary);
+      if (reply) reply.textContent = buildKenjiReply(text, state.memberSummary);
+      if (intent) intent.textContent = classified.intent;
+    }
+
+    if (send) {
+      send.addEventListener("click", function (event) {
+        event.preventDefault();
+        render();
+      });
+    }
+
+    if (input) {
+      input.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          render();
+        }
+      });
+    }
+
+    setText(root, "[data-kenji-status]", memberStatusLine(state.memberSummary).replace(/^ Current member summary: /, ""));
+    if (!reply?.textContent) render("");
+    return { render, state };
+  }
+
+  async function boot() {
+    const roots = Array.prototype.slice.call(global.document?.querySelectorAll?.("[data-kenji-concierge]") || []);
+    if (!roots.length) return;
+    const memberSummary = await loadSanitizedMemberSummary();
+    roots.forEach((root) => bindWebflow(root, memberSummary));
+  }
+
+  const api = Object.freeze({
+    INTENTS,
+    SAFE_COPY,
+    HIGH_POINTS_THRESHOLD,
+    DEMO_ONLY_MEMBER_SUMMARY,
+    classifyIntent,
+    buildKenjiReply,
+    sanitizeMemberSummary,
+    loadSanitizedMemberSummary,
+    bindWebflow
+  });
+
+  global.MMDKenjiMemberConcierge = api;
+
+  if (typeof global.document !== "undefined") {
+    if (global.document.readyState === "loading") {
+      global.document.addEventListener("DOMContentLoaded", boot, { once: true });
+    } else {
+      boot();
+    }
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/webflow/member/kenji-ai-20/kenji-member-concierge.test.mjs
+++ b/webflow/member/kenji-ai-20/kenji-member-concierge.test.mjs
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import vm from "node:vm";
+
+const source = await readFile(new URL("./kenji-member-concierge.js", import.meta.url), "utf8");
+
+function loadConcierge(overrides = {}) {
+  const context = {
+    console,
+    URL,
+    URLSearchParams,
+    Response,
+    location: { origin: "https://www.mmdbkk.com", search: "" },
+    ...overrides
+  };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(source, context);
+  return context.MMDKenjiMemberConcierge;
+}
+
+const concierge = loadConcierge();
+
+test("empty input asks what the member wants help with", () => {
+  assert.equal(concierge.classifyIntent("  ").intent, "empty");
+  assert.match(concierge.buildKenjiReply(""), /Tell me what you want help with today/);
+});
+
+test("booking intent wins over points fallback", () => {
+  const result = concierge.classifyIntent("จอง session มี 5000 points", { points_balance: 5000 });
+  assert.equal(result.intent, "booking");
+  assert.match(concierge.buildKenjiReply("จอง", { membership_status: "active" }), /guide the booking flow/);
+  assert.match(concierge.buildKenjiReply("จอง", { membership_status: "active" }), /membership and status should be checked first/);
+});
+
+test("payment and slip intent includes official verification safety copy", () => {
+  const reply = concierge.buildKenjiReply("ส่งสลิปแล้ว");
+  assert.equal(concierge.classifyIntent("ส่งสลิปแล้ว").intent, "payment_slip");
+  assert.match(reply, /Payment slips are supporting evidence only/);
+  assert.match(reply, /official verification and fund matching/);
+});
+
+test("points intent shows points summary", () => {
+  const reply = concierge.buildKenjiReply("แต้ม", { points_balance: 875 });
+  assert.equal(concierge.classifyIntent("แต้ม", { points_balance: 875 }).intent, "points");
+  assert.match(reply, /875 points/);
+});
+
+test("VIP intent summarizes eligibility without automatic guarantee", () => {
+  const reply = concierge.buildKenjiReply("VIP", { tier: "Premium" });
+  assert.equal(concierge.classifyIntent("VIP").intent, "vip");
+  assert.match(reply, /VIP eligibility signals/);
+  assert.match(reply, /no automatic guarantee/);
+});
+
+test("SVIP intent is Boss Per manual-only and never points-based", () => {
+  const reply = concierge.buildKenjiReply("SVIP please", { points_balance: 9999 });
+  assert.equal(concierge.classifyIntent("SVIP please", { points_balance: 9999 }).intent, "svip");
+  assert.match(reply, /SVIP is Boss Per manual-only/);
+  assert.match(reply, /never points-based/);
+});
+
+test("Black Card intent is private review and not automatic approval", () => {
+  const reply = concierge.buildKenjiReply("Black Card", { points_balance: 9999 });
+  assert.equal(concierge.classifyIntent("Black Card", { points_balance: 9999 }).intent, "black_card");
+  assert.match(reply, /Black Card is private review/);
+  assert.match(reply, /not automatic approval/);
+});
+
+test("membership renewal intent wins over high points fallback", () => {
+  const result = concierge.classifyIntent("ต่ออายุสมาชิก มีแต้มเยอะ", { points_balance: 5000 });
+  assert.equal(result.intent, "membership_renewal");
+  assert.match(concierge.buildKenjiReply("renewal", { membership_status: "active" }), /membership status or renewal/);
+});
+
+test("high points fallback applies only when there is no stronger intent", () => {
+  const result = concierge.classifyIntent("what should I do next", { points_balance: 2400 });
+  const reply = concierge.buildKenjiReply("what should I do next", { points_balance: 2400 });
+  assert.equal(result.intent, "high_points_fallback");
+  assert.match(reply, /points look strong/);
+  assert.match(reply, /without making automatic VIP, SVIP, or Black Card decisions/);
+});
+
+test("sanitized member summary exposes only safe member fields", () => {
+  const summary = concierge.sanitizeMemberSummary({
+    display_name: "Ken",
+    membership_status: "active",
+    tier: "VIP",
+    points_balance: 1200,
+    secret: "do-not-ship",
+    api_key: "do-not-ship",
+    private_note: "do-not-ship"
+  });
+  assert.deepEqual(Object.keys(summary), [
+    "demo_only",
+    "display_name",
+    "membership_status",
+    "tier",
+    "points_balance",
+    "points_updated_at",
+    "renewal_status",
+    "last_verified_at"
+  ]);
+  assert.equal(summary.display_name, "Ken");
+  assert.equal(summary.points_balance, 1200);
+});
+
+test("member summary fetch uses t query param only", async () => {
+  const calls = [];
+  const api = loadConcierge({
+    location: { origin: "https://www.mmdbkk.com", search: "?t=abc123&debug=1" },
+    fetch: async (url) => {
+      calls.push(String(url));
+      return new Response(JSON.stringify({ member: { membership_status: "active", points_balance: 1500 } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+  });
+
+  const summary = await api.loadSanitizedMemberSummary();
+  assert.equal(summary.membership_status, "active");
+  assert.equal(summary.points_balance, 1500);
+  assert.equal(new URL(calls[0]).searchParams.get("t"), "abc123");
+  assert.deepEqual(Array.from(new URL(calls[0]).searchParams.keys()), ["t"]);
+});
+
+test("missing backend uses clearly isolated demo-only fallback", async () => {
+  const api = loadConcierge({
+    location: { origin: "https://www.mmdbkk.com", search: "" }
+  });
+  const summary = await api.loadSanitizedMemberSummary();
+  assert.equal(summary.demo_only, true);
+  assert.equal(summary.membership_status, "demo_preview");
+});


### PR DESCRIPTION
## Summary
- Add Webflow-safe Kenji Member Concierge layer for /member/kenji-ai-20
- Add testable intent classifier and reply builder with safe intent priority
- Document member route meaning, t-only query use, demo-only fallback, and payment/SVIP/Black Card safety rules

## Tests
- npm test
- node --test webflow/member/kenji-ai-20/kenji-member-concierge.test.mjs

## Safety
- No promo/access-code flow included
- No frontend secrets added
- Uses query param t only
- Does not create chat-worker/kv-list.json or modify wrangler 2.toml