### PR TITLE
Route canonical member pages out of front-gate temporary shell

### DIFF
--- a/admin-worker/index.js
+++ b/admin-worker/index.js
@@ -28,6 +28,32 @@ import { demoLinksCreate, demoLinksGet } from "./src/routes/demo-links.js";
 
 const LOCK = "admin-worker-v2026-03-11-full";
 const AIRTABLE_API = "https://api.airtable.com/v0";
+const MEMBER_SYSTEM_PAGE_META = {
+  "/member/profile": {
+    page: "member-profile",
+    title: "MMD Privé | Member Profile",
+    heading: "Member Profile",
+    note: "จัดการข้อมูลสมาชิก สถานะบัญชี และรายละเอียดสำคัญของพื้นที่ส่วนตัว",
+  },
+  "/member/sessions": {
+    page: "member-sessions",
+    title: "MMD Privé | Member Sessions",
+    heading: "Member Sessions",
+    note: "ตรวจคิว เซสชันถัดไป และสถานะที่เกี่ยวข้องกับการนัดหมายของคุณ",
+  },
+  "/member/points": {
+    page: "member-points",
+    title: "MMD Privé | Member Points",
+    heading: "Member Points",
+    note: "ดูคะแนน สิทธิ์ และสถานะการใช้งานในระบบสมาชิกของ MMD Privé",
+  },
+  "/member/upgrade": {
+    page: "member-upgrade",
+    title: "MMD Privé | Member Upgrade",
+    heading: "Member Upgrade",
+    note: "ตรวจหน้าต่างอัปเกรด สิทธิ์ปัจจุบัน และเส้นทางต่อไปของสมาชิก",
+  },
+};
 const MODEL_SAFE_SEARCH_FIELDS = ["name", "nickname", "telegram_username", "telegram_id", "unique_key"];
 const MODEL_SEARCH_FIELDS = [
   "name",
@@ -100,6 +126,11 @@ export default {
         }),
         cors
       );
+    }
+
+    const memberSystemPage = getMemberSystemPageMeta(path);
+    if ((method === "GET" || method === "HEAD") && memberSystemPage) {
+      return renderMemberSystemPage(req, memberSystemPage);
     }
 
     // ------------------------------------------------------
@@ -599,6 +630,68 @@ export default {
     return withCors(json({ ok: false, error: "not_found" }, 404), cors);
   },
 };
