### PR TITLE
Plug Kenji Member Concierge into LINE Official

### DIFF
--- a/docs/line/kenji-line-official.md
+++ b/docs/line/kenji-line-official.md
@@ -1,0 +1,64 @@
+# Kenji AI In LINE Official
+
+Kenji LINE OA is the member-facing concierge entry for MMD Privé. It is not the admin board, not Worker Control Console, and not a production write surface beyond the existing safe Console Inbox / Airtable inbound logging already present in the LINE webhook.
+
+## Surface Map
+
+- `/member/dashboard`: Member Home / Status Hub
+- `/member/kenji-ai-20`: Kenji AI member-facing concierge surface
+- `/sigil/board`: internal system/admin/rules/control layer
+- LINE OA Kenji: member-facing conversational entry
+
+## Required Env
+
+```text
+LINE_AUTO_REPLY_ENABLED=true
+LINE_KENJI_AI_ENABLED=true
+LINE_CHANNEL_SECRET=...
+LINE_CHANNEL_ACCESS_TOKEN=...
+AIRTABLE_API_KEY=...
+AIRTABLE_BASE_ID=...
+```
+
+Optional:
+
+```text
+LINE_KENJI_AI_DEBUG=true
+```
+
+Use the existing Netlify LINE webhook URL. Do not introduce frontend secrets.
+
+## Test Phrases
+
+```text
+เคนจิ
+คุยกับ Per AI
+จอง
+ส่งสลิปแล้ว
+ต่ออายุสมาชิก
+VIP
+SVIP
+Black Card
+```
+
+Expected behavior:
+
+- Replies use warm, concise Kenji voice.
+- Booking reply says Kenji can guide booking but must check member status, conditions, and availability first.
+- Payment/slip reply says proof is supporting evidence only and confirmation requires official verification / fund matching.
+- SVIP reply says Boss Per manual decision only, never points-based.
+- Black Card reply says private review, not automatic approval.
+- Pricing messages keep the existing pricing review acknowledgement path.
+- Model availability messages keep the existing model lookup / Per confirmation path.
+
+## Safety Notes
+
+- No secrets in Webflow or frontend code.
+- Do not use a query/body field named `token`; use `t` only for tokenized public/member links.
+- Payment slips/proof are supporting evidence only.
+- Payment confirmation requires official verification and fund matching.
+- SVIP is Boss Per manual decision only.
+- Black Card is private review only.
+- LINE OA Kenji does not enable real Worker Control POST actions.
+- Deduped LINE events must not reply twice.
+

--- a/immigrate-worker/netlify/functions/webhook.js
+++ b/immigrate-worker/netlify/functions/webhook.js
@@ -1,4 +1,10 @@
 import crypto from "node:crypto";
+import {
+  buildKenjiMemberReply,
+  classifyKenjiMemberIntent,
+  getSafeMemberSummary,
+  isKenjiMemberLineCandidate,
+} from "../../../shared/kenji-member-concierge-core.mjs";
 
 const DEFAULT_SYNC_TABLE = "MMD — Console Inbox";
 const LINE_API_BASE = "https://api.line.me/v2/bot";
@@ -22,6 +28,17 @@ const FAQ_REPLY_INTENTS = new Set([
   "contact_admin",
 ]);
 const PRICING_REVIEW_INTENTS = new Set(["pricing_review", "ask_where_to_get_rate", "image_rate_inquiry"]);
