### PR TITLE
Fix member pages footer template literal

### DIFF
--- a/member-pages-worker/src/index.js
+++ b/member-pages-worker/src/index.js
@@ -472,7 +472,7 @@ export function renderMembershipPage(request) {
         <a class="mmd-member-membership__button secondary" href="${escapeAttribute(dashboardHref)}">Check status</a>
       </section>
 
-      <p class="mmd-member-membership__footer">MMD Privé keeps `/member/*` as the customer-facing Member Area. Private system and admin layers remain under `/sigil/*`. Query parameters are preserved for continuity.</p>
+      <p class="mmd-member-membership__footer">MMD Privé keeps <code>/member/&#42;</code> as the customer-facing Member Area. Private system and admin layers remain under <code>/sigil/&#42;</code>. Query parameters are preserved for continuity.</p>
     </main>
   </body>
 </html>`;


### PR DESCRIPTION
## Summary

Fixes the member pages membership footer copy so the source matches the production-safe deploy behavior. The visible route examples now use safe HTML code markup for `/member/*` and `/sigil/*`, avoiding raw backticks and `/*` inside the JavaScript template literal.

## Why

The previous footer text used inline backticks around `/member/*` inside a template literal, which caused Wrangler's build step to fail. Production was deployed with this safe rendering as a temporary local fix; this PR brings `origin/main` into parity.

## Validation

- `node --check member-pages-worker/src/index.js`
- `node --test member-pages-worker/test/membership.test.mjs`
- `wrangler deploy --config member-pages-worker/wrangler.toml --dry-run`

No redeploy performed.