### PR TITLE
 fix: make LINE rich menu maintenance idempotent

### DIFF
--- a/member-dashboard-chat-worker/wrangler.toml
+++ b/member-dashboard-chat-worker/wrangler.toml
@@ -91,7 +91,7 @@ pattern = "sigil.mmdbkk.com/sigil/login*"
 zone_name = "mmdbkk.com"
 
 [[routes]]
-pattern = "www.mmdbkk.com/webhooks/line*"
+pattern = "sigil.mmdbkk.com/internal/line/rich-menu*"
 zone_name = "mmdbkk.com"
 
 [[routes]]
@@ -180,10 +180,6 @@ zone_name = "mmdbkk.com"
 
 [[routes]]
 pattern = "mmdbkk.com/member/confirm*"
-zone_name = "mmdbkk.com"
-
-[[routes]]
-pattern = "mmdbkk.com/webhooks/line*"
 zone_name = "mmdbkk.com"
 
 [[routes]]

--- a/tmp/cloudflare-member-dashboard-chat-worker/index.js
+++ b/tmp/cloudflare-member-dashboard-chat-worker/index.js
@@ -5411,6 +5411,9 @@ async function handleLinePerAiRichMenuMaintenance(request, env) {
     }, 409);
   }
   const candidates = findLinePerAiRichMenuAreas(richMenu);
+  const alreadyCorrect = candidates.length > 0 && candidates.every(
+    (c) => c.action_type === "message" && c.label === "Hi Per" && c.text === "Hi Per"
+  );
   if (mode === "plan") {
     return json(request, env, {
       ok: true,
@@ -5418,8 +5421,19 @@ async function handleLinePerAiRichMenuMaintenance(request, env) {
       current_default_rich_menu_id: currentRichMenuId,
       candidate_count: candidates.length,
       candidates,
+      already_correct: alreadyCorrect,
+      would_create: !alreadyCorrect,
       would_link_as: "default",
       required_action: { type: "message", label: "Hi Per", text: "Hi Per" }
+    });
+  }
+  if (alreadyCorrect) {
+    return json(request, env, {
+      ok: true,
+      mode,
+      result: "already_correct",
+      current_default_rich_menu_id: currentRichMenuId,
+      changed_area_indexes: []
     });
   }
   if (candidates.length !== 1 && body?.force !== true) {

--- a/tmp/cloudflare-member-dashboard-chat-worker/line-rich-menu-routes.test.mjs
+++ b/tmp/cloudflare-member-dashboard-chat-worker/line-rich-menu-routes.test.mjs
@@ -98,3 +98,190 @@ for (const path of ROUTES) {
     assert.equal(response.status, 404);
   });
 }
