### PR TITLE
[codex] Recover LINE and Telegram channel entrypoints

### DIFF
--- a/docs/channel-access-recovery-diagnosis.md
+++ b/docs/channel-access-recovery-diagnosis.md
@@ -38,6 +38,37 @@ The binding must point to a real Cloudflare KV namespace created for personal pr
 
 Do not deploy `/promo/issue` while the binding still contains placeholder IDs.
 
+## Latest Production Gate Status
+
+### Completed
+
+- LINE diagnostic and trigger alias support added.
+- Telegram `/promo/issue` issuing layer added.
+- `PROMO_CODES_KV` real Cloudflare KV namespace IDs configured in `telegram-worker/wrangler.toml`.
+- PR remains draft.
+- No deploy performed.
+
+### Still Blocked Before Production
+
+1. LINE rich menu gate
+   - Confirm LINE Official default rich menu ID.
+   - Confirm action map for the Per AI / Kenji AI button.
+   - Confirm whether action type is text, postback, or URI.
+   - If text, expected trigger should be `Hi Per` or another supported alias.
+
+2. Telegram bridge/source owner gate
+   - Actual `member-dashboard-chat-worker` source is missing from this worktree.
+   - Historical docs mention `tmp/cloudflare-member-dashboard-chat-worker/index.js`, but that bundle is not present.
+   - Do not patch `chat-worker` unless confirmed as the production source for `member-dashboard-chat-worker`.
+   - Bridge from Telegram verification to `telegram-worker POST /promo/issue` requires source recovery or route owner mapping.
+
+### Production Safety Lock
+
+- Do not deploy PR #77 until LINE rich menu action map is confirmed.
+- Do not deploy Telegram promo issuing until the verified Telegram route owner is confirmed.
+- Do not issue promo codes before Telegram user verification.
+- Do not use promo codes as payment confirmation, membership confirmation, SVIP approval, or Black Card approval.
+
 ## Safety
 
 - No secrets were printed or changed.

--- a/docs/channel-access-recovery-diagnosis.md
+++ b/docs/channel-access-recovery-diagnosis.md
@@ -106,9 +106,16 @@ Remaining external confirmation before LINE gate fully passes:
 ## LINE Rich Menu Current Production Finding
 
 Current manual finding:
-- No active/default rich menu is currently in use in LINE Official Manager.
-- Rich Menu V6 must be recreated or reactivated manually in LINE Official Manager.
-- This is an external LINE configuration issue, not a webhook code issue.
+- An old LINE rich menu is still active/currently in use.
+- Rich Menu V6 is not active/default yet.
+- This is an external LINE Official configuration issue, not a webhook code issue.
+- PR #77 already supports the intended V6 Button 3 payload: `Hi Per`.
+
+Required manual action:
+- Recreate or activate Rich Menu V6 in LINE Official Manager.
+- Set Rich Menu V6 as the active/default rich menu.
+- Do not delete the old rich menu until V6 has been tested.
+- After V6 is active, test Button 3 sends `Hi Per`.
 
 Required V6 mapping:
 
@@ -133,8 +140,7 @@ Required V6 mapping:
 
 Deploy status:
 - Do not deploy PR #77 for this issue.
-- Recreate/reactivate Rich Menu V6 manually first.
-- After manual setup, test Button 3 sends `Hi Per`.
+- Manual LINE rich menu replacement must happen first.
 
 ## Safety
 

--- a/docs/channel-access-recovery-diagnosis.md
+++ b/docs/channel-access-recovery-diagnosis.md
@@ -22,6 +22,14 @@ Telegram has a live `telegram-worker` for bot/internal messaging, but its public
 - Configure a production `PROMO_CODES_KV` binding for `telegram-worker` before deploying `/promo/issue`.
 - Wire Telegram login/verification to call `/promo/issue` after official verification. This patch only adds the minimal issuing layer.
 
+## Production Gate Checklist
+
+- [ ] LINE default rich menu ID confirmed.
+- [ ] LINE rich menu action map confirmed to send supported trigger text/postback.
+- [ ] `PROMO_CODES_KV` production binding configured for `telegram-worker`.
+- [ ] Telegram production route owner decided: `member-dashboard-chat-worker` bridge or `telegram-worker` route.
+- [ ] Telegram login/verification calls `/promo/issue` only after verification.
+
 ## Safety
 
 - No secrets were printed or changed.

