### PR TITLE
Hotfix LINE webhook bridge for mmdbkk.com

### DIFF
--- a/docs/line/kenji-line-official.md
+++ b/docs/line/kenji-line-official.md
@@ -9,7 +9,25 @@ Kenji LINE OA is the member-facing concierge entry for MMD Privé. It is not the
 - `/sigil/board`: internal system/admin/rules/control layer
 - LINE OA Kenji: member-facing conversational entry
 
+## Production Webhook Route
+
+LINE Official should keep using the stable MMD domain route:
+
+```text
+https://mmdbkk.com/webhooks/line
+```
+
+This route is owned at the `mmd-redirect-worker` front gate and can bridge to the configured LINE webhook implementation through:
+
+```text
+LINE_WEBHOOK_UPSTREAM_URL=https://<your-site>.netlify.app/.netlify/functions/webhook
+```
+
+Do not ask LINE Official to point directly to Netlify as the long-term production URL unless there is an intentional migration decision. The public LINE OA URL should remain stable on `mmdbkk.com`; the upstream can be changed behind the gate.
+
 ## Required Env
+
+For the active LINE webhook implementation:
 
 ```text
 LINE_AUTO_REPLY_ENABLED=true
@@ -20,13 +38,17 @@ AIRTABLE_API_KEY=...
 AIRTABLE_BASE_ID=...
 ```
 
+For the `mmdbkk.com/webhooks/line` bridge in `mmd-redirect-worker`:
+
+```text
+LINE_WEBHOOK_UPSTREAM_URL=https://<your-site>.netlify.app/.netlify/functions/webhook
+```
+
 Optional:
 
 ```text
 LINE_KENJI_AI_DEBUG=true
 ```
-
-Use the existing Netlify LINE webhook URL. Do not introduce frontend secrets.
 
 ## Test Phrases
 
@@ -66,3 +88,4 @@ Expected behavior:
 - Black Card is private review only.
 - LINE OA Kenji does not enable real Worker Control POST actions.
 - Deduped LINE events must not reply twice.
+- Netlify / immigrate-worker can be an upstream compatibility target, but should not become the canonical long-term LINE route owner.

--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -16,8 +16,6 @@ export const ADMIN_WORKER_UPSTREAM = "https://admin-worker.malemodel-bkk.workers
 export const FRONT_GATE = "mmd-redirect-worker";
 export const FRONT_VERSION = "20260617T060000Z";
 
