### PR TITLE
Add Webflow V7 gate usage snippet

### DIFF
--- a/webflow/sigil/board/README.md
+++ b/webflow/sigil/board/README.md
@@ -29,3 +29,40 @@ localStorage.setItem("mmd_board_v70_role", "boss_per");
 
 This helper does not include secrets and does not send production writes from
 Webflow.
+
+### Webflow Placement For `/sigil/board`
+
+1. Add the V7 board embed first on the `/sigil/board` Webflow page.
+2. The embed must include the V7 root and gate elements shown in
+   `kenji-board-v70-webflow-snippet.html`:
+   - `[data-mmd-board-v70]`
+   - `[data-v70-gate-passphrase]`
+   - `[data-v70-action="unlock-gate"]`
+   - `[data-v70-gate-status]`
+3. Load `kenji-board-v70-gate.js` after the V7 board embed/root markup.
+
+Recommended Webflow order:
+
+```html
+<!-- 1. V7 board embed/root markup first -->
+<!-- Paste the contents of kenji-board-v70-webflow-snippet.html, excluding this comment. -->
+
+<!-- 2. Gate helper after the V7 board embed -->
+<script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/sigil/board/kenji-board-v70-gate.js"></script>
+```
+
+### Smoke Test
+
+1. Open `/sigil/board`.
+2. Enter the mock passphrase `sigil`.
+3. Click the element with `[data-v70-action="unlock-gate"]`.
+4. Confirm the browser localStorage values:
+
+```js
+localStorage.getItem("mmd_board_v70_gate") === "unlocked";
+localStorage.getItem("mmd_board_v70_role") === "boss_per";
+```
+
+This is a Webflow UI gate only. It must not perform backend writes, Worker
+route changes, Airtable writes, payment changes, membership changes, token
+handling changes, SVIP changes, or Black Card behavior changes.