--- a/docs/channel-access-recovery-diagnosis.md
+++ b/docs/channel-access-recovery-diagnosis.md
@@ -81,6 +81,28 @@ Before production readiness, confirm from LINE Official Manager or LINE Messagin
 
 Do not claim LINE rich menu is repaired until the action map is confirmed.
 
+## LINE Rich Menu V6 Decision
+
+Button 3 final mapping is locked:
+
+- Label: `คุยกับ Per`
+- Action type: `Message`
+- Payload: `Hi Per`
+
+Compatibility:
+- Pass in principle because PR #77 already supports `Hi Per`.
+- No LINE webhook code patch is needed.
+- No new test is needed for this decision.
+
+Important:
+- `คุยกับ Per` is the customer-facing label only.
+- `Hi Per` is the actual LINE Message payload.
+
+Remaining external confirmation before LINE gate fully passes:
+- Confirm default rich menu ID from LINE Official Manager.
+- Confirm active/default = yes.
+- Confirm Button 3 is saved as Message payload `Hi Per`.
+
 ## Safety
 
 - No secrets were printed or changed.

--- a/docs/channel-access-recovery-diagnosis.md
+++ b/docs/channel-access-recovery-diagnosis.md
@@ -103,6 +103,39 @@ Remaining external confirmation before LINE gate fully passes:
 - Confirm active/default = yes.
 - Confirm Button 3 is saved as Message payload `Hi Per`.
 
+## LINE Rich Menu Current Production Finding
+
+Current manual finding:
+- No active/default rich menu is currently in use in LINE Official Manager.
+- Rich Menu V6 must be recreated or reactivated manually in LINE Official Manager.
+- This is an external LINE configuration issue, not a webhook code issue.
+
+Required V6 mapping:
+
+1. สมัครสมาชิก
+   - URL: https://www.mmdbkk.com/pay/membership?src=line-richmenu
+
+2. ต่ออายุสมาชิก
+   - URL: https://www.mmdbkk.com/sigil/pay/renewal?src=line-richmenu
+
+3. คุยกับ Per
+   - Action: Message
+   - Payload: Hi Per
+
+4. สิทธิประโยชน์
+   - URL: https://www.mmdbkk.com/membership/benefits?src=line-richmenu
+
+5. ค้นหานายแบบ
+   - URL: https://www.mmdbkk.com/sigil/models?src=line-richmenu&entry=model-finder
+
+6. จองนายแบบ
+   - URL: https://www.mmdbkk.com/sigil/booking?src=line-richmenu
+
+Deploy status:
+- Do not deploy PR #77 for this issue.
+- Recreate/reactivate Rich Menu V6 manually first.
+- After manual setup, test Button 3 sends `Hi Per`.
+
 ## Safety
 
 - No secrets were printed or changed.

--- a/docs/channel-access-recovery-diagnosis.md
+++ b/docs/channel-access-recovery-diagnosis.md
@@ -1,0 +1,29 @@
+# Minimal Channel Access Recovery Diagnosis
+
+Date: 2026-06-18
+
+## Root Cause
+
+Production `/webhooks/line*` is owned by `mmd-redirect-worker`, which bridges the canonical `/webhooks/line` path to the legacy Netlify LINE webhook owner. The latest Kenji/Per AI maintenance helpers exist elsewhere, but the actual production receiver for LINE is still `immigrate-worker/netlify/functions/webhook.js` through the front-door bridge.
+
+Telegram has a live `telegram-worker` for bot/internal messaging, but its public webhook was only a skeleton and there was no production-safe `/promo/issue` route. Existing `/promo/validate` behavior lives in `payments-worker` and is catalog-only; it does not issue personal single-use Pride codes.
+
+## Minimal Changes
+
+- Keep `/member/dashboard` and `/member/membership` untouched.
+- Keep `mmd-redirect-worker` production route behavior untouched.
+- Add LINE diagnostic support to the actual Netlify webhook owner via `GET /webhooks/line?health=1`.
+- Expand existing Kenji/Per AI LINE trigger recognition for the locked aliases: `Hi Per`, `Per AI`, `Kenji`, `Kenji AI`, `เคนจิ`, and `เปอร์ ai`.
+- Add `telegram-worker` `/promo/issue` using KV-backed storage only. If storage is not configured, it fails closed with `storage_not_configured`.
+
+## Remaining Work
+
+- Confirm LINE Official default rich menu ID and action map from LINE Console/API before claiming rich menu is fully repaired.
+- Configure a production `PROMO_CODES_KV` binding for `telegram-worker` before deploying `/promo/issue`.
+- Wire Telegram login/verification to call `/promo/issue` after official verification. This patch only adds the minimal issuing layer.
+
+## Safety
+
+- No secrets were printed or changed.
+- No payment confirmation, membership confirmation, SVIP approval, or Black Card approval is performed.
+- Promo issue records are discount/access codes only and are single-use by design.