-// Domains that should redirect into the canonical site.
-// Add/remove domains here only.
 export const REDIRECT_HOSTS = new Set([
   "www.mmdbkk.com",
   "mmdbkk.com",
@@ -26,7 +24,6 @@ export const REDIRECT_HOSTS = new Set([
   "malemodel-bkk.workers.dev",
 ]);
 
-// Subdomains or hosts that must never be redirected by this worker.
 export const NEVER_TOUCH_HOSTS = new Set(["sigil.mmdbkk.com"]);
 
 export const LINE_WEBHOOK_PATHS = new Set([
@@ -36,8 +33,6 @@ export const LINE_WEBHOOK_PATHS = new Set([
   "/webhook/line/",
 ]);
 
-// These are not normal public pages.
-// Do not redirect payment/API/webhook/admin traffic unless intentionally designed.
 export const NEVER_TOUCH_PREFIXES = [
   "/api/",
   "/webhook/",
@@ -54,10 +49,6 @@ export const NEVER_TOUCH_PREFIXES = [
   "/uploads/",
 ];
 
-// Host-agnostic front-router protected pages owned by another Worker/source.
-// These paths must pass through exactly, with query strings preserved, so the
-// member dashboard cannot accidentally fall back to Webflow or legacy redirects
-// on either mmdbkk.com or www.mmdbkk.com.
 export const NEVER_REDIRECT_EXACT_PATHS = new Set([
   "/member/dashboard",
   "/member/dashboard/",
@@ -71,8 +62,6 @@ export const NEVER_REDIRECT_EXACT_PATHS = new Set([
   "/model/console/",
 ]);
 
-// Exact old-path to new-path redirects.
-// Keep lowercase keys. The target can keep proper casing if needed.
 export const EXACT_PATH_REDIRECTS = {
   "/inme": "/trust/inme",
   "/login": "/trust/inme",
@@ -85,8 +74,6 @@ export const EXACT_PATH_REDIRECTS = {
   "/trust": "/trust/inme",
 };
 
-// Folder-level redirects.
-// Example: /old-academy/anything -> /academy/anything
 export const FOLDER_REDIRECTS = [
   {
     from: "/old-academy/",
@@ -105,25 +92,17 @@ export function isSafePageRequest(request) {
 
 export function normalizePath(pathname) {
   let path = pathname || "/";
-
-  // Collapse duplicate slashes: /a//b -> /a/b
   path = path.replace(/\/{2,}/g, "/");
-
-  // Remove trailing slash except root.
-  // Example: /trust/inme/ -> /trust/inme
   if (path.length > 1) {
     path = path.replace(/\/+$/g, "");
   }
-
   return path || "/";
 }
 
 export function shouldNeverTouch(url) {
   if (NEVER_TOUCH_HOSTS.has(url.hostname)) return true;
-
   const pathname = url.pathname.toLowerCase();
   if (NEVER_REDIRECT_EXACT_PATHS.has(pathname)) return true;
-
   return NEVER_TOUCH_PREFIXES.some((prefix) => {
     return pathname === prefix.slice(0, -1) || pathname.startsWith(prefix);
   });
@@ -134,7 +113,6 @@ export function buildTargetUrl(originalUrl, nextPathname) {
   target.protocol = CANONICAL_PROTOCOL;
   target.hostname = CANONICAL_HOST;
   target.pathname = nextPathname;
-  // target.search is preserved automatically.
   return target;
 }
 
@@ -175,7 +153,7 @@ function confirmPaymentDashboardBridgeScript() {
       requestUrl = typeof input === "string" ? input : input && input.url || "";
     } catch (_) {}
     var result = originalFetch.apply(this, arguments);
-    if (!/(\/v1\/payments\/notify(?:\?|$)|\/sigil\/api\/payments\/manual-intake(?:\?|$))/.test(requestUrl)) return result;
+    if (!/(\\/v1\\/payments\\/notify(?:\\?|$)|\\/sigil\\/api\\/payments\\/manual-intake(?:\\?|$))/.test(requestUrl)) return result;
     return result.then(function(response){
       try {
         response.clone().json().then(function(payload){
@@ -207,12 +185,10 @@ async function maybeInjectConfirmPaymentBridge(request, response, url) {
   if (!isConfirmPaymentPage(url)) return response;
   const contentType = response.headers.get("content-type") || "";
   if (!contentType.toLowerCase().includes("text/html")) return response;
-
   const html = await response.text();
   if (html.includes("mmd-confirm-dashboard-bridge")) {
     return new Response(html, response);
   }
-
   const script = confirmPaymentDashboardBridgeScript();
   const rewritten = html.includes("</body>")
     ? html.replace("</body>", `${script}</body>`)
@@ -238,14 +214,11 @@ function isLineWebhookPath(url) {
 
 async function fetchLineWebhook(request, env = {}, url) {
   const upstream = String(env?.LINE_WEBHOOK_UPSTREAM_URL || "").trim();
-
   if (!upstream) {
     return fetchPassThrough(request);
   }
-
   const target = new URL(upstream);
   target.search = url.search;
-
   const upstreamRequest = new Request(target.toString(), request);
   return withFrontGateHeaders(await fetch(upstreamRequest));
 }
@@ -290,14 +263,9 @@ function isMemberFrontendPath(url) {
 }
 
 async function fetchMemberFrontend(request, env, url) {
-  // TODO(member-route-migration): /member/dashboard and /member/membership are
-  // legacy locked routes still owned by immigrate-worker. Do not add new
-  // member-facing route dependencies here; migrate these to the canonical
-  // member layer when it is ready.
   if (env?.IMMIGRATE_WORKER?.fetch) {
     return withFrontGateHeaders(await env.IMMIGRATE_WORKER.fetch(request));
   }
-
   const target = new URL(MEMBER_DASHBOARD_UPSTREAM);
   target.pathname = url.pathname;
   target.search = url.search;
@@ -308,7 +276,6 @@ async function fetchAdminMemberPage(request, env, url) {
   if (env?.ADMIN_WORKER?.fetch) {
     return withFrontGateHeaders(await env.ADMIN_WORKER.fetch(request));
   }
-
   const target = new URL(ADMIN_WORKER_UPSTREAM);
   target.pathname = url.pathname;
   target.search = url.search;
@@ -322,9 +289,7 @@ function formatMemberPageHeading(pathname) {
     .split("-")
     .filter(Boolean)
     .slice(0, 6);
-
   if (!words.length) return "Member Page";
-
   return words
     .map((word) => {
       if (/^\d+$/.test(word) || word.length <= 2) return word.toUpperCase();
@@ -372,7 +337,6 @@ function renderRouteRecoveryShell(request, page, title, heading, copy, links = [
     </main>
   </body>
 </html>`;
-
   return new Response(request.method.toUpperCase() === "HEAD" ? null : html, {
     headers: {
       "content-type": "text/html; charset=utf-8",
@@ -434,11 +398,9 @@ function renderModelConsoleRecovery(request) {
 export function findMappedPath(pathname) {
   const normalized = normalizePath(pathname);
   const key = normalized.toLowerCase();
-
   if (EXACT_PATH_REDIRECTS[key]) {
     return EXACT_PATH_REDIRECTS[key];
   }
-
   for (const rule of FOLDER_REDIRECTS) {
     const fromLower = rule.from.toLowerCase();
     if (key.startsWith(fromLower)) {
@@ -446,67 +408,48 @@ export function findMappedPath(pathname) {
       return `${rule.to}${rest}`.replace(/\/{2,}/g, "/");
     }
   }
-
   return normalized;
 }
 
 export default {
   async fetch(request, env = {}) {
     const url = new URL(request.url);
-
     if (isLineWebhookPath(url)) {
       return fetchLineWebhook(request, env, url);
     }
-
-    // Safety: never redirect non-page traffic.
-    // This prevents breaking POST/payment/webhook/API flows.
     if (!isSafePageRequest(request)) {
       return withFrontGateHeaders(await fetch(request));
     }
-
     if (isMemberFrontendPath(url)) {
       return fetchMemberFrontend(request, env, url);
     }
-
     if (isMemberPaymentsPath(url)) {
       return fetchAdminMemberPage(request, env, url);
     }
-
     if (isHallPath(url)) {
       return renderHallRecovery(request);
     }
-
     if (isModelConsolePath(url)) {
       return renderModelConsoleRecovery(request);
     }
-
     if (isMemberPath(url) && !isKnownLegacyMemberRedirect(url)) {
       return renderMemberStaticRecovery(request);
     }
-
     if (shouldNeverTouch(url)) {
       return fetchPassThrough(request);
     }
-
-    // If this host is not managed by this redirect worker, pass through.
     if (!REDIRECT_HOSTS.has(url.hostname)) {
       return fetchPassThrough(request);
     }
-
     const mappedPath = findMappedPath(url.pathname);
     const target = buildTargetUrl(url, mappedPath);
-
     const needsRedirect =
       url.protocol !== CANONICAL_PROTOCOL ||
       url.hostname !== CANONICAL_HOST ||
       url.pathname !== mappedPath;
-
-    // Prevent redirect loop.
     if (!needsRedirect || target.toString() === url.toString()) {
       return fetchPassThrough(request);
     }
-
-    // 301 = permanent redirect for public pages.
     return withFrontGateHeaders(Response.redirect(target.toString(), 301));
   },
 };

--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -14,7 +14,7 @@ export const CONFIRM_PAYMENT_PATH = "/confirm/payment-confirmation";
 export const MEMBER_DASHBOARD_UPSTREAM = "https://immigrate-worker.malemodel-bkk.workers.dev";
 export const ADMIN_WORKER_UPSTREAM = "https://admin-worker.malemodel-bkk.workers.dev";
 export const FRONT_GATE = "mmd-redirect-worker";
-export const FRONT_VERSION = "20260616T051100Z";
+export const FRONT_VERSION = "20260617T060000Z";
 
 // Domains that should redirect into the canonical site.
 // Add/remove domains here only.
@@ -28,6 +28,13 @@ export const REDIRECT_HOSTS = new Set([
 
 // Subdomains or hosts that must never be redirected by this worker.
 export const NEVER_TOUCH_HOSTS = new Set(["sigil.mmdbkk.com"]);
+
+export const LINE_WEBHOOK_PATHS = new Set([
+  "/webhooks/line",
+  "/webhooks/line/",
+  "/webhook/line",
+  "/webhook/line/",
+]);
 
 // These are not normal public pages.
 // Do not redirect payment/API/webhook/admin traffic unless intentionally designed.
@@ -168,7 +175,7 @@ function confirmPaymentDashboardBridgeScript() {
       requestUrl = typeof input === "string" ? input : input && input.url || "";
     } catch (_) {}
     var result = originalFetch.apply(this, arguments);
-    if (!/(\\/v1\\/payments\\/notify(?:\\?|$)|\\/sigil\\/api\\/payments\\/manual-intake(?:\\?|$))/.test(requestUrl)) return result;
+    if (!/(\/v1\/payments\/notify(?:\?|$)|\/sigil\/api\/payments\/manual-intake(?:\?|$))/.test(requestUrl)) return result;
     return result.then(function(response){
       try {
         response.clone().json().then(function(payload){
@@ -223,6 +230,24 @@ async function fetchPassThrough(request) {
   const url = new URL(request.url);
   const response = await fetch(new Request(request, { redirect: "follow" }));
   return withFrontGateHeaders(await maybeInjectConfirmPaymentBridge(request, response, url));
+}
+
+function isLineWebhookPath(url) {
+  return LINE_WEBHOOK_PATHS.has(url.pathname.toLowerCase());
+}
+
+async function fetchLineWebhook(request, env = {}, url) {
+  const upstream = String(env?.LINE_WEBHOOK_UPSTREAM_URL || "").trim();
+
+  if (!upstream) {
+    return fetchPassThrough(request);
+  }
+
+  const target = new URL(upstream);
+  target.search = url.search;
+
+  const upstreamRequest = new Request(target.toString(), request);
+  return withFrontGateHeaders(await fetch(upstreamRequest));
 }
 
 function isMemberDashboardPath(url) {
@@ -428,6 +453,10 @@ export function findMappedPath(pathname) {
 export default {
   async fetch(request, env = {}) {
     const url = new URL(request.url);
+
+    if (isLineWebhookPath(url)) {
+      return fetchLineWebhook(request, env, url);
+    }
 
     // Safety: never redirect non-page traffic.
     // This prevents breaking POST/payment/webhook/API flows.

--- a/mmd-redirect-worker/test/line-webhook-bridge.test.mjs
+++ b/mmd-redirect-worker/test/line-webhook-bridge.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import worker from "../src/index.js";
+
+let originalFetch;
+let upstreamRequests;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  upstreamRequests = [];
+  globalThis.fetch = async (request) => {
+    upstreamRequests.push(request);
+    return new Response("line upstream", {
+      status: 209,
+      headers: { "x-test-line-upstream": "1" },
+    });
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function requestWithEnv(url, env, init) {
+  return worker.fetch(new Request(url, init), env);
+}
+
+describe("LINE webhook bridge", () => {
+  it("bridges mmdbkk.com /webhooks/line to the configured upstream", async () => {
+    const env = {
+      LINE_WEBHOOK_UPSTREAM_URL: "https://example.com/.netlify/functions/webhook",
+    };
+
+    const response = await requestWithEnv("https://mmdbkk.com/webhooks/line?debug=1", env, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-mmd-test-signature": "test-signature",
+      },
+      body: JSON.stringify({ events: [] }),
+    });
+
+    assert.equal(response.status, 209);
+    assert.equal(response.headers.get("x-mmd-front-gate"), "mmd-redirect-worker");
+    assert.equal(response.headers.get("x-test-line-upstream"), "1");
+    assert.equal(upstreamRequests.length, 1);
+    assert.equal(upstreamRequests[0].url, "https://example.com/.netlify/functions/webhook?debug=1");
+    assert.equal(upstreamRequests[0].method, "POST");
+    assert.equal(upstreamRequests[0].headers.get("x-mmd-test-signature"), "test-signature");
+  });
+
+  it("keeps /webhooks/line as pass-through when no bridge upstream is configured", async () => {
+    const response = await requestWithEnv("https://mmdbkk.com/webhooks/line", {}, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ events: [] }),
+    });
+
+    assert.equal(response.status, 209);
+    assert.equal(response.headers.get("x-mmd-front-gate"), "mmd-redirect-worker");
+    assert.equal(upstreamRequests.length, 1);
+    assert.equal(upstreamRequests[0].url, "https://mmdbkk.com/webhooks/line");
+  });
+});


### PR DESCRIPTION
Summary:
- Keeps LINE Official webhook URL stable at https://mmdbkk.com/webhooks/line.
- Adds a configurable mmd-redirect-worker bridge for /webhooks/line and /webhook/line through LINE_WEBHOOK_UPSTREAM_URL.
- Preserves query strings and request method/headers/body when forwarding to the configured upstream.
- Adds bridge tests and updates LINE Kenji docs so production is no longer described as a direct Netlify URL.

Required production env:
LINE_WEBHOOK_UPSTREAM_URL should point to the deployed LINE webhook implementation.

Why:
PR #73 updated the Netlify LINE webhook handler, but the active LINE OA webhook URL remains https://mmdbkk.com/webhooks/line. This bridge lets the existing public URL stay stable while routing to the implementation that currently contains the Kenji/Per AI trigger fixes.

Safety notes:
- No secrets committed.
- No token field introduced.
- No promo/access-code changes.
- No payment/SVIP/Black Card changes.
- Does not make Netlify the canonical public LINE route owner; it is only a configurable upstream behind mmdbkk.com.

Tests to run:
node --test mmd-redirect-worker/test/redirect.test.mjs
node --test mmd-redirect-worker/test/line-webhook-bridge.test.mjs
node --check mmd-redirect-worker/src/index.js
