### PR TITLE
Hotfix LINE Kenji Rich Menu triggers

### DIFF
--- a/docs/line/kenji-line-official.md
+++ b/docs/line/kenji-line-official.md
@@ -31,6 +31,9 @@ Use the existing Netlify LINE webhook URL. Do not introduce frontend secrets.
 ## Test Phrases
 
 ```text
+Hi Per
+สวัสดี เปอร์
+สวัสดีครับ
 เคนจิ
 คุยกับ Per AI
 จอง
@@ -39,6 +42,8 @@ Use the existing Netlify LINE webhook URL. Do not introduce frontend secrets.
 VIP
 SVIP
 Black Card
+Rich Menu: Hi Per
+Rich Menu: สวัสดี เปอร์
 ```
 
 Expected behavior:
@@ -61,4 +66,3 @@ Expected behavior:
 - Black Card is private review only.
 - LINE OA Kenji does not enable real Worker Control POST actions.
 - Deduped LINE events must not reply twice.
-

--- a/immigrate-worker/netlify/functions/webhook.js
+++ b/immigrate-worker/netlify/functions/webhook.js
@@ -98,6 +98,16 @@ function toTextMessage(event) {
   return String(event.message.text || "").trim();
 }
 
+function getLineEventTextForIntent(event) {
+  if (event?.type === "message" && event?.message?.type === "text") {
+    return String(event.message.text || "").trim();
+  }
+  if (event?.type === "postback") {
+    return String(event?.postback?.displayText || event?.postback?.data || "").trim();
+  }
+  return "";
+}
+
 function isImageMessage(event) {
   return event?.type === "message" && event?.message?.type === "image";
 }