--- a/docs/channel-access-recovery-diagnosis.md
+++ b/docs/channel-access-recovery-diagnosis.md
@@ -30,6 +30,14 @@ Telegram has a live `telegram-worker` for bot/internal messaging, but its public
 - [ ] Telegram production route owner decided: `member-dashboard-chat-worker` bridge or `telegram-worker` route.
 - [ ] Telegram login/verification calls `/promo/issue` only after verification.
 
+### PROMO_CODES_KV Binding
+
+`PROMO_CODES_KV` is required before deploying `telegram-worker` `/promo/issue`.
+
+The binding must point to a real Cloudflare KV namespace created for personal promo code records.
+
+Do not deploy `/promo/issue` while the binding still contains placeholder IDs.
+
 ## Safety
 
 - No secrets were printed or changed.

--- a/docs/channel-access-recovery-diagnosis.md
+++ b/docs/channel-access-recovery-diagnosis.md
@@ -69,6 +69,18 @@ Do not deploy `/promo/issue` while the binding still contains placeholder IDs.
 - Do not issue promo codes before Telegram user verification.
 - Do not use promo codes as payment confirmation, membership confirmation, SVIP approval, or Black Card approval.
 
+### LINE Rich Menu Gate
+
+The LINE Official default rich menu ID and action map are not present in this repository/worktree.
+
+Before production readiness, confirm from LINE Official Manager or LINE Messaging API:
+- default rich menu ID
+- Per AI / Kenji AI button action type
+- text/postback/URI payload
+- whether the button sends `Hi Per` or another supported trigger alias
+
+Do not claim LINE rich menu is repaired until the action map is confirmed.
+
 ## Safety
 
 - No secrets were printed or changed.

