### PR TITLE
Add Webflow V7 board smoke helper

### DIFF
--- a/webflow/sigil/board/README.md
+++ b/webflow/sigil/board/README.md
@@ -32,36 +32,76 @@ Webflow.
 
 ### Webflow Placement For `/sigil/board`
 
-1. Add the V7 board embed first on the `/sigil/board` Webflow page.
-2. The embed must include the V7 root and gate elements shown in
+1. Add the HTML/root embed first on the `/sigil/board` Webflow page.
+2. Add the main V7 board inline JS after the HTML/root embed.
+3. Load `kenji-board-v70-gate.js` after the V7 board/root markup and board
+   inline JS.
+4. Load `kenji-board-v70-smoke-test.js` last, or in Webflow **Before
+   `</body>`**.
+5. The HTML/root embed must include the V7 root and gate elements shown in
    `kenji-board-v70-webflow-snippet.html`:
    - `[data-mmd-board-v70]`
    - `[data-v70-gate-passphrase]`
    - `[data-v70-action="unlock-gate"]`
    - `[data-v70-gate-status]`
-3. Load `kenji-board-v70-gate.js` after the V7 board embed/root markup.
 
 Recommended Webflow order:
 
 ```html
-<!-- 1. V7 board embed/root markup first -->
+<!-- 1. HTML/root embed first -->
 <!-- Paste the contents of kenji-board-v70-webflow-snippet.html, excluding this comment. -->
 
-<!-- 2. Gate helper after the V7 board embed -->
+<!-- 2. Main V7 board inline JS after the HTML/root embed -->
+<script>
+  /* Paste the main Kenji Board V7.0 inline JS here. */
+</script>
+
+<!-- 3. Gate helper after the V7 board/root markup -->
 <script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/sigil/board/kenji-board-v70-gate.js"></script>
+
+<!-- 4. Smoke helper last, or in Webflow Before </body> -->
+<script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/sigil/board/kenji-board-v70-smoke-test.js"></script>
 ```
 
 ### Smoke Test
 
 1. Open `/sigil/board`.
-2. Enter the mock passphrase `sigil`.
-3. Click the element with `[data-v70-action="unlock-gate"]`.
-4. Confirm the browser localStorage values:
+2. Confirm the gate helper is loaded:
+
+```js
+typeof window.mmdBoardV70UnlockGate === "function";
+```
+
+3. Run the smoke helper from the console:
+
+```js
+window.mmdBoardV70SmokeTest();
+```
+
+Expected result after the helper unlocks the local Webflow gate:
+
+```js
+{
+  ok: true,
+  root: true,
+  passphraseInput: true,
+  unlockButton: true,
+  status: true,
+  helperLoaded: true,
+  gate: "unlocked",
+  role: "boss_per"
+}
+```
+
+4. You can also confirm the browser localStorage values directly:
 
 ```js
 localStorage.getItem("mmd_board_v70_gate") === "unlocked";
 localStorage.getItem("mmd_board_v70_role") === "boss_per";
 ```
+
+If the gate is still locked, the smoke helper attempts
+`window.mmdBoardV70UnlockGate("sigil")` client-side only.
 
 This is a Webflow UI gate only. It must not perform backend writes, Worker
 route changes, Airtable writes, payment changes, membership changes, token

--- a/webflow/sigil/board/kenji-board-v70-gate.test.mjs
+++ b/webflow/sigil/board/kenji-board-v70-gate.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 const source = await readFile(new URL("./kenji-board-v70-gate.js", import.meta.url), "utf8");
 const snippet = await readFile(new URL("./kenji-board-v70-webflow-snippet.html", import.meta.url), "utf8");