+
+// --- Idempotency tests for /internal/line/rich-menu/maintain ---
+
+// Shared LINE API mock builder: returns a rich menu with one area already set to Hi Per message action
+function makeLineApiMockAlreadyCorrect(lineApiCallLog) {
+  return async (input) => {
+    const url = typeof input === "string" ? input : input.url;
+    const urlStr = String(url);
+    if (urlStr.includes("/v2/bot/user/all/richmenu") && !urlStr.includes("/v2/bot/user/all/richmenu/")) {
+      lineApiCallLog.push("GET_default");
+      return new Response(JSON.stringify({ richMenuId: "rmid-existing-123" }), { status: 200 });
+    }
+    if (urlStr.match(/\/v2\/bot\/richmenu\/rmid-existing-123$/) && !urlStr.includes("/content")) {
+      lineApiCallLog.push("GET_richmenu");
+      return new Response(JSON.stringify({
+        richMenuId: "rmid-existing-123",
+        name: "MMD Test Menu",
+        chatBarText: "Menu",
+        areas: [{
+          bounds: { x: 0, y: 0, width: 833, height: 270 },
+          action: { type: "message", label: "Hi Per", text: "Hi Per" }
+        }]
+      }), { status: 200 });
+    }
+    // Any write endpoint — should not be reached when already correct
+    if (urlStr.includes("/v2/bot/richmenu") && (input.method === "POST" || (typeof input !== "string" && input.method === "POST"))) {
+      lineApiCallLog.push("POST_write");
+    }
+    return new Response("{}", { status: 200 });
+  };
+}
+
+// Shared LINE API mock builder: returns a rich menu with one area needing patch (postback action)
+function makeLineApiMockNeedsUpdate(lineApiCallLog) {
+  return async (input, init) => {
+    const url = typeof input === "string" ? input : input.url;
+    const method = init?.method || (typeof input !== "string" ? input.method : "GET") || "GET";
+    const urlStr = String(url);
+    if (urlStr.includes("/v2/bot/user/all/richmenu") && !urlStr.includes("/v2/bot/user/all/richmenu/")) {
+      lineApiCallLog.push("GET_default");
+      return new Response(JSON.stringify({ richMenuId: "rmid-old-456" }), { status: 200 });
+    }
+    if (urlStr.match(/\/v2\/bot\/richmenu\/rmid-old-456$/) && !urlStr.includes("/content")) {
+      lineApiCallLog.push("GET_richmenu");
+      return new Response(JSON.stringify({
+        richMenuId: "rmid-old-456",
+        name: "MMD Old Menu",
+        chatBarText: "Menu",
+        areas: [{
+          bounds: { x: 0, y: 0, width: 833, height: 270 },
+          action: { type: "postback", label: "Per AI", data: "talk_to_per_ai" }
+        }]
+      }), { status: 200 });
+    }
+    if (urlStr === "https://api.line.me/v2/bot/richmenu" && method === "POST") {
+      lineApiCallLog.push("POST_create");
+      return new Response(JSON.stringify({ richMenuId: "rmid-new-789" }), { status: 200 });
+    }
+    if (urlStr.includes("/content") && method === "POST") {
+      lineApiCallLog.push("POST_image_upload");
+      return new Response("{}", { status: 200 });
+    }
+    if (urlStr.includes("/content") && method !== "POST") {
+      lineApiCallLog.push("GET_image");
+      return new Response(new Uint8Array([1, 2, 3]).buffer, {
+        status: 200,
+        headers: { "content-type": "image/png" }
+      });
+    }
+    if (urlStr.includes("/v2/bot/user/all/richmenu/rmid-new-789") && method === "POST") {
+      lineApiCallLog.push("POST_set_default");
+      return new Response("{}", { status: 200 });
+    }
+    return new Response("{}", { status: 200 });
+  };
+}
+
+const MAINTAIN = "/internal/line/rich-menu/maintain";
+const AUTH_ENV = { CONFIRM_KEY: "test-key", LINE_CHANNEL_ACCESS_TOKEN: "tok" };
+const AUTH_HEADERS = { "x-admin-key": "test-key", "content-type": "application/json" };
+
+test(`${MAINTAIN} plan — already_correct:true when candidate has exact Hi Per message action`, async () => {
+  const log = [];
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = makeLineApiMockAlreadyCorrect(log);
+    const response = await worker.fetch(
+      new Request(`https://www.mmdbkk.com${MAINTAIN}`, {
+        method: "POST",
+        headers: AUTH_HEADERS,
+        body: JSON.stringify({ mode: "plan" }),
+      }),
+      AUTH_ENV,
+      {}
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.mode, "plan");
+    assert.equal(body.already_correct, true, "plan should signal already_correct:true");
+    assert.equal(body.would_create, false, "plan should signal would_create:false");
+    assert.equal(log.includes("POST_write"), false, "plan must not call any write endpoint");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test(`${MAINTAIN} execute — returns already_correct and calls no LINE write API when candidate is exact`, async () => {
+  const log = [];
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = makeLineApiMockAlreadyCorrect(log);
+    const response = await worker.fetch(
+      new Request(`https://www.mmdbkk.com${MAINTAIN}`, {
+        method: "POST",
+        headers: AUTH_HEADERS,
+        body: JSON.stringify({ mode: "execute" }),
+      }),
+      AUTH_ENV,
+      {}
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.mode, "execute");
+    assert.equal(body.result, "already_correct");
+    assert.deepEqual(body.changed_area_indexes, []);
+    assert.equal(log.includes("POST_create"), false, "must not create rich menu");
+    assert.equal(log.includes("POST_image_upload"), false, "must not upload image");
+    assert.equal(log.includes("POST_set_default"), false, "must not set default");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test(`${MAINTAIN} execute — creates clone and sets default when candidate needs update`, async () => {
+  const log = [];
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = makeLineApiMockNeedsUpdate(log);
+    const response = await worker.fetch(
+      new Request(`https://www.mmdbkk.com${MAINTAIN}`, {
+        method: "POST",
+        headers: AUTH_HEADERS,
+        body: JSON.stringify({ mode: "execute" }),
+      }),
+      AUTH_ENV,
+      {}
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.mode, "execute");
+    assert.equal(body.result, undefined, "should not return already_correct when update was needed");
+    assert.equal(body.linked_as, "default");
+    assert.equal(log.includes("POST_create"), true, "must create new rich menu");
+    assert.equal(log.includes("POST_set_default"), true, "must set new menu as default");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test(`${MAINTAIN} execute — unauthorized requests still rejected before any LINE API call`, async () => {
+  const log = [];
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async (input) => {
+      log.push("called");
+      return new Response("{}", { status: 200 });
+    };
+    const response = await worker.fetch(
+      new Request(`https://www.mmdbkk.com${MAINTAIN}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ mode: "execute" }),
+      }),
+      {},
+      {}
+    );
+    assert.equal(response.status, 500);
+    const body = await response.json();
+    assert.equal(body.error, "admin_key_not_configured");
+    assert.equal(log.length, 0, "no LINE API call before auth");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- Adds idempotency guard for `/internal/line/rich-menu/maintain`
- `plan` mode now reports `already_correct` and `would_create` signals
- `execute` mode returns `result: "already_correct"` without creating, uploading, or linking when the `Hi Per` action is already correct on all matched candidate areas
- Preserves existing execute behavior (clone → upload image → set default) when update is actually needed
- Includes route-safe `wrangler.toml` config that matches the deployed production state:
  - removes `www.mmdbkk.com/webhooks/line*`
  - removes `mmdbkk.com/webhooks/line*`
  - adds `sigil.mmdbkk.com/internal/line/rich-menu*`

## Motivation

Part A deployed (version f6987371). Authorized plan call found 1 candidate with
action_type: message, label: Hi Per, text: Hi Per — the area already has the correct
action. Without this patch, execute would always create a new cloned rich menu even
when no change is needed, risking duplicate rich menus in LINE.

## No-ops confirmed

- No deploy performed
- No LINE API call performed
- No Telegram API call performed
- No secrets touched
- No `.dev.vars` touched

## Validation

| Suite | Result |
|---|---|
| line-rich-menu-routes.test.mjs | 14/14 pass |
| internal-admin-alias.test.mjs | 2/2 pass |
| npm run test:line-ofc | 63/63 pass |
| npm run test:redirect | 33/33 pass |
| **Total** | **112/112 pass** |