--- a/immigrate-worker/netlify/functions/webhook.js
+++ b/immigrate-worker/netlify/functions/webhook.js
@@ -227,10 +227,13 @@ function isTalkToPerAi(text = "") {
   const spaced = normalizeLookup(text);
   return (
     normalized.includes("kenji") ||
+    normalized.includes("kenjiai") ||
     normalized.includes("เคนจิ") ||
     normalized.includes("hiper") ||
     normalized.includes("helloper") ||
     normalized.includes("สวัสดีเปอร์") ||
+    normalized.includes("เปอร์ai") ||
+    normalized.includes("เปอร์เอไอ") ||
     /\b(?:hi|hello)\s+per\b/i.test(spaced) ||
     normalized.includes("คุยกับเปอร์") ||
     normalized.includes("คุยกับเคนจิ") ||
@@ -958,6 +961,19 @@ async function writeEventToAirtable({ baseId, apiKey, tableName, event, profile 
 
 export async function handler(event) {
   if (event.httpMethod === "GET") {
+    const query = event.queryStringParameters || {};
+    if (String(query.health || query.diagnostic || "") === "1") {
+      return json(200, {
+        ok: true,
+        owner: "line-webhook-netlify",
+        canonical_assistant_id: "kenji_ai",
+        public_alias: "Per AI",
+        kenji_ai_trigger_supported: true,
+        supported_triggers: ["Hi Per", "สวัสดี เปอร์", "Per AI", "Kenji", "Kenji AI", "เคนจิ", "เปอร์ ai"],
+        rich_menu_checked: false,
+        request_id: crypto.randomUUID(),
+      });
+    }
     return json(200, { ok: true, service: "line-webhook-netlify" });
   }
 

--- a/immigrate-worker/netlify/tests/webhook-faq-intent.test.mjs
+++ b/immigrate-worker/netlify/tests/webhook-faq-intent.test.mjs
@@ -4,6 +4,7 @@ import {
   buildFaqReply,
   choosePricingReplyStrategy,
   getLineEventTextForIntent,
+  handler,
   inferFaqIntent,
   inferIntent,
   shouldAutoReplyForIntent,
@@ -78,6 +79,18 @@ const thaiHiPerReply = await buildAutoReplyMessage(textEvent("สวัสดี
 assert.match(thaiHiPerReply, /Kenji/);
 assert.match(thaiHiPerReply, /ผู้ช่วยสมาชิก/);
 
+const perAiReply = await buildAutoReplyMessage(textEvent("Per AI"), profile, { lineKenjiAiEnabled: true });
+assert.match(perAiReply, /Kenji/);
+assert.match(perAiReply, /ผู้ช่วยสมาชิก/);
+
+const kenjiAiReply = await buildAutoReplyMessage(textEvent("Kenji AI"), profile, { lineKenjiAiEnabled: true });
+assert.match(kenjiAiReply, /Kenji/);
+assert.match(kenjiAiReply, /ผู้ช่วยสมาชิก/);
+
+const thaiPerAiReply = await buildAutoReplyMessage(textEvent("เปอร์ ai"), profile, { lineKenjiAiEnabled: true });
+assert.match(thaiPerAiReply, /Kenji/);
+assert.match(thaiPerAiReply, /ผู้ช่วยสมาชิก/);
+
 const plainGreetingReply = await buildAutoReplyMessage(textEvent("สวัสดีครับ"), profile, { lineKenjiAiEnabled: true });
 assert.match(plainGreetingReply, /สวัสดีครับ/);
 assert.match(plainGreetingReply, /วันนี้ให้ผมช่วย/);
@@ -104,5 +117,16 @@ assert.match(blackCardReply, /automatic approval/);
 const bookingReply = await buildAutoReplyMessage(textEvent("จอง"), profile, { lineKenjiAiEnabled: true });
 assert.match(bookingReply, /ผมช่วยพาไปขั้นตอนการจองได้ครับ/);
 assert.match(bookingReply, /ขอเช็กสถานะสมาชิก/);
+
+const health = await handler({
+  httpMethod: "GET",
+  queryStringParameters: { health: "1" },
+});
+assert.equal(health.statusCode, 200);
+const healthBody = JSON.parse(health.body);
+assert.equal(healthBody.owner, "line-webhook-netlify");
+assert.equal(healthBody.canonical_assistant_id, "kenji_ai");
+assert.equal(healthBody.kenji_ai_trigger_supported, true);
+assert.equal(healthBody.rich_menu_checked, false);
 
 console.log("webhook FAQ/pricing intent tests passed");

--- a/telegram-worker/src/index.js
+++ b/telegram-worker/src/index.js
@@ -2,6 +2,111 @@ import { json, safeJson, HttpError } from "../lib/http.js";
 import { requireInternalToken } from "../lib/guard.js";
 import { telegramNotify } from "../lib/telegram.js";
 
+const DEFAULT_PROMO_CAMPAIGN = "PRIDE_2026";
+const PROMO_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+function str(value) {
+  return value == null ? "" : String(value).trim();
+}
+
+function normalizeCampaign(value) {
+  return str(value || DEFAULT_PROMO_CAMPAIGN).toUpperCase().replace(/[^A-Z0-9_:-]/g, "_").slice(0, 40) || DEFAULT_PROMO_CAMPAIGN;
+}
+
+function normalizePromoCode(value) {
+  return str(value).toUpperCase().replace(/[^A-Z0-9]/g, "");
+}
+
+function requirePromoKv(env) {
+  const kv = env.PROMO_CODES_KV || env.PROMO_KV || env.PAY_SESSIONS_KV;
+  if (!kv?.get || !kv?.put) {
+    throw new HttpError(503, {
+      ok: false,
+      error: "storage_not_configured",
+      message: "PROMO_CODES_KV is required before issuing production promo codes.",
+    });
+  }
+  return kv;
+}
+
+function makePromoCode() {
+  const bytes = crypto.getRandomValues(new Uint8Array(6));
+  return [...bytes].map((byte) => PROMO_CODE_ALPHABET[byte % PROMO_CODE_ALPHABET.length]).join("");
+}
+
+async function issuePromoCode(env, input) {
+  const kv = requirePromoKv(env);
+  const telegramUserId = str(input.telegram_user_id || input.telegramUserId);
+  if (!telegramUserId) {
+    throw new HttpError(400, { ok: false, error: "telegram_user_id_required" });
+  }
+
+  const campaign = normalizeCampaign(input.campaign);
+  const source = str(input.source || "telegram") || "telegram";
+  const requestId = str(input.request_id || crypto.randomUUID());
+  const userKey = `promo:${campaign}:telegram_user:${telegramUserId}`;
+  const existingCode = await kv.get(userKey);
+
+  if (existingCode) {
+    const existingRecord = await kv.get(`promo:${campaign}:code:${normalizePromoCode(existingCode)}`, "json");
+    if (existingRecord?.status === "issued") {
+      return {
+        ok: true,
+        code: existingRecord.code,
+        campaign,
+        single_use: true,
+        status: "issued",
+        idempotent: true,
+      };
+    }
+  }
+
+  let code = "";
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const candidate = makePromoCode();
+    const taken = await kv.get(`promo:${campaign}:code:${candidate}`);
+    if (!taken) {
+      code = candidate;
+      break;
+    }
+  }
+
+  if (!code) {
+    throw new HttpError(409, { ok: false, error: "promo_code_exhausted" });
+  }
+
+  const record = {
+    code,
+    campaign,
+    telegram_user_id: telegramUserId,
+    issued_at: new Date().toISOString(),
+    used_at: "",
+    status: "issued",
+    source,
+    request_id: requestId,
+    single_use: true,
+  };
+
+  await kv.put(`promo:${campaign}:code:${code}`, JSON.stringify(record));
+  await kv.put(userKey, code);
+
+  return {
+    ok: true,
+    code,
+    campaign,
+    single_use: true,
+    status: "issued",
+  };
+}
+
+async function handlePromoIssue(req, env) {
+  requireInternalToken(req, env);
+  const body = await safeJson(req);
+  if (!body) return json({ ok: false, error: "invalid_json" }, 400);
+  const result = await issuePromoCode(env, body);
+  return json(result, 200);
+}
+
 export default {
   async fetch(req, env) {
     const url = new URL(req.url);
@@ -17,6 +122,10 @@ export default {
         const update = await safeJson(req);
         if (!update) return json({ ok: false, error: "invalid_json" }, 400);
         return json({ ok: true, received: true }, 200);
+      }
+
+      if (path === "/promo/issue" && req.method === "POST") {
+        return await handlePromoIssue(req, env);
       }
 
       // Optional: internal send (ให้ worker อื่นเรียกผ่านตัวนี้)
@@ -35,3 +144,5 @@ export default {
     }
   },
 };
+
+export { issuePromoCode };

--- a/telegram-worker/test/promo-issue.test.mjs
+++ b/telegram-worker/test/promo-issue.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import worker from "../src/index.js";
+
+function makeKv() {
+  const store = new Map();
+  return {
+    async get(key, type) {
+      const value = store.get(key) || null;
+      if (type === "json" && value) return JSON.parse(value);
+      return value;
+    },
+    async put(key, value) {
+      store.set(key, String(value));
+    },
+    store,
+  };
+}
+
+async function post(path, body, env = {}) {
+  return worker.fetch(
+    new Request(`https://telegram-worker.test${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-internal-token": "test-key" },
+      body: JSON.stringify(body),
+    }),
+    { INTERNAL_API_TOKEN: "test-key", ...env },
+  );
+}
+
+{
+  const response = await post("/promo/issue", {
+    telegram_user_id: "12345",
+    campaign: "PRIDE_2026",
+    source: "telegram",
+    request_id: "req_1",
+  });
+  assert.equal(response.status, 503);
+  const body = await response.json();
+  assert.equal(body.error, "storage_not_configured");
+}
+
+{
+  const kv = makeKv();
+  const response = await post(
+    "/promo/issue",
+    {
+      telegram_user_id: "12345",
+      campaign: "PRIDE_2026",
+      source: "telegram",
+      request_id: "req_1",
+    },
+    { PROMO_CODES_KV: kv },
+  );
+  assert.equal(response.status, 200);
+  const body = await response.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.campaign, "PRIDE_2026");
+  assert.equal(body.single_use, true);
+  assert.equal(body.status, "issued");
+  assert.match(body.code, /^[A-Z0-9]{6}$/);
+
+  const record = await kv.get(`promo:PRIDE_2026:code:${body.code}`, "json");
+  assert.equal(record.telegram_user_id, "12345");
+  assert.equal(record.status, "issued");
+  assert.equal(record.used_at, "");
+  assert.equal(record.single_use, true);
+}
+
+{
+  const kv = makeKv();
+  const first = await post("/promo/issue", { telegram_user_id: "67890", campaign: "PRIDE_2026" }, { PROMO_CODES_KV: kv });
+  const firstBody = await first.json();
+  const second = await post("/promo/issue", { telegram_user_id: "67890", campaign: "PRIDE_2026" }, { PROMO_CODES_KV: kv });
+  const secondBody = await second.json();
+  assert.equal(second.status, 200);
+  assert.equal(secondBody.code, firstBody.code);
+  assert.equal(secondBody.idempotent, true);
+}
+
+console.log("telegram promo issue tests passed");

--- a/telegram-worker/wrangler.toml
+++ b/telegram-worker/wrangler.toml
@@ -2,6 +2,11 @@ name = "telegram-worker"
 main = "src/index.js"
 compatibility_date = "2026-01-20"
 
+[[kv_namespaces]]
+binding = "PROMO_CODES_KV"
+id = "REPLACE_WITH_PROMO_CODES_KV_ID"
+preview_id = "REPLACE_WITH_PROMO_CODES_KV_PREVIEW_ID"
+
 [vars]
 TELEGRAM_CHAT_ID = "-1003546439681"
 TG_THREAD_MEMBERSHIP = "20"

--- a/telegram-worker/wrangler.toml
+++ b/telegram-worker/wrangler.toml
@@ -4,8 +4,8 @@ compatibility_date = "2026-01-20"
 
 [[kv_namespaces]]
 binding = "PROMO_CODES_KV"
-id = "REPLACE_WITH_PROMO_CODES_KV_ID"
-preview_id = "REPLACE_WITH_PROMO_CODES_KV_PREVIEW_ID"
+id = "00bc04f319604b6397737e95b8475d82"
+preview_id = "dee5553a9a8a4085813fceb0f3302950"
 
 [vars]
 TELEGRAM_CHAT_ID = "-1003546439681"


### PR DESCRIPTION
## Summary

Minimal channel access recovery for LINE `Hi Per` / Kenji AI triggers and Telegram Pride promo issuing.

No deploy performed.

## Diagnosis

- Production `mmdbkk.com/webhooks/line*` is owned by `mmd-redirect-worker`, which bridges canonical `/webhooks/line` to the legacy Netlify LINE webhook owner.
- The actual LINE receiver is `immigrate-worker/netlify/functions/webhook.js` returning `service: line-webhook-netlify`.
- Existing Kenji/Per AI reply logic already lived in that receiver, but production-safe diagnostics were missing and a few locked aliases needed explicit coverage.
- Production `www/mmdbkk.com/webhooks/telegram*` is owned by `member-dashboard-chat-worker`, while `telegram-worker` currently has only a skeleton `/telegram/webhook` and internal send route.
- Existing `/promo/validate` behavior lives in `payments-worker` and is catalog validation only; it does not issue personal single-use Pride promo codes.

## Changes

- LINE Netlify webhook owner:
  - Adds `GET /webhooks/line?health=1` diagnostic payload with owner, `kenji_ai` assistant id, public alias, trigger support, and `rich_menu_checked: false`.
  - Expands trigger recognition for locked aliases including `Kenji AI`, `เปอร์ ai`, and `เปอร์เอไอ`.
  - Extends existing LINE tests for `Per AI`, `Kenji AI`, Thai Per AI alias, and health output.
- Telegram worker:
  - Adds `POST /promo/issue`.
  - Issues exactly 6-character personal Pride codes using `PROMO_CODES_KV` / compatible KV only.
  - One issued code per Telegram user per campaign; repeated requests return the existing issued code idempotently.
  - Fails closed with `storage_not_configured` when no KV binding exists.
  - Adds tests for code length, idempotency, single-use record shape, and missing storage fail-closed.
- Adds `docs/channel-access-recovery-diagnosis.md` with root cause, minimality, and remaining work.

## Safety

- No secrets printed, changed, or added.
- No `.env` / `.dev.vars` added.
- No member routes touched.
- No `mmd-redirect-worker` production rules changed.
- No payment confirmation, membership confirmation, SVIP auto approval, or Black Card auto approval.
- Promo codes are discount/access codes only.

## Validation

- `node immigrate-worker/netlify/tests/webhook-faq-intent.test.mjs` passed.
- `node --check immigrate-worker/netlify/functions/webhook.js` passed.
- `node --check telegram-worker/src/index.js` passed.
- `node telegram-worker/test/promo-issue.test.mjs` passed.
- `git diff --check` passed.

## Remaining Work Before Production Readiness

- Confirm LINE Official default rich menu ID and action map from LINE Console/API before claiming rich menu is fully repaired.
- Configure production `PROMO_CODES_KV` binding for `telegram-worker` before deploying `/promo/issue`.
- Wire Telegram login/verification to call `/promo/issue` after official verification. This PR adds the minimal issuing layer only.