+
+function getMemberSystemPageMeta(path) {
+  const normalized = path.length > 1 ? path.replace(/\/+$/g, "") : path;
+  return MEMBER_SYSTEM_PAGE_META[normalized] || null;
+}
+
+function renderMemberSystemPage(req, page) {
+  const url = new URL(req.url);
+  const query = url.search || "";
+  const links = [
+    { label: "Dashboard", href: "/member/dashboard" },
+    { label: "Payments", href: "/member/payments" },
+    { label: "Profile", href: "/member/profile" },
+    { label: "Sessions", href: "/member/sessions" },
+    { label: "Points", href: "/member/points" },
+    { label: "Upgrade", href: "/member/upgrade" },
+  ];
+  const nav = links
+    .map((link) => `<a href="${escHtml(`${link.href}${query}`)}">${escHtml(link.label)}</a>`)
+    .join("");
+  const html = `<!doctype html>
+<html lang="th">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>${escHtml(page.title)}</title>
+    <style>
+      :root { color-scheme: dark; }
+      * { box-sizing: border-box; letter-spacing: 0; }
+      body { margin: 0; min-height: 100vh; padding: 22px; background: radial-gradient(circle at top left, #1f1709 0, #080604 42%, #050403 100%); color: #fff7e8; font-family: Inter, "Avenir Next", "Segoe UI", "Noto Sans Thai", Arial, sans-serif; }
+      main { width: min(860px, 100%); margin: 0 auto; padding: 28px 0 42px; }
+      .brand { margin: 0 0 14px; color: #ffd784; font-size: 13px; font-weight: 900; line-height: 1.4; text-transform: uppercase; }
+      h1 { margin: 0 0 14px; color: #fff; font-size: clamp(38px, 10vw, 78px); line-height: 1; overflow-wrap: anywhere; }
+      p { margin: 0; color: #fff1d5; font-size: 17px; line-height: 1.68; }
+      nav { display: flex; flex-wrap: wrap; gap: 8px; margin: 24px 0; }
+      a { min-height: 44px; display: inline-flex; align-items: center; justify-content: center; padding: 0 14px; border: 1px solid #d8ad5a; border-radius: 999px; color: #fff7e8; background: #17110a; text-decoration: none; font-weight: 850; line-height: 1.2; }
+      .panel { margin-top: 18px; padding: 18px; border: 1px solid rgba(216, 173, 90, .34); border-radius: 8px; background: rgba(23, 17, 10, .72); }
+    </style>
+  </head>
+  <body data-mmd-member-system-page="${escHtml(page.page)}">
+    <main>
+      <p class="brand">MMD Privé Member System</p>
+      <h1>${escHtml(page.heading)}</h1>
+      <p>${escHtml(page.note)}</p>
+      <nav aria-label="Member system">${nav}</nav>
+      <section class="panel" aria-label="Member continuity">
+        <p>พื้นที่นี้อยู่ในระบบสมาชิกหลักของ MMD Privé และเชื่อมต่อกับเส้นทางสมาชิกที่เกี่ยวข้อง</p>
+      </section>
+    </main>
+  </body>
+</html>`;
+
+  return new Response(req.method.toUpperCase() === "HEAD" ? null : html, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+      "x-mmd-owner": "admin-worker",
+      "x-mmd-page": page.page,
+    },
+  });
+}
 
 /* =========================
    CORS

--- a/admin-worker/member-system-pages.test.mjs
+++ b/admin-worker/member-system-pages.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "./index.js";
+
+const DEBUG_TEXT = /Front Gate Active|Route recovery shell|x-mmd-page|x-mmd-front-gate|x-mmd-front-version|fallback|recovery/i;
+
+test("known member system pages render from admin-worker with preserved query links", async () => {
+  const pages = [
+    ["/member/profile", "member-profile", "Member Profile"],
+    ["/member/sessions", "member-sessions", "Member Sessions"],
+    ["/member/points", "member-points", "Member Points"],
+    ["/member/upgrade", "member-upgrade", "Member Upgrade"],
+  ];
+
+  for (const [path, page, heading] of pages) {
+    const response = await worker.fetch(new Request(`https://mmdbkk.com${path}?t=abc&code=x&promo=y&cb=test`), {});
+    const html = await response.text();
+
+    assert.equal(response.status, 200, path);
+    assert.match(response.headers.get("content-type") || "", /text\/html/i, path);
+    assert.equal(response.headers.get("x-mmd-owner"), "admin-worker", path);
+    assert.equal(response.headers.get("x-mmd-page"), page, path);
+    assert.match(html, new RegExp(`<h1>${heading}</h1>`), path);
+    assert.ok(html.includes("/member/dashboard?t=abc&amp;code=x&amp;promo=y&amp;cb=test"), path);
+    assert.doesNotMatch(html, /name=["']token["']/i, path);
+    assert.doesNotMatch(html, DEBUG_TEXT, path);
+  }
+});

--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -58,6 +58,14 @@ export const NEVER_REDIRECT_EXACT_PATHS = new Set([
   "/member/membership/",
   "/member/payments",
   "/member/payments/",
+  "/member/profile",
+  "/member/profile/",
+  "/member/sessions",
+  "/member/sessions/",
+  "/member/points",
+  "/member/points/",
+  "/member/upgrade",
+  "/member/upgrade/",
   "/hall",
   "/hall/",
   "/model/console",
@@ -238,6 +246,21 @@ function isMemberMembershipPath(url) {
 function isMemberPaymentsPath(url) {
   const pathname = url.pathname.toLowerCase();
   return pathname === "/member/payments" || pathname === "/member/payments/";
+}
+
+function isAdminMemberSystemPath(url) {
+  const pathname = url.pathname.toLowerCase();
+  return (
+    isMemberPaymentsPath(url) ||
+    pathname === "/member/profile" ||
+    pathname === "/member/profile/" ||
+    pathname === "/member/sessions" ||
+    pathname === "/member/sessions/" ||
+    pathname === "/member/points" ||
+    pathname === "/member/points/" ||
+    pathname === "/member/upgrade" ||
+    pathname === "/member/upgrade/"
+  );
 }
 
 function isHallPath(url) {
@@ -439,7 +462,7 @@ export default {
       return fetchMemberFrontend(request, env, url);
     }
 
-    if (isMemberPaymentsPath(url)) {
+    if (isAdminMemberSystemPath(url)) {
       return fetchAdminMemberPage(request, env, url);
     }
 

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -179,6 +179,47 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 0);
   });
 
+  it("delegates known member system pages to admin-worker without using the member-static shell", async () => {
+    const adminRequests = [];
+    const env = {
+      ADMIN_WORKER: {
+        fetch: async (request) => {
+          adminRequests.push(request);
+          const url = new URL(request.url);
+          const slug = url.pathname.replace(/^\/member\/|\/$/g, "");
+          return new Response(`<main><h1>${slug}</h1><a href="/member/dashboard${url.search}">Dashboard</a></main>`, {
+            status: 200,
+            headers: { "x-mmd-owner": "admin-worker", "x-mmd-page": `member-${slug}` },
+          });
+        },
+      },
+    };
+
+    const urls = [
+      "https://mmdbkk.com/member/profile?t=abc&cb=test",
+      "https://mmdbkk.com/member/sessions?t=abc&cb=test",
+      "https://mmdbkk.com/member/points?t=abc&cb=test",
+      "https://mmdbkk.com/member/upgrade?t=abc&cb=test",
+      "https://www.mmdbkk.com/member/profile?t=abc&code=x&promo=y&cb=test",
+    ];
+
+    for (const url of urls) {
+      const response = await requestWithEnv(url, env);
+      const html = await response.text();
+      const query = new URL(url).search;
+
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-mmd-owner"), "admin-worker", url);
+      assert.notEqual(response.headers.get("x-mmd-page"), "member-static", url);
+      assert.ok(html.includes(`/member/dashboard${query}`), url);
+      assertPolishedShell(html, url);
+      assert.equal(adminRequests.at(-1).url, url);
+    }
+
+    assert.equal(passThroughRequests.length, 0);
+  });
+
   it("renders /hall as a polished MMD Privé page without redirecting or changing query strings", async () => {
     const urls = [
       "https://mmdbkk.com/hall?t=abc&cb=test",


### PR DESCRIPTION
## Summary

Moved known member system routes toward the canonical `ADMIN_WORKER` owner while keeping unknown member content/static pages on the polished front-gate fallback.

- Routes `/member/profile`, `/member/sessions`, `/member/points`, and `/member/upgrade` now route from `mmd-redirect-worker` to `ADMIN_WORKER`.
- Added lightweight canonical member-system pages in `admin-worker` for those known system routes.
- Kept unknown member content/static routes such as `/member/kenji-20-ai` and `/member/some-new-page` on the existing polished `member-static` front-gate shell.
- Did not touch `immigrate-worker`.
- Did not touch `/hall` or `/model/console` behavior.
- Preserved canonical `t` and all query params in internal links.
- Did not introduce `token` or `name="token"`.

## Tests

- `npm --prefix mmd-redirect-worker test` -> pass, 32/32
- `node --test admin-worker/member-system-pages.test.mjs` -> pass, 1/1

## Notes

`/member/dashboard` and `/member/membership` were left stable in their existing legacy path for this PR. `/member/payments` remains routed to `ADMIN_WORKER` as before.

No deploy performed.