### PR TITLE
fix: polish front-gate recovery pages

### DIFF
--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -1,14 +1,23 @@
 /**
- * MMD public front-door route guard.
- *
- * Keeps canonical redirects small and lets the member-facing routes be served
- * by immigrate-worker without falling through to Webflow, payment, or JSON API
- * auth responses.
+ * MMD Permanent Redirect Guard
+ * Purpose:
+ * - Canonicalize host/protocol
+ * - Preserve every path and query string, including ?t=
+ * - Redirect legacy paths permanently
+ * - Avoid redirect loops
+ * - Do NOT touch API/payment/webhook/admin endpoints
  */
 
 export const CANONICAL_HOST = "mmdbkk.com";
 export const CANONICAL_PROTOCOL = "https:";
+export const CONFIRM_PAYMENT_PATH = "/confirm/payment-confirmation";
+export const MEMBER_DASHBOARD_UPSTREAM = "https://immigrate-worker.malemodel-bkk.workers.dev";
+export const ADMIN_WORKER_UPSTREAM = "https://admin-worker.malemodel-bkk.workers.dev";
+export const FRONT_GATE = "mmd-redirect-worker";
+export const FRONT_VERSION = "20260616T051100Z";
 
+// Domains that should redirect into the canonical site.
+// Add/remove domains here only.
 export const REDIRECT_HOSTS = new Set([
   "www.mmdbkk.com",
   "mmdbkk.com",
@@ -17,8 +26,11 @@ export const REDIRECT_HOSTS = new Set([
   "malemodel-bkk.workers.dev",
 ]);
 
+// Subdomains or hosts that must never be redirected by this worker.
 export const NEVER_TOUCH_HOSTS = new Set(["sigil.mmdbkk.com"]);
 
+// These are not normal public pages.
+// Do not redirect payment/API/webhook/admin traffic unless intentionally designed.
 export const NEVER_TOUCH_PREFIXES = [
   "/api/",
   "/webhook/",
@@ -35,13 +47,25 @@ export const NEVER_TOUCH_PREFIXES = [
   "/uploads/",
 ];
 
-export const MEMBER_FRONTEND_PATHS = new Set([
+// Host-agnostic front-router protected pages owned by another Worker/source.
+// These paths must pass through exactly, with query strings preserved, so the
+// member dashboard cannot accidentally fall back to Webflow or legacy redirects
+// on either mmdbkk.com or www.mmdbkk.com.
+export const NEVER_REDIRECT_EXACT_PATHS = new Set([
   "/member/dashboard",
   "/member/dashboard/",
   "/member/membership",
   "/member/membership/",
+  "/member/payments",
+  "/member/payments/",
+  "/hall",
+  "/hall/",
+  "/model/console",
+  "/model/console/",
 ]);
 
+// Exact old-path to new-path redirects.
+// Keep lowercase keys. The target can keep proper casing if needed.
 export const EXACT_PATH_REDIRECTS = {
   "/inme": "/trust/inme",
   "/login": "/trust/inme",
@@ -54,9 +78,17 @@ export const EXACT_PATH_REDIRECTS = {
   "/trust": "/trust/inme",
 };
 
+// Folder-level redirects.
+// Example: /old-academy/anything -> /academy/anything
 export const FOLDER_REDIRECTS = [
-  { from: "/old-academy/", to: "/academy/" },
-  { from: "/old-trust/", to: "/trust/" },
+  {
+    from: "/old-academy/",
+    to: "/academy/",
+  },
+  {
+    from: "/old-trust/",
+    to: "/trust/",
+  },
 ];
 
 export function isSafePageRequest(request) {
@@ -66,19 +98,25 @@ export function isSafePageRequest(request) {
 
 export function normalizePath(pathname) {
   let path = pathname || "/";
-  path = path.replace(/\/{2,}/g, "/");
-  if (path.length > 1) path = path.replace(/\/+$/g, "");
-  return path || "/";
-}
 
-export function isMemberFrontendPath(url) {
-  return MEMBER_FRONTEND_PATHS.has(url.pathname.toLowerCase());
+  // Collapse duplicate slashes: /a//b -> /a/b
+  path = path.replace(/\/{2,}/g, "/");
+
+  // Remove trailing slash except root.
+  // Example: /trust/inme/ -> /trust/inme
+  if (path.length > 1) {
+    path = path.replace(/\/+$/g, "");
+  }
+
+  return path || "/";
 }
 
 export function shouldNeverTouch(url) {
   if (NEVER_TOUCH_HOSTS.has(url.hostname)) return true;
 
   const pathname = url.pathname.toLowerCase();
+  if (NEVER_REDIRECT_EXACT_PATHS.has(pathname)) return true;
+
   return NEVER_TOUCH_PREFIXES.some((prefix) => {
     return pathname === prefix.slice(0, -1) || pathname.startsWith(prefix);
   });
@@ -89,25 +127,292 @@ export function buildTargetUrl(originalUrl, nextPathname) {
   target.protocol = CANONICAL_PROTOCOL;
   target.hostname = CANONICAL_HOST;
   target.pathname = nextPathname;
+  // target.search is preserved automatically.
   return target;
 }
 
-export async function fetchMemberFrontend(request, env, url) {
-  if (env?.IMMIGRATE_WORKER?.fetch) {
-    return env.IMMIGRATE_WORKER.fetch(request);
+function withFrontGateHeaders(response) {
+  const headers = new Headers(response.headers);
+  headers.set("x-mmd-front-gate", FRONT_GATE);
+  headers.set("x-mmd-front-version", FRONT_VERSION);
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function isConfirmPaymentPage(url) {
+  return url.pathname === CONFIRM_PAYMENT_PATH || url.pathname === `${CONFIRM_PAYMENT_PATH}/`;
+}
+
+function confirmPaymentDashboardBridgeScript() {
+  return `<script id="mmd-confirm-dashboard-bridge">
+(function(){
+  if (window.__MMD_CONFIRM_DASHBOARD_BRIDGE__) return;
+  window.__MMD_CONFIRM_DASHBOARD_BRIDGE__ = true;
+  var originalFetch = window.fetch;
+  if (typeof originalFetch !== "function") return;
+  function getDashboardUrl(payload){
+    var fromPayload = payload && (payload.dashboard_url || payload.dashboard_access && payload.dashboard_access.dashboard_url) || "";
+    if (fromPayload) return fromPayload;
+    var params = new URLSearchParams(window.location.search || "");
+    var token = params.get("t") || "";
+    if (token) return "/member/dashboard?t=" + encodeURIComponent(token);
+    var root = document.getElementById("mmd-payment-confirmation");
+    return root && root.getAttribute("data-dashboard-url") || "/sigil/member/account";
+  }
+  window.fetch = function(input, init){
+    var requestUrl = "";
+    try {
+      requestUrl = typeof input === "string" ? input : input && input.url || "";
+    } catch (_) {}
+    var result = originalFetch.apply(this, arguments);
+    if (!/(\\/v1\\/payments\\/notify(?:\\?|$)|\\/sigil\\/api\\/payments\\/manual-intake(?:\\?|$))/.test(requestUrl)) return result;
+    return result.then(function(response){
+      try {
+        response.clone().json().then(function(payload){
+          var dashboardUrl = getDashboardUrl(payload);
+          if (!dashboardUrl) return;
+          try {
+            sessionStorage.setItem("mmd_pay_membership_confirm_state_v2026_04", JSON.stringify({
+              status: "paid",
+              dashboard_url: dashboardUrl,
+              paid_at: new Date().toISOString()
+            }));
+          } catch (_) {}
+          var link = document.getElementById("mmdrenew-dashboard-link");
+          if (link) link.href = dashboardUrl;
+          window.setTimeout(function(){
+            window.location.href = dashboardUrl;
+          }, 900);
+        }).catch(function(){});
+      } catch (_) {}
+      return response;
+    });
+  };
+})();
+</script>`;
+}
+
+async function maybeInjectConfirmPaymentBridge(request, response, url) {
+  if (request.method.toUpperCase() === "HEAD") return response;
+  if (!isConfirmPaymentPage(url)) return response;
+  const contentType = response.headers.get("content-type") || "";
+  if (!contentType.toLowerCase().includes("text/html")) return response;
+
+  const html = await response.text();
+  if (html.includes("mmd-confirm-dashboard-bridge")) {
+    return new Response(html, response);
   }
 
-  const target = new URL("https://immigrate-worker.malemodel-bkk.workers.dev");
+  const script = confirmPaymentDashboardBridgeScript();
+  const rewritten = html.includes("</body>")
+    ? html.replace("</body>", `${script}</body>`)
+    : `${html}${script}`;
+  const headers = new Headers(response.headers);
+  headers.delete("content-length");
+  return new Response(rewritten, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+async function fetchPassThrough(request) {
+  const url = new URL(request.url);
+  const response = await fetch(new Request(request, { redirect: "follow" }));
+  return withFrontGateHeaders(await maybeInjectConfirmPaymentBridge(request, response, url));
+}
+
+function isMemberDashboardPath(url) {
+  const pathname = url.pathname.toLowerCase();
+  return pathname === "/member/dashboard" || pathname === "/member/dashboard/";
+}
+
+function isMemberMembershipPath(url) {
+  const pathname = url.pathname.toLowerCase();
+  return pathname === "/member/membership" || pathname === "/member/membership/";
+}
+
+function isMemberPaymentsPath(url) {
+  const pathname = url.pathname.toLowerCase();
+  return pathname === "/member/payments" || pathname === "/member/payments/";
+}
+
+function isHallPath(url) {
+  const pathname = url.pathname.toLowerCase();
+  return pathname === "/hall" || pathname === "/hall/";
+}
+
+function isModelConsolePath(url) {
+  const pathname = url.pathname.toLowerCase();
+  return pathname === "/model/console" || pathname === "/model/console/";
+}
+
+function isMemberPath(url) {
+  const pathname = url.pathname.toLowerCase();
+  return pathname === "/member" || pathname === "/member/" || pathname.startsWith("/member/");
+}
+
+function isKnownLegacyMemberRedirect(url) {
+  const pathname = normalizePath(url.pathname).toLowerCase();
+  return Boolean(EXACT_PATH_REDIRECTS[pathname]);
+}
+
+function isMemberFrontendPath(url) {
+  return isMemberDashboardPath(url) || isMemberMembershipPath(url);
+}
+
+async function fetchMemberFrontend(request, env, url) {
+  // TODO(member-route-migration): /member/dashboard and /member/membership are
+  // legacy locked routes still owned by immigrate-worker. Do not add new
+  // member-facing route dependencies here; migrate these to the canonical
+  // member layer when it is ready.
+  if (env?.IMMIGRATE_WORKER?.fetch) {
+    return withFrontGateHeaders(await env.IMMIGRATE_WORKER.fetch(request));
+  }
+
+  const target = new URL(MEMBER_DASHBOARD_UPSTREAM);
   target.pathname = url.pathname;
   target.search = url.search;
-  return fetch(new Request(target.toString(), request));
+  return withFrontGateHeaders(await fetch(new Request(target.toString(), request)));
+}
+
+async function fetchAdminMemberPage(request, env, url) {
+  if (env?.ADMIN_WORKER?.fetch) {
+    return withFrontGateHeaders(await env.ADMIN_WORKER.fetch(request));
+  }
+
+  const target = new URL(ADMIN_WORKER_UPSTREAM);
+  target.pathname = url.pathname;
+  target.search = url.search;
+  return withFrontGateHeaders(await fetch(new Request(target.toString(), request)));
+}
+
+function formatMemberPageHeading(pathname) {
+  const slug = normalizePath(pathname).split("/").filter(Boolean).at(-1) || "";
+  const words = slug
+    .replace(/[^a-z0-9-]+/gi, "-")
+    .split("-")
+    .filter(Boolean)
+    .slice(0, 6);
+
+  if (!words.length) return "Member Page";
+
+  return words
+    .map((word) => {
+      if (/^\d+$/.test(word) || word.length <= 2) return word.toUpperCase();
+      return `${word.charAt(0).toUpperCase()}${word.slice(1).toLowerCase()}`;
+    })
+    .join(" ");
+}
+
+function renderRouteRecoveryShell(request, page, title, heading, copy, links = []) {
+  const url = new URL(request.url);
+  const query = url.search || "";
+  const renderedLinks = links
+    .map((link, index) => {
+      const href = `${link.href}${query}`;
+      const className = index === 0 ? ` class="primary"` : "";
+      return `<a${className} href="${href}">${link.label}</a>`;
+    })
+    .join("");
+  const html = `<!doctype html>
+<html lang="th">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${title}</title>
+    <style>
+      :root { color-scheme: dark; }
+      * { box-sizing: border-box; letter-spacing: 0; }
+      html { min-height: 100%; background: #050403; }
+      body { margin: 0; min-height: 100vh; padding: 22px; background: radial-gradient(circle at top left, #241907 0, #090705 36%, #050403 100%); color: #fff7e8; font-family: Inter, "Avenir Next", "Segoe UI", "Noto Sans Thai", Arial, sans-serif; }
+      main { width: min(780px, 100%); margin: 0 auto; padding: 28px 0 40px; display: block; }
+      .brand { margin: 0 0 14px; color: #ffd784; font-size: 13px; font-weight: 900; line-height: 1.4; text-transform: uppercase; }
+      h1 { margin: 0 0 16px; color: #ffffff; font-size: clamp(38px, 12vw, 76px); line-height: 1; overflow-wrap: anywhere; }
+      p { margin: 0 0 16px; color: #fff1d5; font-size: 17px; line-height: 1.65; }
+      .actions { margin-top: 14px; }
+      a { min-height: 46px; display: inline-flex; align-items: center; justify-content: center; margin: 8px 8px 0 0; padding: 0 16px; border: 1px solid #d8ad5a; border-radius: 999px; color: #fff7e8; background: #17110a; text-decoration: none; font-weight: 850; line-height: 1.2; }
+      a.primary { color: #130d05; background: #ffd784; border-color: #ffd784; }
+    </style>
+  </head>
+  <body>
+    <main data-mmd-page-shell="${page}">
+      <p class="brand">MMD Privé</p>
+      <h1>${heading}</h1>
+      <p>${copy}</p>
+      <p class="actions">${renderedLinks}</p>
+    </main>
+  </body>
+</html>`;
+
+  return new Response(request.method.toUpperCase() === "HEAD" ? null : html, {
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0",
+      "pragma": "no-cache",
+      "expires": "0",
+      "x-mmd-worker": "mmd-redirect-worker",
+      "x-mmd-front-gate": FRONT_GATE,
+      "x-mmd-front-version": FRONT_VERSION,
+      "x-mmd-page": page,
+      "x-mmd-temporary-route": "true",
+    },
+  });
+}
+
+function renderMemberStaticRecovery(request) {
+  const heading = formatMemberPageHeading(new URL(request.url).pathname);
+  return renderRouteRecoveryShell(
+    request,
+    "member-static",
+    "MMD Privé | Member",
+    heading,
+    "หน้านี้อยู่ในพื้นที่สมาชิกของ MMD Privé และพร้อมเชื่อมต่อกับเนื้อหาหลักในขั้นต่อไป",
+    [
+      { label: "Enter Member Area", href: "/member/dashboard" },
+      { label: "Membership", href: "/member/membership" },
+    ],
+  );
+}
+
+function renderHallRecovery(request) {
+  return renderRouteRecoveryShell(
+    request,
+    "hall",
+    "MMD Privé | Hall",
+    "MMD Hall",
+    "พื้นที่กลางสำหรับเข้าสู่ระบบสมาชิก ตรวจสถานะ และไปต่อยังเส้นทางที่เกี่ยวข้องของ MMD Privé",
+    [
+      { label: "Enter Member Area", href: "/member/dashboard" },
+      { label: "Member Payments", href: "/member/payments" },
+    ],
+  );
+}
+
+function renderModelConsoleRecovery(request) {
+  return renderRouteRecoveryShell(
+    request,
+    "model-console",
+    "MMD Privé | Model Console",
+    "Model Console",
+    "พื้นที่สำหรับผู้ให้บริการตรวจสถานะงานและไปต่อยังขั้นตอนที่เกี่ยวข้องของ MMD Privé",
+    [
+      { label: "Continue", href: "/v1/model/session/dashboard" },
+      { label: "Member Area", href: "/member/dashboard" },
+    ],
+  );
 }
 
 export function findMappedPath(pathname) {
   const normalized = normalizePath(pathname);
   const key = normalized.toLowerCase();
 
-  if (EXACT_PATH_REDIRECTS[key]) return EXACT_PATH_REDIRECTS[key];
+  if (EXACT_PATH_REDIRECTS[key]) {
+    return EXACT_PATH_REDIRECTS[key];
+  }
 
   for (const rule of FOLDER_REDIRECTS) {
     const fromLower = rule.from.toLowerCase();
@@ -124,33 +429,55 @@ export default {
   async fetch(request, env = {}) {
     const url = new URL(request.url);
 
+    // Safety: never redirect non-page traffic.
+    // This prevents breaking POST/payment/webhook/API flows.
     if (!isSafePageRequest(request)) {
-      return fetch(request);
+      return withFrontGateHeaders(await fetch(request));
     }
 
     if (isMemberFrontendPath(url)) {
       return fetchMemberFrontend(request, env, url);
     }
 
-    if (shouldNeverTouch(url)) {
-      return fetch(request);
+    if (isMemberPaymentsPath(url)) {
+      return fetchAdminMemberPage(request, env, url);
     }
 
+    if (isHallPath(url)) {
+      return renderHallRecovery(request);
+    }
+
+    if (isModelConsolePath(url)) {
+      return renderModelConsoleRecovery(request);
+    }
+
+    if (isMemberPath(url) && !isKnownLegacyMemberRedirect(url)) {
+      return renderMemberStaticRecovery(request);
+    }
+
+    if (shouldNeverTouch(url)) {
+      return fetchPassThrough(request);
+    }
+
+    // If this host is not managed by this redirect worker, pass through.
     if (!REDIRECT_HOSTS.has(url.hostname)) {
-      return fetch(request);
+      return fetchPassThrough(request);
     }
 
     const mappedPath = findMappedPath(url.pathname);
     const target = buildTargetUrl(url, mappedPath);
+
     const needsRedirect =
       url.protocol !== CANONICAL_PROTOCOL ||
       url.hostname !== CANONICAL_HOST ||
       url.pathname !== mappedPath;
 
+    // Prevent redirect loop.
     if (!needsRedirect || target.toString() === url.toString()) {
-      return fetch(request);
+      return fetchPassThrough(request);
     }
 
-    return Response.redirect(target.toString(), 301);
+    // 301 = permanent redirect for public pages.
+    return withFrontGateHeaders(Response.redirect(target.toString(), 301));
   },
 };

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -1,42 +1,498 @@
 import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
 import worker, {
   findMappedPath,
-  isMemberFrontendPath,
+  normalizePath,
   shouldNeverTouch,
 } from "../src/index.js";
 
-assert.equal(findMappedPath("/login"), "/trust/inme");
-assert.equal(findMappedPath("/member/membership/benefits"), "/pay/membership");
-assert.equal(findMappedPath("/member/dashboard"), "/member/dashboard");
+let originalFetch;
+let passThroughRequests;
 
-assert.equal(isMemberFrontendPath(new URL("https://mmdbkk.com/member/dashboard?t=abc&debug=1")), true);
-assert.equal(isMemberFrontendPath(new URL("https://mmdbkk.com/member/membership?code=abc&promo=gold")), true);
-assert.equal(shouldNeverTouch(new URL("https://mmdbkk.com/pay/membership")), true);
-assert.equal(shouldNeverTouch(new URL("https://mmdbkk.com/sigil/admin/login")), true);
-
-{
-  const response = await worker.fetch(new Request("https://www.mmdbkk.com/login?debug=1"));
-  assert.equal(response.status, 301);
-  assert.equal(response.headers.get("location"), "https://mmdbkk.com/trust/inme?debug=1");
-}
-
-{
-  const env = {
-    IMMIGRATE_WORKER: {
-      fetch(request) {
-        const url = new URL(request.url);
-        return new Response("member", {
-          status: 200,
-          headers: {
-            "x-test-path": url.pathname,
-            "x-test-query": url.search,
-          },
-        });
-      },
-    },
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  passThroughRequests = [];
+  globalThis.fetch = async (request) => {
+    passThroughRequests.push(request);
+    return new Response("pass-through", {
+      status: 209,
+      headers: { "x-test-pass-through": "1" },
+    });
   };
-  const response = await worker.fetch(new Request("https://mmdbkk.com/member/dashboard?t=abc&code=gold&debug=1"), env);
-  assert.equal(response.status, 200);
-  assert.equal(response.headers.get("x-test-path"), "/member/dashboard");
-  assert.equal(response.headers.get("x-test-query"), "?t=abc&code=gold&debug=1");
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function request(url, init) {
+  return worker.fetch(new Request(url, init));
 }
+
+async function requestWithEnv(url, env, init) {
+  return worker.fetch(new Request(url, init), env);
+}
+
+const VISIBLE_DEBUG_TEXT = [
+  "Front Gate Active",
+  "Route recovery shell",
+  "x-mmd-page",
+  "x-mmd-front-gate",
+  "x-mmd-front-version",
+  "fallback",
+  "recovery",
+];
+
+function assertPolishedShell(html, url) {
+  assert.doesNotMatch(html, /name=["']token["']/i, url);
+  for (const text of VISIBLE_DEBUG_TEXT) {
+    assert.doesNotMatch(html, new RegExp(text, "i"), `${url} should not show ${text}`);
+  }
+}
+
+describe("MMD permanent redirect guard", () => {
+  it("canonicalizes www legacy paths and preserves query strings", async () => {
+    const response = await request("http://www.mmdbkk.com/inme?t=abc123&ref=line");
+
+    assert.equal(response.status, 301);
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/trust/inme?t=abc123&ref=line");
+    assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("maps /login to /trust/inme and preserves ?t=", async () => {
+    const response = await request("https://mmdbkk.com/login?t=abc");
+
+    assert.equal(response.status, 301);
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/trust/inme?t=abc");
+  });
+
+  it("maps /member and /membership to the membership benefits page", async () => {
+    const member = await request("https://mmdbkk.com/member?t=abc");
+    const membership = await request("https://www.mmdbkk.com/membership?t=abc");
+
+    assert.equal(member.status, 301);
+    assert.equal(member.headers.get("location"), "https://mmdbkk.com/membership/benefits?t=abc");
+    assert.equal(membership.status, 301);
+    assert.equal(membership.headers.get("location"), "https://mmdbkk.com/membership/benefits?t=abc");
+  });
+
+  it("delegates /member/dashboard to immigrate-worker by service binding without redirecting or changing query strings", async () => {
+    const serviceRequests = [];
+    const env = {
+      IMMIGRATE_WORKER: {
+        fetch: async (request) => {
+          serviceRequests.push(request);
+          return new Response("member dashboard", {
+            status: 200,
+            headers: { "x-mmd-worker": "immigrate-worker", "x-mmd-page": "member-dashboard" },
+          });
+        },
+      },
+    };
+
+    const urls = [
+      "https://mmdbkk.com/member/dashboard",
+      "https://mmdbkk.com/member/dashboard/",
+      "https://mmdbkk.com/member/dashboard?t=abc&code=x&promo=y&debug=1",
+      "https://www.mmdbkk.com/member/dashboard?t=abc&code=x&promo=y&debug=1",
+    ];
+
+    for (const url of urls) {
+      const response = await requestWithEnv(url, env);
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null);
+      assert.equal(response.headers.get("x-mmd-page"), "member-dashboard");
+      assert.equal(serviceRequests.at(-1).url, url);
+    }
+
+    assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("delegates /member/membership to immigrate-worker by service binding without redirecting or changing query strings", async () => {
+    const serviceRequests = [];
+    const env = {
+      IMMIGRATE_WORKER: {
+        fetch: async (request) => {
+          serviceRequests.push(request);
+          return new Response("member membership", {
+            status: 200,
+            headers: { "x-mmd-worker": "immigrate-worker", "x-mmd-page": "member-membership" },
+          });
+        },
+      },
+    };
+
+    const urls = [
+      "https://mmdbkk.com/member/membership",
+      "https://www.mmdbkk.com/member/membership",
+      "https://mmdbkk.com/member/membership/",
+      "https://www.mmdbkk.com/member/membership/",
+      "https://mmdbkk.com/member/membership?t=abc&code=x&promo=y&debug=1",
+      "https://www.mmdbkk.com/member/membership?t=abc&code=x&promo=y&debug=1",
+    ];
+
+    for (const url of urls) {
+      const response = await requestWithEnv(url, env);
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null);
+      assert.equal(response.headers.get("x-mmd-page"), "member-membership");
+      assert.equal(serviceRequests.at(-1).url, url);
+    }
+
+    assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("delegates /member/payments to admin-worker without redirecting or changing query strings", async () => {
+    const adminRequests = [];
+    const env = {
+      ADMIN_WORKER: {
+        fetch: async (request) => {
+          adminRequests.push(request);
+          const query = new URL(request.url).search;
+          return new Response(`<a href="/member/dashboard${query}">Dashboard</a>`, {
+            status: 200,
+            headers: { "x-mmd-worker": "admin-worker", "x-mmd-page": "member-payments" },
+          });
+        },
+      },
+    };
+
+    const urls = [
+      "https://mmdbkk.com/member/payments?t=abc",
+      "https://mmdbkk.com/member/payments/?t=abc",
+      "https://www.mmdbkk.com/member/payments?t=abc&code=x&promo=y&debug=1",
+    ];
+
+    for (const url of urls) {
+      const response = await requestWithEnv(url, env);
+      const html = await response.text();
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-mmd-worker"), "admin-worker", url);
+      assert.equal(response.headers.get("x-mmd-page"), "member-payments", url);
+      assert.match(html, new RegExp(`/member/dashboard\\${new URL(url).search}`), url);
+      assert.doesNotMatch(html, /name=["']token["']/i, url);
+      assert.equal(adminRequests.at(-1).url, url);
+    }
+
+    assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("renders /hall as a polished MMD Privé page without redirecting or changing query strings", async () => {
+    const urls = [
+      "https://mmdbkk.com/hall?t=abc&cb=test",
+      "https://mmdbkk.com/hall/?t=abc&cb=test",
+      "https://www.mmdbkk.com/hall?t=abc&code=x&promo=y&debug=1",
+    ];
+
+    for (const url of urls) {
+      const response = await request(url);
+      const html = await response.text();
+      const query = new URL(url).search;
+
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-mmd-worker"), "mmd-redirect-worker", url);
+      assert.equal(response.headers.get("x-mmd-page"), "hall", url);
+      assert.equal(response.headers.get("x-mmd-temporary-route"), "true", url);
+      assert.equal(response.headers.get("cache-control"), "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0", url);
+      assert.equal(response.headers.get("pragma"), "no-cache", url);
+      assert.equal(response.headers.get("expires"), "0", url);
+      assert.match(html, /MMD Hall/, url);
+      assert.match(html, /พื้นที่กลางสำหรับเข้าสู่ระบบสมาชิก/, url);
+      assert.ok(html.includes(`/member/dashboard${query}`), url);
+      assert.ok(html.includes(`/member/payments${query}`), url);
+      assertPolishedShell(html, url);
+    }
+
+    assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("renders unknown /member/* routes as polished MMD Privé pages without redirecting", async () => {
+    const urls = [
+      "https://mmdbkk.com/member/kenji-20-ai?t=abc&cb=test",
+      "https://mmdbkk.com/member/some-new-page?t=abc&cb=test",
+      "https://www.mmdbkk.com/member/kenji-20-ai?t=abc&code=x&promo=y&debug=1",
+    ];
+
+    for (const url of urls) {
+      const response = await request(url);
+      const html = await response.text();
+      const query = new URL(url).search;
+
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-mmd-page"), "member-static", url);
+      assert.equal(response.headers.get("x-mmd-temporary-route"), "true", url);
+      assert.match(html, url.includes("kenji-20-ai") ? /Kenji 20 AI/ : /Some New Page/, url);
+      assert.match(html, /หน้านี้อยู่ในพื้นที่สมาชิกของ MMD Privé/, url);
+      assert.ok(html.includes(`/member/dashboard${query}`), url);
+      assert.ok(html.includes(`/member/membership${query}`), url);
+      assertPolishedShell(html, url);
+    }
+
+    assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("renders /model/console as a polished MMD Privé page without redirecting", async () => {
+    const urls = [
+      "https://mmdbkk.com/model/console?t=abc&cb=test",
+      "https://www.mmdbkk.com/model/console?t=abc&debug=1",
+    ];
+
+    for (const url of urls) {
+      const response = await request(url);
+      const html = await response.text();
+      const query = new URL(url).search;
+
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-mmd-page"), "model-console", url);
+      assert.equal(response.headers.get("x-mmd-temporary-route"), "true", url);
+      assert.match(html, /Model Console/, url);
+      assert.match(html, /พื้นที่สำหรับผู้ให้บริการตรวจสถานะงาน/, url);
+      assert.ok(html.includes(`/v1/model/session/dashboard${query}`), url);
+      assert.ok(html.includes(`/member/dashboard${query}`), url);
+      assertPolishedShell(html, url);
+    }
+
+    assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("falls back to the immigrate-worker upstream for /member/membership when service binding is missing", async () => {
+    globalThis.fetch = async (request) => {
+      passThroughRequests.push(request);
+      return new Response("membership upstream", {
+        status: 200,
+        headers: { "x-mmd-worker": "immigrate-worker", "x-mmd-page": "member-membership" },
+      });
+    };
+
+    const urls = [
+      "https://mmdbkk.com/member/membership",
+      "https://mmdbkk.com/member/membership/",
+      "https://mmdbkk.com/member/membership?t=abc&code=x&promo=y&debug=1",
+    ];
+
+    for (const url of urls) {
+      const response = await request(url);
+      const expected = new URL(url);
+      expected.protocol = "https:";
+      expected.hostname = "immigrate-worker.malemodel-bkk.workers.dev";
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null);
+      assert.equal(passThroughRequests.at(-1).url, expected.toString());
+    }
+  });
+
+  it("proxies /member/dashboard on both hosts without redirecting or changing query strings", async () => {
+    const urls = [
+      "https://mmdbkk.com/member/dashboard?t=test",
+      "https://www.mmdbkk.com/member/dashboard?t=test",
+      "https://mmdbkk.com/member/dashboard/?t=test",
+      "https://www.mmdbkk.com/member/dashboard/?t=test",
+      "https://mmdbkk.com/member/dashboard?code=KJ-PRV-TEST01",
+      "https://www.mmdbkk.com/member/dashboard?code=KJ-PRV-TEST01",
+      "https://mmdbkk.com/member/dashboard?promo=KJ-PRV-TEST01",
+      "https://www.mmdbkk.com/member/dashboard?promo=KJ-PRV-TEST01",
+      "https://mmdbkk.com/member/dashboard?t=test&code=KJ-PRV-TEST01",
+      "https://www.mmdbkk.com/member/dashboard?t=test&code=KJ-PRV-TEST01",
+      "https://mmdbkk.com/member/dashboard?t=test&promo=KJ-PRV-TEST01",
+      "https://www.mmdbkk.com/member/dashboard?t=test&promo=KJ-PRV-TEST01",
+      "https://mmdbkk.com/member/dashboard/?t=test&code=KJ-PRV-TEST01",
+      "https://www.mmdbkk.com/member/dashboard/?t=test&code=KJ-PRV-TEST01",
+      "https://mmdbkk.com/member/dashboard/?t=test&promo=KJ-PRV-TEST01",
+      "https://www.mmdbkk.com/member/dashboard/?t=test&promo=KJ-PRV-TEST01",
+    ];
+
+    for (const url of urls) {
+      const response = await request(url);
+      const expected = new URL(url);
+      expected.protocol = "https:";
+      expected.hostname = "immigrate-worker.malemodel-bkk.workers.dev";
+      assert.equal(response.status, 209, url);
+      assert.equal(passThroughRequests.at(-1).url, expected.toString());
+      assert.equal(response.headers.get("location"), null);
+    }
+  });
+
+  it("keeps /pay/membership separate as the payment page pass-through", async () => {
+    const response = await request("https://mmdbkk.com/pay/membership?t=abc&code=x&promo=y&debug=1");
+
+    assert.equal(response.status, 209);
+    assert.equal(response.headers.get("location"), null);
+    assert.equal(response.headers.get("x-test-pass-through"), "1");
+    assert.equal(passThroughRequests.at(-1).url, "https://mmdbkk.com/pay/membership?t=abc&code=x&promo=y&debug=1");
+  });
+
+  it("maps nested /member/membership paths to /pay/membership paths", async () => {
+    const response = await request("https://www.mmdbkk.com/member/membership/benefits?t=abc");
+
+    assert.equal(response.status, 301);
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/pay/membership?t=abc");
+  });
+
+  it("maps /member/membership/benefits directly to /pay/membership", async () => {
+    const response = await request("https://mmdbkk.com/member/membership/benefits?t=abc");
+
+    assert.equal(response.status, 301);
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/pay/membership?t=abc");
+  });
+
+  it("canonicalizes www host without changing query parameter order or names", async () => {
+    const response = await request("https://www.mmdbkk.com/path?x=1&t=abc");
+
+    assert.equal(response.status, 301);
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/path?x=1&t=abc");
+  });
+
+  it("redirects legacy domains to canonical host while preserving normalized paths", async () => {
+    const response = await request("https://www.mmdprive.com/old-trust/a//b/?t=tok");
+
+    assert.equal(response.status, 301);
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/trust/a/b?t=tok");
+  });
+
+  it("normalizes duplicate and trailing slashes on managed hosts", async () => {
+    const response = await request("https://mmdbkk.com/trust//inme/?t=kept");
+
+    assert.equal(response.status, 301);
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/trust/inme?t=kept");
+  });
+
+  it("redirects a trailing slash once and then passes through canonical target", async () => {
+    const first = await request("https://mmdbkk.com/trust/inme/");
+    assert.equal(first.status, 301);
+    assert.equal(first.headers.get("location"), "https://mmdbkk.com/trust/inme");
+
+    const second = await request(first.headers.get("location"));
+    assert.equal(second.status, 209);
+    assert.equal(passThroughRequests.length, 1);
+  });
+
+  it("normalizes duplicate slashes once and then passes through canonical target", async () => {
+    const first = await request("https://mmdbkk.com/trust//inme");
+    assert.equal(first.status, 301);
+    assert.equal(first.headers.get("location"), "https://mmdbkk.com/trust/inme");
+
+    const second = await request(first.headers.get("location"));
+    assert.equal(second.status, 209);
+    assert.equal(passThroughRequests.length, 1);
+  });
+
+  it("passes through canonical URLs that do not need changes", async () => {
+    const response = await request("https://mmdbkk.com/about?t=abc");
+
+    assert.equal(response.status, 209);
+    assert.equal(response.headers.get("x-test-pass-through"), "1");
+    assert.equal(passThroughRequests.length, 1);
+  });
+
+  it("passes through already canonical /trust/inme", async () => {
+    const response = await request("https://mmdbkk.com/trust/inme");
+
+    assert.equal(response.status, 209);
+    assert.equal(passThroughRequests.length, 1);
+  });
+
+  it("passes through unsafe methods", async () => {
+    const response = await request("https://www.mmdbkk.com/inme?t=abc", { method: "POST" });
+
+    assert.equal(response.status, 209);
+    assert.equal(passThroughRequests.length, 1);
+  });
+
+  it("passes through POST /login without redirecting", async () => {
+    const response = await request("https://www.mmdbkk.com/login?t=abc", { method: "POST" });
+
+    assert.equal(response.status, 209);
+    assert.equal(passThroughRequests.length, 1);
+  });
+
+  it("passes through API, payment, webhook, admin, and asset prefixes", async () => {
+    const paths = [
+      "/api/member",
+      "/api/health",
+      "/webhook/line",
+      "/webhooks/line",
+      "/pay/renewal",
+      "/payments/checkout",
+      "/payments/test",
+      "/payment/review",
+      "/payment-webhook/stripe",
+      "/admin/console",
+      "/sigil/admin/login",
+      "/sigil/pay/renewal",
+      "/sigil/api/recovery/ack",
+      "/cdn-cgi/trace",
+      "/assets/app.js",
+      "/static/app.css",
+      "/uploads/photo.jpg",
+    ];
+
+    for (const path of paths) {
+      const response = await request(`https://www.mmdbkk.com${path}?t=abc`);
+      assert.equal(response.status, 209, path);
+    }
+
+    assert.equal(passThroughRequests.length, paths.length);
+  });
+
+  it("passes through never-touch hosts", async () => {
+    const response = await request("https://sigil.mmdbkk.com/inme?t=abc");
+
+    assert.equal(response.status, 209);
+    assert.equal(passThroughRequests.length, 1);
+  });
+
+  it("passes through unmanaged hosts", async () => {
+    const response = await request("https://models.mmdbkk.com/inme?t=abc");
+
+    assert.equal(response.status, 209);
+    assert.equal(passThroughRequests.length, 1);
+  });
+
+  it("passes through SIGIL admin on a never-touch host if it ever reaches this worker", async () => {
+    const response = await request("https://sigil.mmdbkk.com/sigil/admin/login?t=abc");
+
+    assert.equal(response.status, 209);
+    assert.equal(passThroughRequests.length, 1);
+  });
+
+  it("injects the dashboard bridge on the payment confirmation page only", async () => {
+    globalThis.fetch = async (request) => {
+      passThroughRequests.push(request);
+      return new Response("<html><body><main>confirm</main></body></html>", {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    };
+
+    const response = await request("https://mmdbkk.com/confirm/payment-confirmation?payment_ref=pay_1");
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.match(html, /mmd-confirm-dashboard-bridge/);
+    assert.match(html, /payments\\\/notify/);
+    assert.equal(passThroughRequests.length, 1);
+  });
+});
+
+describe("redirect helpers", () => {
+  it("normalizes paths", () => {
+    assert.equal(normalizePath("/a//b///"), "/a/b");
+    assert.equal(normalizePath("/"), "/");
+    assert.equal(normalizePath(""), "/");
+  });
+
+  it("maps exact and folder redirects case-insensitively", () => {
+    assert.equal(findMappedPath("/LOGIN/"), "/trust/inme");
+    assert.equal(findMappedPath("/old-academy/Lv1"), "/academy/Lv1");
+  });
+
+  it("recognizes exact no-touch prefixes without trailing slash", () => {
+    assert.equal(shouldNeverTouch(new URL("https://mmdbkk.com/api")), true);
+    assert.equal(shouldNeverTouch(new URL("https://mmdbkk.com/payment")), true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds polished front-gate temporary pages for `/hall`, unknown `/member/*`, and `/model/console`.

- Removed visible debug/recovery wording from user-facing bodies.
- Kept diagnostic metadata only in HTTP headers.
- Added no-cache headers for recovery shell responses.
- Preserved query params and canonical `t`.
- Did not expand or modify `immigrate-worker`.

## Confirmations

- Latest commit includes only:
  - `mmd-redirect-worker/src/index.js`
  - `mmd-redirect-worker/test/redirect.test.mjs`
- No `immigrate-worker` files are staged or committed.
- Tests passed: `npm --prefix mmd-redirect-worker test` → 31/31.
- Deploy version ID: `cc5c5f1f-cf9d-416a-b21a-cd68c442e88a`.

## Follow-Up TODO

Move temporary pages to a canonical page owner later, e.g. `mmd-pages-worker` or a Pages/Webflow route.
