### PR TITLE
Route ownership fix for /member/membership

### DIFF
--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -14,6 +14,7 @@ export const CONFIRM_PAYMENT_PATH = "/confirm/payment-confirmation";
 export const MEMBER_DASHBOARD_UPSTREAM = "https://immigrate-worker.malemodel-bkk.workers.dev";
 export const MEMBER_PAGES_UPSTREAM = "https://member-pages-worker.malemodel-bkk.workers.dev";
 export const ADMIN_WORKER_UPSTREAM = "https://admin-worker.malemodel-bkk.workers.dev";
+export const DEFAULT_WEBFLOW_ORIGIN_HOST = "mmdprive.webflow.io";
 export const FRONT_GATE = "mmd-redirect-worker";
 export const FRONT_VERSION = "20260620T000000Z";
 
@@ -67,9 +68,9 @@ export const EXACT_PATH_REDIRECTS = {
   "/inme": "/trust/inme",
   "/login": "/trust/inme",
   "/member": "/membership/benefits",
-  "/member/membership/benefits": "/pay/membership",
+  "/member/membership/benefits": "/member/membership",
   "/members": "/trust/inme",
-  "/membership": "/membership/benefits",
+  "/membership": "/member/membership",
   "/renew": "/trust/inme",
   "/renewal": "/trust/inme",
   "/trust": "/trust/inme",
@@ -224,6 +225,36 @@ async function fetchLineWebhook(request, env = {}, url) {
   return withFrontGateHeaders(await fetch(upstreamRequest));
 }
 
+function getWebflowOriginHost(env = {}) {
+  return String(env.WEBFLOW_ORIGIN_HOST || DEFAULT_WEBFLOW_ORIGIN_HOST)
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/\/.*$/g, "");
+}
+
+async function fetchWebflowOrigin(request, env, url) {
+  const host = getWebflowOriginHost(env);
+  const target = new URL(request.url);
+  target.protocol = "https:";
+  target.hostname = host;
+  target.port = "";
+  target.pathname = url.pathname;
+  target.search = url.search;
+
+  const headers = new Headers(request.headers);
+  headers.delete("host");
+
+  return withFrontGateHeaders(
+    await fetch(
+      new Request(target.toString(), {
+        method: request.method,
+        headers,
+        redirect: "follow",
+      }),
+    ),
+  );
+}
+
 function isMemberDashboardPath(url) {
   const pathname = url.pathname.toLowerCase();
   return pathname === "/member/dashboard" || pathname === "/member/dashboard/";
@@ -264,6 +295,9 @@ function isMemberFrontendPath(url) {
 }
 
 async function fetchMemberFrontend(request, env, url) {
+  // TODO(member-route-migration): /member/dashboard is a legacy locked route
+  // still owned by immigrate-worker. Do not add new member-facing route
+  // dependencies here; migrate it to the canonical member layer when ready.
   if (env?.IMMIGRATE_WORKER?.fetch) {
     return withFrontGateHeaders(await env.IMMIGRATE_WORKER.fetch(request));
   }
@@ -434,9 +468,11 @@ export default {
     if (isMemberFrontendPath(url)) {
       return fetchMemberFrontend(request, env, url);
     }
+
     if (isMemberMembershipPath(url)) {
-      return fetchMemberPage(request, env, url);
+      return fetchWebflowOrigin(request, env, url);
     }
+
     if (isMemberPaymentsPath(url)) {
       return fetchAdminMemberPage(request, env, url);
     }

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -67,14 +67,14 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(response.headers.get("location"), "https://mmdbkk.com/trust/inme?t=abc");
   });
 
-  it("maps /member and /membership to the membership benefits page", async () => {
+  it("maps /member to the legacy benefits page and /membership to member membership", async () => {
     const member = await request("https://mmdbkk.com/member?t=abc");
     const membership = await request("https://www.mmdbkk.com/membership?t=abc");
 
     assert.equal(member.status, 301);
     assert.equal(member.headers.get("location"), "https://mmdbkk.com/membership/benefits?t=abc");
     assert.equal(membership.status, 301);
-    assert.equal(membership.headers.get("location"), "https://mmdbkk.com/membership/benefits?t=abc");
+    assert.equal(membership.headers.get("location"), "https://mmdbkk.com/member/membership?t=abc");
   });
 
   it("delegates /member/dashboard to immigrate-worker by service binding without redirecting or changing query strings", async () => {
@@ -109,18 +109,24 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 0);
   });
 
-  it("delegates /member/membership to immigrate-worker by service binding without redirecting or changing query strings", async () => {
-    const serviceRequests = [];
+  it("uses the Webflow origin for /member/membership without redirecting or changing query strings", async () => {
+    const immigrateRequests = [];
+    const webflowRequests = [];
     const env = {
+      WEBFLOW_ORIGIN_HOST: "mmdprive.webflow.io",
       IMMIGRATE_WORKER: {
         fetch: async (request) => {
-          serviceRequests.push(request);
-          return new Response("member membership", {
-            status: 200,
-            headers: { "x-mmd-worker": "immigrate-worker", "x-mmd-page": "member-membership" },
-          });
+          immigrateRequests.push(request);
+          throw new Error(`/member/membership must not route to immigrate-worker: ${request.url}`);
         },
       },
+    };
+    globalThis.fetch = async (request) => {
+      webflowRequests.push(request);
+      return new Response("webflow membership", {
+        status: 200,
+        headers: { "x-webflow-page": "member-membership" },
+      });
     };
 
     const urls = [
@@ -134,13 +140,19 @@ describe("MMD permanent redirect guard", () => {
 
     for (const url of urls) {
       const response = await requestWithEnv(url, env);
+      const expected = new URL(url);
+      expected.protocol = "https:";
+      expected.hostname = "mmdprive.webflow.io";
+
       assert.equal(response.status, 200, url);
-      assert.equal(response.headers.get("location"), null);
-      assert.equal(response.headers.get("x-mmd-page"), "member-membership");
-      assert.equal(serviceRequests.at(-1).url, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-webflow-page"), "member-membership", url);
+      assert.equal(response.headers.get("x-mmd-front-gate"), "mmd-redirect-worker", url);
+      assert.equal(webflowRequests.at(-1).url, expected.toString(), url);
     }
 
-    assert.equal(passThroughRequests.length, 0);
+    assert.equal(immigrateRequests.length, 0);
+    assert.equal(webflowRequests.length, urls.length);
   });
 
   it("delegates /member/payments to admin-worker without redirecting or changing query strings", async () => {
@@ -260,12 +272,12 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 0);
   });
 
-  it("falls back to the immigrate-worker upstream for /member/membership when service binding is missing", async () => {
+  it("falls back to the configured Webflow origin for /member/membership when service binding is missing", async () => {
     globalThis.fetch = async (request) => {
       passThroughRequests.push(request);
-      return new Response("membership upstream", {
+      return new Response("membership webflow origin", {
         status: 200,
-        headers: { "x-mmd-worker": "immigrate-worker", "x-mmd-page": "member-membership" },
+        headers: { "x-webflow-page": "member-membership" },
       });
     };
 
@@ -279,10 +291,36 @@ describe("MMD permanent redirect guard", () => {
       const response = await request(url);
       const expected = new URL(url);
       expected.protocol = "https:";
-      expected.hostname = "immigrate-worker.malemodel-bkk.workers.dev";
+      expected.hostname = "mmdprive.webflow.io";
       assert.equal(response.status, 200, url);
       assert.equal(response.headers.get("location"), null);
+      assert.equal(response.headers.get("x-webflow-page"), "member-membership");
       assert.equal(passThroughRequests.at(-1).url, expected.toString());
+    }
+  });
+
+  it("does not redirect /member/membership to payment, trust, or legacy membership pages", async () => {
+    const upstreamRequests = [];
+    globalThis.fetch = async (request) => {
+      upstreamRequests.push(request);
+      return new Response("webflow membership", { status: 200 });
+    };
+
+    const urls = [
+      "https://mmdbkk.com/member/membership?t=abc&code=x&promo=y",
+      "https://www.mmdbkk.com/member/membership?t=abc&code=x&promo=y",
+      "https://mmdbkk.com/member/membership/?t=abc&code=x&promo=y",
+    ];
+
+    for (const url of urls) {
+      const response = await request(url);
+
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.doesNotMatch(upstreamRequests.at(-1).url, /\/pay\/membership|\/trust\/inme|\/membership\/benefits/i, url);
+      assert.match(upstreamRequests.at(-1).url, /[?&]t=abc(?:&|$)/, url);
+      assert.match(upstreamRequests.at(-1).url, /[?&]code=x(?:&|$)/, url);
+      assert.match(upstreamRequests.at(-1).url, /[?&]promo=y(?:&|$)/, url);
     }
   });
 
@@ -326,18 +364,18 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.at(-1).url, "https://mmdbkk.com/pay/membership?t=abc&code=x&promo=y&debug=1");
   });
 
-  it("maps nested /member/membership paths to /pay/membership paths", async () => {
+  it("maps nested /member/membership paths to /member/membership paths", async () => {
     const response = await request("https://www.mmdbkk.com/member/membership/benefits?t=abc");
 
     assert.equal(response.status, 301);
-    assert.equal(response.headers.get("location"), "https://mmdbkk.com/pay/membership?t=abc");
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/member/membership?t=abc");
   });
 
-  it("maps /member/membership/benefits directly to /pay/membership", async () => {
+  it("maps /member/membership/benefits directly to /member/membership", async () => {
     const response = await request("https://mmdbkk.com/member/membership/benefits?t=abc");
 
     assert.equal(response.status, 301);
-    assert.equal(response.headers.get("location"), "https://mmdbkk.com/pay/membership?t=abc");
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/member/membership?t=abc");
   });
 
   it("canonicalizes www host without changing query parameter order or names", async () => {


### PR DESCRIPTION
## Summary
- Before: `/member/membership` was rendered through `member-pages-worker` via the redirect worker membership route.
- After: `/member/membership` uses the canonical Webflow origin, preserving the incoming path and query string.
- `/member/dashboard` remains unchanged and still routes to its existing immigrate-worker owner.
- No deploy performed.

## Regression coverage
- `/member/dashboard` still routes to the current locked owner.
- `/member/membership` no longer routes to `member-pages-worker` or `IMMIGRATE_WORKER`.
- `/member/membership` preserves `t`, `code`, and `promo`.
- `/member/membership` does not redirect to `/pay/membership`, `/trust/inme`, or legacy membership benefit pages.

## Tests
- `npm --prefix mmd-redirect-worker test`