@@ -214,9 +224,14 @@ function looksLikeSpecificModelRequest(text) {
 
 function isTalkToPerAi(text = "") {
   const normalized = normalizeLookup(text).replace(/\s+/g, "");
+  const spaced = normalizeLookup(text);
   return (
     normalized.includes("kenji") ||
     normalized.includes("เคนจิ") ||
+    normalized.includes("hiper") ||
+    normalized.includes("helloper") ||
+    normalized.includes("สวัสดีเปอร์") ||
+    /\b(?:hi|hello)\s+per\b/i.test(spaced) ||
     normalized.includes("คุยกับเปอร์") ||
     normalized.includes("คุยกับเคนจิ") ||
     normalized.includes("คุยกับper") ||
@@ -418,6 +433,8 @@ function inferIntent(text, event) {
 
 function buildAdminNote(event, text) {
   if (text) return text;
+  const intentText = getLineEventTextForIntent(event);
+  if (intentText) return intentText;
   if (event?.type === "follow") return "[follow] user added LINE OA";
   if (event?.type === "unfollow") return "[unfollow] user blocked or removed LINE OA";
   if (event?.type === "postback") return `[postback] ${String(event?.postback?.data || "").trim() || "received"}`;
@@ -449,7 +466,7 @@ function buildAirtableRecord(event) {
 
 function buildAirtableRecordWithProfile(event, profile) {
   const receivedAt = new Date().toISOString();
-  const messageText = toTextMessage(event);
+  const messageText = getLineEventTextForIntent(event);
   const lineUserId = getLineUserId(event);
   const eventId = String(event?.message?.id || event?.webhookEventId || `evt_${Date.now()}`);
   const migrationId = `line_${eventId}`;
@@ -702,7 +719,7 @@ function buildLineMemberSummary(event, profile) {
 }
 
 function buildKenjiLineReply(event, profile, options = {}) {
-  return buildKenjiMemberReply(toTextMessage(event), buildLineMemberSummary(event, profile), {
+  return buildKenjiMemberReply(getLineEventTextForIntent(event), buildLineMemberSummary(event, profile), {
     lineOfficialChatUrl: options.lineOfficialChatUrl || "",
   });
 }
@@ -802,7 +819,7 @@ function logLineWebhookDebug(options, data) {
 }
 
 async function buildAutoReplyMessage(event, profile, options = {}) {
-  const text = toTextMessage(event);
+  const text = getLineEventTextForIntent(event);
   const name = String(profile?.displayName || "").trim();
   const firstName = name ? name.split(/\s+/)[0] : "";
   const prefix = firstName ? `${firstName} ` : "";
@@ -992,7 +1009,7 @@ export async function handler(event) {
 
   for (const item of events) {
     const lineUserId = getLineUserId(item);
-    const messageText = toTextMessage(item);
+    const messageText = getLineEventTextForIntent(item);
     const clientTagged = hasClientTag(messageText);
     const intent = inferIntent(messageText, item);
     const shouldFetchProfile =
@@ -1043,4 +1060,4 @@ export async function handler(event) {
   });
 }
 
-export { buildAutoReplyMessage, buildFaqReply, choosePricingReplyStrategy, inferFaqIntent, inferIntent, parseAdContextFromText, shouldAutoReplyForIntent };
+export { buildAutoReplyMessage, buildFaqReply, choosePricingReplyStrategy, getLineEventTextForIntent, inferFaqIntent, inferIntent, parseAdContextFromText, shouldAutoReplyForIntent };

--- a/immigrate-worker/netlify/tests/webhook-faq-intent.test.mjs
+++ b/immigrate-worker/netlify/tests/webhook-faq-intent.test.mjs
@@ -3,6 +3,7 @@ import {
   buildAutoReplyMessage,
   buildFaqReply,
   choosePricingReplyStrategy,
+  getLineEventTextForIntent,
   inferFaqIntent,
   inferIntent,
   shouldAutoReplyForIntent,
@@ -21,6 +22,13 @@ const imageEvent = (context = {}) => ({
   source: { type: "user", userId: "U123" },
   replyToken: "reply-token",
   ...context,
+});
+
+const postbackEvent = (data, displayText = "") => ({
+  type: "postback",
+  postback: { data, displayText },
+  source: { type: "user", userId: "U123" },
+  replyToken: "reply-token",
 });
 
 assert.equal(inferFaqIntent("สอบถามเรทได้ที่ไหนครับ"), "ask_where_to_get_rate");
@@ -61,6 +69,24 @@ const profile = { displayName: "Boss" };
 const kenjiReply = await buildAutoReplyMessage(textEvent("เคนจิ"), profile, { lineKenjiAiEnabled: true });
 assert.match(kenjiReply, /Kenji/);
 assert.match(kenjiReply, /ผู้ช่วยสมาชิก/);
+
+const hiPerReply = await buildAutoReplyMessage(textEvent("Hi Per"), profile, { lineKenjiAiEnabled: true });
+assert.match(hiPerReply, /Kenji/);
+assert.match(hiPerReply, /ผู้ช่วยสมาชิก/);
+
+const thaiHiPerReply = await buildAutoReplyMessage(textEvent("สวัสดี เปอร์"), profile, { lineKenjiAiEnabled: true });
+assert.match(thaiHiPerReply, /Kenji/);
+assert.match(thaiHiPerReply, /ผู้ช่วยสมาชิก/);
+
+const plainGreetingReply = await buildAutoReplyMessage(textEvent("สวัสดีครับ"), profile, { lineKenjiAiEnabled: true });
+assert.match(plainGreetingReply, /สวัสดีครับ/);
+assert.match(plainGreetingReply, /วันนี้ให้ผมช่วย/);
+
+const richMenuPostback = postbackEvent("action=kenji&trigger=Hi%20Per", "Hi Per");
+assert.equal(getLineEventTextForIntent(richMenuPostback), "Hi Per");
+const postbackReply = await buildAutoReplyMessage(richMenuPostback, profile, { lineKenjiAiEnabled: true });
+assert.match(postbackReply, /Kenji/);
+assert.match(postbackReply, /ผู้ช่วยสมาชิก/);
 
 const slipReply = await buildAutoReplyMessage(textEvent("ส่งสลิปแล้ว"), profile, { lineKenjiAiEnabled: true });
 assert.match(slipReply, /supporting evidence/);

--- a/shared/kenji-member-concierge-core.mjs
+++ b/shared/kenji-member-concierge-core.mjs
@@ -116,7 +116,17 @@ export function classifyKenjiMemberIntent(input, memberSummary = {}) {
 
   if (
     includesAny(text, ["kenji", "kenji ai", "per ai", "เคนจิ", "เปอร์ ai"]) ||
-    includesAny(dense, ["คุยกับเคนจิ", "คุยกับperai", "คุยกับเปอร์ai", "ขอคุยกับเคนจิ", "ขอคุยกับperai"])
+    includesAny(dense, [
+      "คุยกับเคนจิ",
+      "คุยกับperai",
+      "คุยกับเปอร์ai",
+      "ขอคุยกับเคนจิ",
+      "ขอคุยกับperai",
+      "hiper",
+      "helloper",
+      "สวัสดีเปอร์",
+    ]) ||
+    /\b(?:hi|hello)\s+per\b/i.test(text)
   ) {
     return { intent: INTENTS.TALK_TO_PER_AI, confidence: 0.9 };
   }

--- a/shared/kenji-member-concierge-core.test.mjs
+++ b/shared/kenji-member-concierge-core.test.mjs
@@ -10,6 +10,12 @@ const summary = getSafeMemberSummary({ display_name: "บอส", active_points:
 
 assert.equal(classifyKenjiMemberIntent("").intent, "empty");
 assert.equal(classifyKenjiMemberIntent("สวัสดีครับ").intent, "greeting");
+assert.equal(classifyKenjiMemberIntent("Hi Per").intent, "talk_to_per_ai");
+assert.equal(classifyKenjiMemberIntent("hi per").intent, "talk_to_per_ai");
+assert.equal(classifyKenjiMemberIntent("hiper").intent, "talk_to_per_ai");
+assert.equal(classifyKenjiMemberIntent("hello per").intent, "talk_to_per_ai");
+assert.equal(classifyKenjiMemberIntent("สวัสดี เปอร์").intent, "talk_to_per_ai");
+assert.equal(classifyKenjiMemberIntent("สวัสดีเปอร์").intent, "talk_to_per_ai");
 assert.equal(classifyKenjiMemberIntent("เคนจิ").intent, "talk_to_per_ai");
 assert.equal(classifyKenjiMemberIntent("คุยกับ Per AI").intent, "talk_to_per_ai");
 assert.equal(classifyKenjiMemberIntent("อยากจองครับ").intent, "booking");
@@ -50,4 +56,3 @@ const pointsReply = buildKenjiMemberReply("แต้ม", summary);
 assert.match(pointsReply, /1,280/);
 
 console.log("kenji member concierge core tests passed");
-


### PR DESCRIPTION
## Summary
- Routes canonical Rich Menu triggers `Hi Per` and `สวัสดี เปอร์` into the Kenji / Per AI concierge flow.
- Adds compact variants including `hiper`, `hi per`, `hello per`, `สวัสดีเปอร์`, and `สวัสดี เปอร์` without converting plain `hi` or plain `สวัสดีครับ` into Per AI.
- Adds postback-safe intent text extraction via `getLineEventTextForIntent()` so Rich Menu postbacks can use `displayText` or `data` for routing while preserving text message handling.
- Updates LINE Kenji docs and tests.

## Safety notes
- No secrets committed.
- No public/query/body `token` field introduced.
- No promo/access-code changes.
- No `chat-worker/kv-list.json` created.
- No `wrangler 2.toml` modified.
- Payment/SVIP/Black Card safety unchanged.
- Existing pricing/model availability behavior preserved.

## Tests run
```text
npm test
npm run test:kenji-line
node --test shared/kenji-member-concierge-core.test.mjs
node --test immigrate-worker/netlify/tests/webhook-faq-intent.test.mjs
node --check immigrate-worker/netlify/functions/webhook.js
```

## Manual QA
- Send `Hi Per` in LINE OA and confirm Kenji/Per AI concierge reply.
- Send `สวัสดี เปอร์` in LINE OA and confirm Kenji/Per AI concierge reply.
- Send `สวัสดีครับ` and confirm it remains a greeting.
- Tap Rich Menu `Hi Per` / `สวัสดี เปอร์` postback and confirm it routes to Kenji concierge.
- Confirm pricing/model availability behavior still follows the existing paths.