+const KENJI_MEMBER_INTENTS = new Set([
+  "talk_to_per_ai",
+  "payment_slip",
+  "points",
+  "vip",
+  "svip",
+  "black_card",
+  "membership",
+  "create_session",
+  "greeting",
+]);
 const STOP_MODEL_WORDS = new Set([
   "วันที่",
   "เวลา",
@@ -198,7 +215,10 @@ function looksLikeSpecificModelRequest(text) {
 function isTalkToPerAi(text = "") {
   const normalized = normalizeLookup(text).replace(/\s+/g, "");
   return (
+    normalized.includes("kenji") ||
+    normalized.includes("เคนจิ") ||
     normalized.includes("คุยกับเปอร์") ||
+    normalized.includes("คุยกับเคนจิ") ||
     normalized.includes("คุยกับper") ||
     normalized.includes("คุยกับperai") ||
     normalized.includes("ขอคุยกับเปอร์") ||
@@ -207,6 +227,10 @@ function isTalkToPerAi(text = "") {
     normalized.includes("ติดต่อper") ||
     normalized.includes("perai")
   );
+}
+
+function getKenjiCoreIntent(text) {
+  return classifyKenjiMemberIntent(text, {}).intent;
 }
 
 function inferFaqIntent(text) {
@@ -371,6 +395,12 @@ function inferIntent(text, event) {
   }
 
   if (isTalkToPerAi(text)) return "talk_to_per_ai";
+  const kenjiIntent = getKenjiCoreIntent(text);
+  if (kenjiIntent === "black_card") return "black_card";
+  if (kenjiIntent === "svip") return "svip";
+  if (kenjiIntent === "payment_slip") return "payment_slip";
+  if (kenjiIntent === "vip") return "vip";
+  if (kenjiIntent === "points") return "points";
   const faqIntent = inferFaqIntent(text);
   if (faqIntent) {
     return hasPriorImageContext(event) && (faqIntent === "pricing_review" || faqIntent === "ask_where_to_get_rate")
@@ -570,11 +600,13 @@ function buildModelSourceFallbackReply({ prefix, booking, resolution }) {
   return `รับทราบครับ ${prefix}ผมเห็นว่าต้องการเช็ก ${requestedName} เดี๋ยวส่งให้ Per ตรวจสอบจากประวัติ model-side ก่อนยืนยันนะครับ`;
 }
 
-function shouldAutoReplyForIntent(intent, text, event) {
+function shouldAutoReplyForIntent(intent, text, event, options = {}) {
   if (event?.type === "follow") return true;
   if (hasClientTag(text)) return true;
   if (intent === "model_availability") return true;
   if (FAQ_REPLY_INTENTS.has(intent)) return true;
+  if (options.lineKenjiAiEnabled && KENJI_MEMBER_INTENTS.has(intent)) return true;
+  if (options.lineKenjiAiEnabled && isKenjiMemberLineCandidate(text)) return true;
   return false;
 }
 
@@ -657,6 +689,22 @@ Premium จะเหมาะกับคนที่ต้องการเล
 ถ้ามีรายละเอียดเพิ่มเติม เช่น แพ็กเกจที่สนใจ วันเวลา หรือแนวนายแบบที่ต้องการ ส่งเพิ่มไว้ในแชทนี้ได้เลยครับ`;
   }
   return "";
+}
+
+function buildLineMemberSummary(event, profile) {
+  return getSafeMemberSummary({
+    display_name: String(profile?.displayName || "").trim(),
+    line_user_id: getLineUserId(event),
+    membership_status: "LINE Member",
+    tier: "Preview",
+    active_points: 0,
+  });
+}
+
+function buildKenjiLineReply(event, profile, options = {}) {
+  return buildKenjiMemberReply(toTextMessage(event), buildLineMemberSummary(event, profile), {
+    lineOfficialChatUrl: options.lineOfficialChatUrl || "",
+  });
 }
 
 function parsePricingRequest(text) {
@@ -760,7 +808,7 @@ async function buildAutoReplyMessage(event, profile, options = {}) {
   const prefix = firstName ? `${firstName} ` : "";
   const intent = inferIntent(text, event);
 
-  if (!shouldAutoReplyForIntent(intent, text, event)) {
+  if (!shouldAutoReplyForIntent(intent, text, event, options)) {
     logLineWebhookDebug(options, { intent, reply_sent: false, category: "not_auto_reply_intent" });
     return "";
   }
@@ -801,6 +849,14 @@ async function buildAutoReplyMessage(event, profile, options = {}) {
     return reply;
   }
 
+  if (options.lineKenjiAiEnabled && intent === "talk_to_per_ai") {
+    const reply = buildKenjiLineReply(event, profile, options);
+    if (options.lineKenjiAiDebug) {
+      logLineWebhookDebug(options, { intent, reply_sent: Boolean(reply), category: "kenji_member_concierge" });
+    }
+    return reply;
+  }
+
   if (FAQ_REPLY_INTENTS.has(intent)) {
     let pricingReview = null;
     const adContext = parseAdContextFromText(text);
@@ -816,6 +872,14 @@ async function buildAutoReplyMessage(event, profile, options = {}) {
       pricing_review_created: Boolean(pricingReview?.ok),
       telegram_sent: Boolean(pricingReview?.telegram_sent),
     });
+    return reply;
+  }
+
+  if (options.lineKenjiAiEnabled && (KENJI_MEMBER_INTENTS.has(intent) || isKenjiMemberLineCandidate(text))) {
+    const reply = buildKenjiLineReply(event, profile, options);
+    if (options.lineKenjiAiDebug) {
+      logLineWebhookDebug(options, { intent, reply_sent: Boolean(reply), category: "kenji_member_concierge" });
+    }
     return reply;
   }
 
@@ -895,6 +959,9 @@ export async function handler(event) {
   const autoReplyEnabled = String(process.env.LINE_AUTO_REPLY_ENABLED || "false").toLowerCase() === "true";
   const lineModelLookupDebug = process.env.LINE_MODEL_LOOKUP_DEBUG || "";
   const lineWebhookDebug = process.env.LINE_WEBHOOK_DEBUG || "";
+  const lineKenjiAiEnabled = String(process.env.LINE_KENJI_AI_ENABLED || "false").toLowerCase() === "true";
+  const lineKenjiAiDebug = String(process.env.LINE_KENJI_AI_DEBUG || "false").toLowerCase() === "true";
+  const lineOfficialChatUrl = process.env.LINE_OFFICIAL_CHAT_URL || "";
 
   if (!lineChannelSecret || !airtableApiKey || !airtableBaseId) {
     return json(500, {
@@ -929,7 +996,7 @@ export async function handler(event) {
     const clientTagged = hasClientTag(messageText);
     const intent = inferIntent(messageText, item);
     const shouldFetchProfile =
-      (clientTagged || intent === "model_availability" || FAQ_REPLY_INTENTS.has(intent)) &&
+      (clientTagged || intent === "model_availability" || FAQ_REPLY_INTENTS.has(intent) || (lineKenjiAiEnabled && (KENJI_MEMBER_INTENTS.has(intent) || isKenjiMemberLineCandidate(messageText)))) &&
       item?.source?.type === "user" &&
       lineChannelAccessToken;
     const profile = shouldFetchProfile ? await fetchLineProfile(lineChannelAccessToken, lineUserId) : null;
@@ -946,6 +1013,9 @@ export async function handler(event) {
       confirmKey,
       lineModelLookupDebug,
       lineWebhookDebug,
+      lineKenjiAiEnabled,
+      lineKenjiAiDebug,
+      lineOfficialChatUrl,
       createPricingReviewEnabled: !record?.deduped,
     });
     const replied =
@@ -973,4 +1043,4 @@ export async function handler(event) {
   });
 }
 
-export { buildFaqReply, choosePricingReplyStrategy, inferFaqIntent, inferIntent, parseAdContextFromText, shouldAutoReplyForIntent };
+export { buildAutoReplyMessage, buildFaqReply, choosePricingReplyStrategy, inferFaqIntent, inferIntent, parseAdContextFromText, shouldAutoReplyForIntent };

--- a/immigrate-worker/netlify/tests/webhook-faq-intent.test.mjs
+++ b/immigrate-worker/netlify/tests/webhook-faq-intent.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  buildAutoReplyMessage,
   buildFaqReply,
   choosePricingReplyStrategy,
   inferFaqIntent,
@@ -51,5 +52,31 @@ assert.equal(choosePricingReplyStrategy({}), "generic_pricing_ack");
 
 assert.equal(shouldAutoReplyForIntent("pricing_review"), true);
 assert.equal(shouldAutoReplyForIntent("model_availability"), true);
+
+assert.equal(shouldAutoReplyForIntent("greeting", "สวัสดี", textEvent("สวัสดี")), false);
+assert.equal(shouldAutoReplyForIntent("greeting", "สวัสดี", textEvent("สวัสดี"), { lineKenjiAiEnabled: true }), true);
+assert.equal(shouldAutoReplyForIntent("note_only", "เคนจิ", textEvent("เคนจิ"), { lineKenjiAiEnabled: true }), true);
+
+const profile = { displayName: "Boss" };
+const kenjiReply = await buildAutoReplyMessage(textEvent("เคนจิ"), profile, { lineKenjiAiEnabled: true });
+assert.match(kenjiReply, /Kenji/);
+assert.match(kenjiReply, /ผู้ช่วยสมาชิก/);
+
+const slipReply = await buildAutoReplyMessage(textEvent("ส่งสลิปแล้ว"), profile, { lineKenjiAiEnabled: true });
+assert.match(slipReply, /supporting evidence/);
+assert.match(slipReply, /official verification/);
+assert.match(slipReply, /fund matching/);
+
+const svipReply = await buildAutoReplyMessage(textEvent("SVIP"), profile, { lineKenjiAiEnabled: true });
+assert.match(svipReply, /Boss Per/);
+assert.match(svipReply, /ไม่ได้ปลดล็อกจากแต้มอัตโนมัติ/);
+
+const blackCardReply = await buildAutoReplyMessage(textEvent("Black Card"), profile, { lineKenjiAiEnabled: true });
+assert.match(blackCardReply, /private review/);
+assert.match(blackCardReply, /automatic approval/);
+
+const bookingReply = await buildAutoReplyMessage(textEvent("จอง"), profile, { lineKenjiAiEnabled: true });
+assert.match(bookingReply, /ผมช่วยพาไปขั้นตอนการจองได้ครับ/);
+assert.match(bookingReply, /ขอเช็กสถานะสมาชิก/);
 
 console.log("webhook FAQ/pricing intent tests passed");

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dev:events": "wrangler dev --config workers/events-worker/wrangler.toml",
     "dev:telegram": "wrangler dev --config workers/telegram-worker/wrangler.toml",
     "dev:sigil-board": "wrangler dev --config workers/sigil-board-worker/wrangler.toml",
-    "check:sigil-board": "node --check workers/sigil-board-worker/src/index.js"
+    "check:sigil-board": "node --check workers/sigil-board-worker/src/index.js",
+    "test:kenji-line": "node --test shared/kenji-member-concierge-core.test.mjs"
   }
 }

--- a/shared/kenji-member-concierge-core.mjs
+++ b/shared/kenji-member-concierge-core.mjs
@@ -1,0 +1,188 @@
+const HIGH_POINTS_THRESHOLD = 1200;
+
+const INTENTS = Object.freeze({
+  EMPTY: "empty",
+  GREETING: "greeting",
+  BOOKING: "booking",
+  PAYMENT_SLIP: "payment_slip",
+  POINTS: "points",
+  VIP: "vip",
+  SVIP: "svip",
+  BLACK_CARD: "black_card",
+  MEMBERSHIP_RENEWAL: "membership_renewal",
+  PRICING_RATE: "pricing_rate",
+  MODEL_AVAILABILITY: "model_availability",
+  TALK_TO_PER_AI: "talk_to_per_ai",
+  HIGH_POINTS_FALLBACK: "high_points_fallback",
+  GENERAL: "general",
+});
+
+function toText(value) {
+  return value === null || value === undefined ? "" : String(value).trim();
+}
+
+function normalize(value) {
+  return toText(value)
+    .toLowerCase()
+    .normalize("NFKC")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function compact(value) {
+  return normalize(value).replace(/\s+/g, "");
+}
+
+function asFiniteNumber(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function includesAny(text, terms) {
+  return terms.some((term) => text.includes(term));
+}
+
+function getPointsBalance(memberSummary) {
+  if (!memberSummary || typeof memberSummary !== "object") return null;
+  return asFiniteNumber(memberSummary.active_points ?? memberSummary.points_balance ?? memberSummary.points?.balance);
+}
+
+function formatPoints(value) {
+  const number = asFiniteNumber(value);
+  if (number === null) return "";
+  return number.toLocaleString("en-US");
+}
+
+export function getSafeMemberSummary(raw = {}) {
+  const source = raw && typeof raw === "object" ? raw : {};
+  const activePoints = getPointsBalance(source);
+  return {
+    display_name: toText(source.display_name || source.name || source.line_display_name),
+    membership_status: toText(source.membership_status || source.status || "LINE Member"),
+    tier: toText(source.tier || source.member_tier || "Preview"),
+    active_points: activePoints === null ? 0 : activePoints,
+    points_updated_at: toText(source.points_updated_at),
+    renewal_status: toText(source.renewal_status || "unknown"),
+    line_user_id_redacted: redactLineUserId(source.line_user_id || source.lineUserId),
+  };
+}
+
+function redactLineUserId(value) {
+  const text = toText(value);
+  if (!text) return "";
+  if (text.length <= 8) return `${text.slice(0, 2)}***`;
+  return `${text.slice(0, 4)}***${text.slice(-4)}`;
+}
+
+export function classifyKenjiMemberIntent(input, memberSummary = {}) {
+  const text = normalize(input);
+  const dense = compact(input);
+  const summary = getSafeMemberSummary(memberSummary);
+
+  if (!text) return { intent: INTENTS.EMPTY, confidence: 1 };
+
+  if (includesAny(text, ["black card", "blackcard", "บัตรดำ"])) {
+    return { intent: INTENTS.BLACK_CARD, confidence: 0.98 };
+  }
+
+  if (includesAny(text, ["svip", "s vip", "super vip", "เอสวีไอพี"])) {
+    return { intent: INTENTS.SVIP, confidence: 0.98 };
+  }
+
+  if (includesAny(text, ["ส่งสลิป", "สลิป", "slip", "payment proof", "โอนแล้ว", "โอน", "ชำระ", "จ่ายแล้ว", "paid"])) {
+    return { intent: INTENTS.PAYMENT_SLIP, confidence: 0.96 };
+  }
+
+  if (includesAny(text, ["จอง", "booking", "book", "reserve", "appointment", "session", "คิว", "นัด", "ว่าง", "available", "availability", "เช็กคิว", "เช็คคิว"])) {
+    return { intent: INTENTS.BOOKING, confidence: 0.95 };
+  }
+
+  if (includesAny(text, ["สมาชิก", "ต่ออายุ", "renew", "renewal", "membership", "member", "status hub", "หมดอายุ"])) {
+    return { intent: INTENTS.MEMBERSHIP_RENEWAL, confidence: 0.92 };
+  }
+
+  const hasPointsIntent = includesAny(text, ["แต้ม", "points", "point", "คะแนน"]);
+  if (!hasPointsIntent && includesAny(text, ["ราคา", "เรท", "rate", "price", "pricing", "แพ็กเกจ", "แพคเกจ", "เท่าไร", "เท่าไหร่", "กี่บาท"])) {
+    return { intent: INTENTS.PRICING_RATE, confidence: 0.9 };
+  }
+
+  if (includesAny(text, ["vip", "วีไอพี"])) {
+    return { intent: INTENTS.VIP, confidence: 0.9 };
+  }
+
+  if (hasPointsIntent) {
+    return { intent: INTENTS.POINTS, confidence: 0.9 };
+  }
+
+  if (
+    includesAny(text, ["kenji", "kenji ai", "per ai", "เคนจิ", "เปอร์ ai"]) ||
+    includesAny(dense, ["คุยกับเคนจิ", "คุยกับperai", "คุยกับเปอร์ai", "ขอคุยกับเคนจิ", "ขอคุยกับperai"])
+  ) {
+    return { intent: INTENTS.TALK_TO_PER_AI, confidence: 0.9 };
+  }
+
+  if (includesAny(text, ["สวัสดี", "hello", "hi", "hey", "ดีครับ", "ดีค่ะ"])) {
+    return { intent: INTENTS.GREETING, confidence: 0.75 };
+  }
+
+  if (summary.active_points >= HIGH_POINTS_THRESHOLD) {
+    return { intent: INTENTS.HIGH_POINTS_FALLBACK, confidence: 0.65 };
+  }
+
+  return { intent: INTENTS.GENERAL, confidence: 0.45 };
+}
+
+export function isKenjiMemberLineCandidate(text) {
+  const classified = classifyKenjiMemberIntent(text, {});
+  return ![INTENTS.EMPTY, INTENTS.GENERAL, INTENTS.HIGH_POINTS_FALLBACK].includes(classified.intent);
+}
+
+export function buildKenjiMemberReply(input, memberSummary = {}, options = {}) {
+  const summary = getSafeMemberSummary(memberSummary);
+  const classified = classifyKenjiMemberIntent(input, summary);
+  const name = summary.display_name ? `พี่${summary.display_name}` : "พี่";
+  const statusLine = buildStatusLine(summary);
+  const lineOfficialChatUrl = toText(options.lineOfficialChatUrl);
+
+  switch (classified.intent) {
+    case INTENTS.EMPTY:
+      return `สวัสดีครับ ${name} ผม Kenji ครับ พิมพ์เรื่องที่อยากให้ช่วยได้เลย เช่น จอง, ส่งสลิป, แต้ม, ต่ออายุสมาชิก, VIP, SVIP หรือ Black Card ครับ`;
+    case INTENTS.GREETING:
+      return `สวัสดีครับ ${name} ผม Kenji ครับ วันนี้ให้ผมช่วยเรื่องสมาชิก จองงาน แต้ม หรือส่งหลักฐานชำระเงินได้เลยครับ`;
+    case INTENTS.TALK_TO_PER_AI:
+      return `ได้ครับ ${name} ผม Kenji ผู้ช่วยสมาชิกของ MMD Privé ครับ ผมช่วยจัดเรื่องให้เป็นขั้นตอน และส่งต่อเคสที่ต้องให้ Per ตรวจสอบได้ครับ วันนี้อยากให้ผมช่วยเรื่องไหนก่อนครับ`;
+    case INTENTS.BOOKING:
+      return `ผมช่วยพาไปขั้นตอนการจองได้ครับ แต่ขอเช็กสถานะสมาชิก เงื่อนไข และความพร้อมก่อนนะครับ${statusLine} ถ้ามีนายแบบ วัน เวลา และโซนที่ต้องการ ส่งมาได้เลยครับ`;
+    case INTENTS.MODEL_AVAILABILITY:
+      return `รับทราบครับ ${name} เดี๋ยวผมช่วยจัดข้อมูลเพื่อให้ Per หรือระบบเช็กสถานะนายแบบและความพร้อมก่อนยืนยันการจองนะครับ`;
+    case INTENTS.PAYMENT_SLIP:
+      return `รับทราบครับ ${name} สลิปหรือหลักฐานการโอนเป็น supporting evidence เท่านั้นนะครับ ยังไม่ถือเป็นการยืนยันยอด การยืนยันต้องผ่าน official verification และ fund matching ก่อนครับ`;
+    case INTENTS.POINTS:
+      if (summary.active_points > 0) return `ตอนนี้ผมเห็นแต้มของ${name}ประมาณ ${formatPoints(summary.active_points)} points ครับ แต้มช่วยประกอบการดูแลได้ แต่การอัปเกรดหรือสิทธิ์พิเศษต้องตรวจตามเงื่อนไขล่าสุดก่อนครับ`;
+      return `ผมช่วยเช็กแต้มผ่านสถานะสมาชิกให้ได้ครับ ตอนนี้ยังไม่มีแต้มที่ยืนยันได้ใน LINE นี้ ขอเช็กจาก Member Home / Status Hub หรือให้ทีมตรวจสถานะล่าสุดก่อนนะครับ`;
+    case INTENTS.VIP:
+      return `VIP ดูจากหลายสัญญาณประกอบกันได้ครับ เช่น สถานะสมาชิก ประวัติการใช้งาน แต้ม และการตรวจสอบจากทีม แต่ยังไม่ใช่การอัปเกรดอัตโนมัติหรือการการันตีสิทธิ์นะครับ`;
+    case INTENTS.SVIP:
+      return `SVIP ต้องพิจารณาเป็นรายเคสโดย Boss Per เท่านั้นครับ และไม่ได้ปลดล็อกจากแต้มอัตโนมัติ ผมช่วยรวบรวมข้อมูลให้เข้าทาง review ที่ถูกต้องได้ครับ`;
+    case INTENTS.BLACK_CARD:
+      return `Black Card เป็น private review เท่านั้นครับ ไม่ใช่ automatic approval ผมช่วยเตรียมบริบทสมาชิกให้ทีมตรวจแบบส่วนตัวและปลอดภัยได้ครับ`;
+    case INTENTS.MEMBERSHIP_RENEWAL:
+      return `ผมช่วยดูเรื่องสถานะสมาชิกหรือต่ออายุได้ครับ${statusLine} ถ้ามีหลักฐานชำระเงิน ส่งได้ครับ แต่การยืนยันยังต้องผ่าน official verification และ fund matching ก่อนนะครับ`;
+    case INTENTS.PRICING_RATE:
+      return `สอบถามเรทกับผมได้ครับ เดี๋ยวผมช่วยรับเรื่องและส่งให้ Per/Ewvon ตรวจสอบราคา รายละเอียด และเงื่อนไขที่เหมาะสมก่อนแจ้งกลับนะครับ`;
+    case INTENTS.HIGH_POINTS_FALLBACK:
+      return `แต้มของ${name}ดูแข็งแรงครับ แต่ผมจะไม่สรุป VIP, SVIP หรือ Black Card ให้อัตโนมัติ ถ้าพี่ต้องการ ผมช่วยพาไปเช็กขั้นตอนสมาชิกที่เหมาะสมต่อได้ครับ`;
+    default:
+      return `ผมช่วยดูเรื่องสมาชิก จองงาน แต้ม การชำระเงิน VIP, SVIP หรือ Black Card ได้ครับ${lineOfficialChatUrl ? ` ถ้าต้องส่งต่อให้ทีม ผมจะพาไปทาง official flow ให้ครับ` : ""}`;
+  }
+}
+
+function buildStatusLine(summary) {
+  const parts = [];
+  if (summary.membership_status) parts.push(`สถานะ: ${summary.membership_status}`);
+  if (summary.tier) parts.push(`tier: ${summary.tier}`);
+  if (summary.active_points > 0) parts.push(`แต้ม: ${formatPoints(summary.active_points)}`);
+  return parts.length ? ` (${parts.join(", ")})` : "";
+}
+
+export { HIGH_POINTS_THRESHOLD, INTENTS };

--- a/shared/kenji-member-concierge-core.test.mjs
+++ b/shared/kenji-member-concierge-core.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import {
+  buildKenjiMemberReply,
+  classifyKenjiMemberIntent,
+  getSafeMemberSummary,
+  isKenjiMemberLineCandidate,
+} from "./kenji-member-concierge-core.mjs";
+
+const summary = getSafeMemberSummary({ display_name: "บอส", active_points: 1280, tier: "VIP" });
+
+assert.equal(classifyKenjiMemberIntent("").intent, "empty");
+assert.equal(classifyKenjiMemberIntent("สวัสดีครับ").intent, "greeting");
+assert.equal(classifyKenjiMemberIntent("เคนจิ").intent, "talk_to_per_ai");
+assert.equal(classifyKenjiMemberIntent("คุยกับ Per AI").intent, "talk_to_per_ai");
+assert.equal(classifyKenjiMemberIntent("อยากจองครับ").intent, "booking");
+assert.equal(classifyKenjiMemberIntent("ส่งสลิปแล้วครับ").intent, "payment_slip");
+assert.equal(classifyKenjiMemberIntent("แต้มผมเท่าไร").intent, "points");
+assert.equal(classifyKenjiMemberIntent("VIP ต้องทำยังไง").intent, "vip");
+assert.equal(classifyKenjiMemberIntent("SVIP มีแต้ม 1200", summary).intent, "svip");
+assert.equal(classifyKenjiMemberIntent("Black Card VIP").intent, "black_card");
+assert.equal(classifyKenjiMemberIntent("ต่ออายุสมาชิก").intent, "membership_renewal");
+assert.equal(classifyKenjiMemberIntent("แค่ทักทั่วไป", summary).intent, "high_points_fallback");
+
+assert.equal(classifyKenjiMemberIntent("ส่งสลิปแล้ว อยากจอง").intent, "payment_slip");
+assert.equal(classifyKenjiMemberIntent("SVIP มีแต้ม 1200", summary).intent, "svip");
+assert.equal(classifyKenjiMemberIntent("Black Card VIP").intent, "black_card");
+
+assert.equal(isKenjiMemberLineCandidate("เคนจิ"), true);
+assert.equal(isKenjiMemberLineCandidate("ส่งสลิปแล้ว"), true);
+assert.equal(isKenjiMemberLineCandidate("random note only"), false);
+
+const paymentReply = buildKenjiMemberReply("ส่งสลิปแล้ว", summary);
+assert.match(paymentReply, /supporting evidence/);
+assert.match(paymentReply, /official verification/);
+assert.match(paymentReply, /fund matching/);
+
+const svipReply = buildKenjiMemberReply("SVIP มีแต้ม 1200", summary);
+assert.match(svipReply, /Boss Per/);
+assert.match(svipReply, /ไม่ได้ปลดล็อกจากแต้มอัตโนมัติ/);
+
+const blackCardReply = buildKenjiMemberReply("Black Card VIP", summary);
+assert.match(blackCardReply, /private review/);
+assert.match(blackCardReply, /automatic approval/);
+
+const bookingReply = buildKenjiMemberReply("จอง", summary);
+assert.match(bookingReply, /ผมช่วยพาไปขั้นตอนการจองได้ครับ/);
+assert.match(bookingReply, /ขอเช็กสถานะสมาชิก/);
+
+const pointsReply = buildKenjiMemberReply("แต้ม", summary);
+assert.match(pointsReply, /1,280/);
+
+console.log("kenji member concierge core tests passed");
+


### PR DESCRIPTION
## Summary

Plug Kenji Member Concierge into LINE Official through the existing Netlify LINE webhook, while keeping the member-facing `/member/kenji-ai-20` logic shared and safe.

## Changes

- Add DOM-free shared Kenji member concierge core.
- Add LINE webhook support for `LINE_KENJI_AI_ENABLED` and `LINE_KENJI_AI_DEBUG`.
- Preserve existing pricing review and model availability behavior before Kenji routing.
- Add safe LINE replies for:
  - Kenji / Per AI
  - booking
  - payment/slip
  - points
  - VIP
  - SVIP
  - Black Card
  - membership / renewal
- Add docs for LINE Official setup and manual QA.
- Add/extend tests for core intent handling and LINE webhook routing.

## Safety

- No secrets committed.
- No frontend secrets added.
- No `token` field introduced; `t` remains the only allowed tokenized public/member query param when needed.
- No promo/access-code work included.
- No `chat-worker/kv-list.json` created.
- No `wrangler 2.toml` modified.
- No payment confirmation from slip.
- SVIP remains Boss Per manual-only.
- Black Card remains private review and never automatic approval.
- Existing pricing/model availability paths preserved.

## Env needed after merge/deploy

```txt
LINE_AUTO_REPLY_ENABLED=true
LINE_KENJI_AI_ENABLED=true
LINE_CHANNEL_SECRET=...
LINE_CHANNEL_ACCESS_TOKEN=...
AIRTABLE_API_KEY=...
AIRTABLE_BASE_ID=...
```

Optional:

```txt
LINE_KENJI_AI_DEBUG=true
```

## Tests reported by Codex

```txt
npm test
npm run test:kenji-line
node --test shared/kenji-member-concierge-core.test.mjs
node --test immigrate-worker/netlify/tests/webhook-faq-intent.test.mjs
node --check immigrate-worker/netlify/functions/webhook.js
```

## Manual LINE QA after deploy

Send these in LINE OA:

```txt
เคนจิ
คุยกับ Per AI
จอง
ส่งสลิปแล้ว
ต่ออายุสมาชิก
VIP
SVIP
Black Card
```

Confirm:

- Replies are in warm Kenji voice.
- Booking copy remains safe and does not confirm availability.
- Payment/slip copy says proof is supporting evidence only.
- SVIP is not unlocked by points.
- Black Card is private review only.
- Inbound events still write to Airtable/Console Inbox.
- Deduped events do not reply twice.