+const smoke = await readFile(new URL("./kenji-board-v70-smoke-test.js", import.meta.url), "utf8");
 
 test("V7 gate helper uses delegated click handling and fallback unlock API", () => {
   assert.match(source, /document\.addEventListener\("click"/);
@@ -27,6 +28,7 @@ test("V7 Webflow snippet includes required root and gate selectors", () => {
   assert.match(snippet, /data-v70-action="unlock-gate"/);
   assert.match(snippet, /data-v70-gate-status/);
   assert.match(snippet, /kenji-board-v70-gate\.js/);
+  assert.match(snippet, /kenji-board-v70-smoke-test\.js/);
 });
 
 test("V7 Webflow snippet keeps wrapper neutral so only unlock control matches gate action", () => {
@@ -61,5 +63,38 @@ test("V7 Webflow snippet stays secret-free and read-only", () => {
 
   for (const pattern of forbidden) {
     assert.doesNotMatch(snippet, pattern);
+  }
+});
+
+test("V7 smoke helper exposes console smoke API and checks required selectors", () => {
+  assert.match(smoke, /window\.mmdBoardV70SmokeTest = runSmokeTest/);
+  assert.match(smoke, /typeof window\.mmdBoardV70UnlockGate === "function"/);
+  assert.match(smoke, /window\.mmdBoardV70UnlockGate\("sigil"\)/);
+  assert.match(smoke, /localStorage\.getItem\(key\)/);
+  assert.match(smoke, /mmd_board_v70_gate/);
+  assert.match(smoke, /mmd_board_v70_role/);
+  assert.match(smoke, /boss_per/);
+  assert.match(smoke, /\[data-mmd-board-v70\]/);
+  assert.match(smoke, /\[data-v70-gate-passphrase\]/);
+  assert.match(smoke, /\[data-v70-action=\\"unlock-gate\\"\]/);
+  assert.match(smoke, /\[data-v70-gate-status\]/);
+});
+
+test("V7 smoke helper stays client-only and secret-free", () => {
+  const forbidden = [
+    /\bfetch\s*\(/i,
+    /XMLHttpRequest/i,
+    /\bmethod\s*:\s*["']POST["']/i,
+    /Airtable\s*token/i,
+    /AIRTABLE_[A-Z0-9_]+/i,
+    /admin[_ -]?key/i,
+    /worker\s*secret/i,
+    /wrangler\s+secret/i,
+    /sk-[A-Za-z0-9_-]+/i,
+    /pat[A-Za-z0-9]{10,}/i
+  ];
+
+  for (const pattern of forbidden) {
+    assert.doesNotMatch(smoke, pattern);
   }
 });

--- a/webflow/sigil/board/kenji-board-v70-smoke-test.js
+++ b/webflow/sigil/board/kenji-board-v70-smoke-test.js
@@ -1,0 +1,55 @@
+(function () {
+  "use strict";
+
+  var GATE_KEY = "mmd_board_v70_gate";
+  var ROLE_KEY = "mmd_board_v70_role";
+  var UNLOCKED = "unlocked";
+  var ROLE = "boss_per";
+
+  function hasElement(selector) {
+    return Boolean(document.querySelector(selector));
+  }
+
+  function readLocalStorage(key) {
+    try {
+      return localStorage.getItem(key);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function runSmokeTest() {
+    var helperLoaded = typeof window.mmdBoardV70UnlockGate === "function";
+    var gate = readLocalStorage(GATE_KEY);
+
+    if (helperLoaded && gate !== UNLOCKED) {
+      window.mmdBoardV70UnlockGate("sigil");
+      gate = readLocalStorage(GATE_KEY);
+    }
+
+    var result = {
+      ok: false,
+      root: hasElement("[data-mmd-board-v70]"),
+      passphraseInput: hasElement("[data-v70-gate-passphrase]"),
+      unlockButton: hasElement("[data-v70-action=\"unlock-gate\"]"),
+      status: hasElement("[data-v70-gate-status]"),
+      helperLoaded: helperLoaded,
+      gate: gate,
+      role: readLocalStorage(ROLE_KEY)
+    };
+
+    result.ok = Boolean(
+      result.root &&
+      result.passphraseInput &&
+      result.unlockButton &&
+      result.status &&
+      result.helperLoaded &&
+      result.gate === UNLOCKED &&
+      result.role === ROLE
+    );
+
+    return result;
+  }
+
+  window.mmdBoardV70SmokeTest = runSmokeTest;
+})();

--- a/webflow/sigil/board/kenji-board-v70-webflow-snippet.html
+++ b/webflow/sigil/board/kenji-board-v70-webflow-snippet.html
@@ -3,6 +3,7 @@
   Placement:
   1. Paste the V7 board embed/root markup first on /sigil/board.
   2. Load kenji-board-v70-gate.js after this embed.
+  3. Load kenji-board-v70-smoke-test.js last, or in Before </body>.
 -->
 <section data-mmd-board-v70 data-gate="locked" data-role="guest">
   <div class="mmd-board-v70__gate-panel" data-v70-gate-panel>
@@ -24,3 +25,6 @@
 
 <!-- Load after the V7 board embed/root markup. -->
 <script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/sigil/board/kenji-board-v70-gate.js"></script>
+
+<!-- Load last for console verification. -->
+<script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/sigil/board/kenji-board-v70-smoke-test.js"></script>


### PR DESCRIPTION
## Summary
- Add `kenji-board-v70-smoke-test.js`, a Webflow-safe console helper that exposes `window.mmdBoardV70SmokeTest()`.
- Check required V7 board/gate selectors, gate helper availability, and localStorage gate/role state.
- Update `/sigil/board` Webflow placement docs and snippet order so the smoke helper loads last.
- Extend node:test coverage for selector checks and client-only/no-secret/no-production-write guardrails.

## Test Notes
- `node --test webflow/sigil/board/kenji-board-v70-gate.test.mjs`
- `npm test`

## Scope Notes
- Webflow/SIGIL Board UI/debug integration only.
- Only files under `webflow/sigil/board/*` changed.
- No Worker route changes.
- No backend/API/payment/token/Airtable/membership/SVIP/Black Card behavior changes.