--- a/webflow/sigil/board/kenji-board-v70-gate.test.mjs
+++ b/webflow/sigil/board/kenji-board-v70-gate.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const source = await readFile(new URL("./kenji-board-v70-gate.js", import.meta.url), "utf8");
+const snippet = await readFile(new URL("./kenji-board-v70-webflow-snippet.html", import.meta.url), "utf8");
 
 test("V7 gate helper uses delegated click handling and fallback unlock API", () => {
   assert.match(source, /document\.addEventListener\("click"/);
@@ -18,4 +19,31 @@ test("V7 gate helper keeps the mock passphrase client-only", () => {
   assert.doesNotMatch(source, /\bfetch\s*\(/);
   assert.doesNotMatch(source, /XMLHttpRequest/);
   assert.doesNotMatch(source, /\bmethod\s*:\s*["']POST["']/i);
+});
+
+test("V7 Webflow snippet includes required root and gate selectors", () => {
+  assert.match(snippet, /data-mmd-board-v70/);
+  assert.match(snippet, /data-v70-gate-passphrase/);
+  assert.match(snippet, /data-v70-action="unlock-gate"/);
+  assert.match(snippet, /data-v70-gate-status/);
+  assert.match(snippet, /kenji-board-v70-gate\.js/);
+});
+
+test("V7 Webflow snippet stays secret-free and read-only", () => {
+  const forbidden = [
+    /\bfetch\s*\(/i,
+    /\bmethod\s*:\s*["']POST["']/i,
+    /XMLHttpRequest/i,
+    /Airtable\s*token/i,
+    /AIRTABLE_[A-Z0-9_]+/i,
+    /admin[_ -]?key/i,
+    /worker\s*secret/i,
+    /wrangler\s+secret/i,
+    /sk-[A-Za-z0-9_-]+/i,
+    /pat[A-Za-z0-9]{10,}/i
+  ];
+
+  for (const pattern of forbidden) {
+    assert.doesNotMatch(snippet, pattern);
+  }
 });

--- a/webflow/sigil/board/kenji-board-v70-gate.test.mjs
+++ b/webflow/sigil/board/kenji-board-v70-gate.test.mjs
@@ -29,6 +29,22 @@ test("V7 Webflow snippet includes required root and gate selectors", () => {
   assert.match(snippet, /kenji-board-v70-gate\.js/);
 });
 
+test("V7 Webflow snippet keeps wrapper neutral so only unlock control matches gate action", () => {
+  const classTokens = Array.from(snippet.matchAll(/class="([^"]*)"/g))
+    .flatMap((match) => match[1].split(/\s+/).filter(Boolean));
+
+  assert.match(snippet, /class="mmd-board-v70__gate-panel"/);
+  assert.match(snippet, /data-v70-gate-panel/);
+  assert.ok(!classTokens.includes("mmd-board-v70__gate"));
+  assert.doesNotMatch(snippet, /data-mmd-board-v70-unlock/);
+  assert.doesNotMatch(snippet, /data-mmd-board-v70-gate/);
+  assert.doesNotMatch(snippet, /data-gate-action="unlock"/);
+
+  const unlockActionMatches = snippet.match(/data-v70-action="unlock-gate"/g) || [];
+  assert.equal(unlockActionMatches.length, 1);
+  assert.match(snippet, /<button[^>]*data-v70-action="unlock-gate"[^>]*>/);
+});
+
 test("V7 Webflow snippet stays secret-free and read-only", () => {
   const forbidden = [
     /\bfetch\s*\(/i,

--- a/webflow/sigil/board/kenji-board-v70-webflow-snippet.html
+++ b/webflow/sigil/board/kenji-board-v70-webflow-snippet.html
@@ -5,7 +5,7 @@
   2. Load kenji-board-v70-gate.js after this embed.
 -->
 <section data-mmd-board-v70 data-gate="locked" data-role="guest">
-  <div class="mmd-board-v70__gate">
+  <div class="mmd-board-v70__gate-panel" data-v70-gate-panel>
     <label for="mmd-board-v70-passphrase">Gate passphrase</label>
     <input
       id="mmd-board-v70-passphrase"

--- a/webflow/sigil/board/kenji-board-v70-webflow-snippet.html
+++ b/webflow/sigil/board/kenji-board-v70-webflow-snippet.html
@@ -1,0 +1,26 @@
+<!--
+  MMD SIGIL Board V7.0 Webflow embed snippet
+  Placement:
+  1. Paste the V7 board embed/root markup first on /sigil/board.
+  2. Load kenji-board-v70-gate.js after this embed.
+-->
+<section data-mmd-board-v70 data-gate="locked" data-role="guest">
+  <div class="mmd-board-v70__gate">
+    <label for="mmd-board-v70-passphrase">Gate passphrase</label>
+    <input
+      id="mmd-board-v70-passphrase"
+      type="password"
+      autocomplete="off"
+      data-v70-gate-passphrase
+    />
+    <button type="button" data-v70-action="unlock-gate">
+      Unlock V7 Gate
+    </button>
+    <p data-v70-gate-status aria-live="polite">
+      Gate locked.
+    </p>
+  </div>
+</section>
+
+<!-- Load after the V7 board embed/root markup. -->
+<script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/sigil/board/kenji-board-v70-gate.js"></script>


### PR DESCRIPTION
## Summary
- Add a Webflow-ready `/sigil/board` V7 gate snippet with the required root, passphrase, action, and status selectors.
- Document exact Webflow placement order: V7 board embed first, then `kenji-board-v70-gate.js`.
- Extend node:test coverage to assert snippet selectors and block production-write/secret patterns.

## Test Notes
- `node --test webflow/sigil/board/kenji-board-v70-gate.test.mjs`
- `npm test`

## Scope Notes
- Webflow/SIGIL Board UI integration only.
- No Worker route changes.
- No production writes from Webflow.
- No backend/API/payment/membership/SVIP/Black Card/token/Airtable behavior changes.