### PR TITLE
Route public membership to Webflow separately from SIGIL access

### DIFF
--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -17,6 +17,7 @@ export const ADMIN_WORKER_UPSTREAM = "https://admin-worker.malemodel-bkk.workers
 export const SIGIL_WORKER_UPSTREAM = "https://sigil.mmdbkk.com";
 export const FRONT_GATE = "mmd-redirect-worker";
 export const FRONT_VERSION = "20260622T071500Z";
+export const DEFAULT_WEBFLOW_ORIGIN_HOST = "mmdprive.webflow.io";
 export const SIGIL_APPLY_PAGE = "sigil-private-model-setup";
 export const SIGIL_PRIVATE_MODEL_APPLY_API_PAGE = "sigil-private-model-apply-api";
 export const SIGIL_APPLY_ROUTE_OWNER = "sigil-worker";
@@ -24,8 +25,7 @@ export const SIGIL_APPLY_ROUTE_OWNER = "sigil-worker";
 export const REDIRECT_HOSTS = new Set(["www.mmdbkk.com", "mmdbkk.com", "mmdprive.com", "www.mmdprive.com", "malemodel-bkk.workers.dev"]);
 export const NEVER_TOUCH_HOSTS = new Set(["sigil.mmdbkk.com"]);
 export const LINE_WEBHOOK_PATHS = new Set(["/webhooks/line", "/webhooks/line/", "/webhook/line", "/webhook/line/"]);
-export const MEMBER_PAGE_PATHS = new Set(["/member/membership", "/member/membership/", "/member/profile", "/member/profile/", "/pay/membership", "/pay/membership/", "/pay/pending-verification", "/pay/pending-verification/"]);
-
+export const MEMBER_PAGE_PATHS = new Set(["/member/profile", "/member/profile/", "/pay/membership", "/pay/membership/", "/pay/pending-verification", "/pay/pending-verification/"]);
 export const NEVER_TOUCH_PREFIXES = ["/api/", "/webhook/", "/webhooks/", "/pay/", "/payments/", "/payment/", "/payment-webhook/", "/admin/", "/sigil/", "/cdn-cgi/", "/assets/", "/static/", "/uploads/"];
 export const NEVER_REDIRECT_EXACT_PATHS = new Set(["/member/dashboard", "/member/dashboard/", "/member/membership", "/member/membership/", "/member/profile", "/member/profile/", "/member/payments", "/member/payments/", "/pay/membership", "/pay/membership/", "/pay/pending-verification", "/pay/pending-verification/", "/hall", "/hall/", "/model/console", "/model/console/"]);
 export const EXACT_PATH_REDIRECTS = { "/trust/inme": "/sigil/start", "/inme": "/sigil/start", "/login": "/sigil/start", "/member": "/member/dashboard", "/member/membership/benefits": "/member/membership", "/members": "/sigil/start", "/membership": "/member/membership", "/membership/benefits": "/member/membership", "/renew": "/sigil/membership", "/renewal": "/sigil/membership", "/trust": "/sigil/start" };
@@ -100,11 +100,52 @@ async function fetchPassThrough(request) {
   return withFrontGateHeaders(await maybeInjectConfirmPaymentBridge(request, response, url));
 }
 
+function getWebflowOriginHost(env = {}) {
+  return String(env.WEBFLOW_ORIGIN_HOST || DEFAULT_WEBFLOW_ORIGIN_HOST)
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/\/.*$/g, "");
+}
+
+function buildWebflowOriginUrl(request, env = {}) {
+  const host = getWebflowOriginHost(env);
+  if (!host) return null;
+
+  const target = new URL(request.url);
+  target.protocol = "https:";
+  target.hostname = host;
+  target.port = "";
+  return target;
+}
+
+async function fetchWebflowOriginPage(request, env = {}) {
+  const incoming = new URL(request.url);
+  const target = buildWebflowOriginUrl(request, env);
+
+  if (!target || target.hostname === incoming.hostname) {
+    return fetchPassThrough(request);
+  }
+
+  const headers = new Headers(request.headers);
+  headers.delete("host");
+  const response = await fetch(
+    new Request(target.toString(), {
+      method: request.method,
+      headers,
+      redirect: "follow",
+    }),
+  );
+  const passThrough = withFrontGateHeaders(response);
+  passThrough.headers.set("x-mmd-origin-pass-through", "webflow-origin");
+  return passThrough;
+}
+
 function isLineWebhookPath(url) { return LINE_WEBHOOK_PATHS.has(url.pathname.toLowerCase()); }
 function isSigilApplyPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/apply" || p === "/sigil/apply/"; }
 function isSigilMembershipPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/membership" || p === "/sigil/membership/"; }
 function isSigilPrivateModelApplyApiPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/api/private-model/apply" || p === "/sigil/api/private-model/apply/"; }
 function isMemberDashboardPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/dashboard" || p === "/member/dashboard/"; }
+function isMemberMembershipPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/membership" || p === "/member/membership/"; }
 function isMemberPagePath(url) { return MEMBER_PAGE_PATHS.has(url.pathname.toLowerCase()); }
 function isMemberPaymentsPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/payments" || p === "/member/payments/"; }
 function isHallPath(url) { const p = url.pathname.toLowerCase(); return p === "/hall" || p === "/hall/"; }
@@ -207,6 +248,7 @@ export default {
     if (isSigilApplyPath(url)) return fetchSigilApplyPage(request, env, url);
     if (isSigilMembershipPath(url)) return fetchMemberPage(request, env, url);
     if (isMemberDashboardPath(url)) return fetchMemberFrontend(request, env, url);
+    if (isMemberMembershipPath(url)) return fetchWebflowOriginPage(request, env);
     if (isMemberPagePath(url)) return fetchMemberPage(request, env, url);
     if (isMemberPaymentsPath(url)) return fetchAdminMemberPage(request, env, url);
     if (isHallPath(url)) return renderHallRecovery(request);

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -633,6 +633,7 @@ describe("MMD permanent redirect guard", () => {
       assert.match(upstreamUrl, /[?&]t=abc(?:&|$)/, url);
       assert.match(upstreamUrl, /[?&]code=x(?:&|$)/, url);
       assert.match(upstreamUrl, /[?&]promo=y(?:&|$)/, url);
+      assert.match(upstreamUrl, /^https:\/\/mmdprive\.webflow\.io\/member\/membership\/?/);
     }
   });
 

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -173,16 +173,20 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 0);
   });
 
-  it("delegates /member/membership to member-pages-worker by service binding without redirecting or changing query strings", async () => {
-    const serviceRequests = [];
+  it("passes /member/membership through to the Webflow origin path without redirecting or changing query strings", async () => {
+    const memberPageRequests = [];
+    const immigrateRequests = [];
     const env = {
       MEMBER_PAGES_WORKER: {
         fetch: async (request) => {
-          serviceRequests.push(request);
-          return new Response("member membership", {
-            status: 200,
-            headers: { "x-mmd-worker": "immigrate-worker", "x-mmd-page": "member-membership" },
-          });
+          memberPageRequests.push(request);
+          throw new Error(`/member/membership must not route to member-pages-worker: ${request.url}`);
+        },
+      },
+      IMMIGRATE_WORKER: {
+        fetch: async (request) => {
+          immigrateRequests.push(request);
+          throw new Error(`/member/membership must not route to immigrate-worker: ${request.url}`);
         },
       },
     };
@@ -198,13 +202,22 @@ describe("MMD permanent redirect guard", () => {
 
     for (const url of urls) {
       const response = await requestWithEnv(url, env);
-      assert.equal(response.status, 200, url);
-      assert.equal(response.headers.get("location"), null);
-      assert.equal(response.headers.get("x-mmd-page"), "member-membership");
-      assert.equal(serviceRequests.at(-1).url, url);
+      const upstream = new URL(url);
+      upstream.protocol = "https:";
+      upstream.hostname = "mmdprive.webflow.io";
+
+      assert.notEqual(response.status, 301, url);
+      assert.notEqual(response.status, 302, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-mmd-worker"), null, url);
+      assert.notEqual(response.headers.get("x-mmd-worker"), "member-pages-worker", url);
+      assert.equal(response.headers.get("x-mmd-origin-pass-through"), "webflow-origin", url);
+      assert.equal(passThroughRequests.at(-1).url, upstream.toString(), url);
     }
 
-    assert.equal(passThroughRequests.length, 0);
+    assert.equal(memberPageRequests.length, 0);
+    assert.equal(immigrateRequests.length, 0);
+    assert.equal(passThroughRequests.length, urls.length);
   });
 
   it("delegates /sigil/membership to member-pages-worker before generic SIGIL pass-through", async () => {
@@ -569,12 +582,12 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 0);
   });
 
-  it("falls back to the member-pages-worker upstream for /member/membership when service binding is missing", async () => {
+  it("passes /member/membership through to origin when service bindings are missing", async () => {
     globalThis.fetch = async (request) => {
       passThroughRequests.push(request);
-      return new Response("membership upstream", {
+      return new Response("webflow membership", {
         status: 200,
-        headers: { "x-mmd-worker": "immigrate-worker", "x-mmd-page": "member-membership" },
+        headers: { "x-webflow-page": "member-membership" },
       });
     };
 
@@ -588,10 +601,38 @@ describe("MMD permanent redirect guard", () => {
       const response = await request(url);
       const expected = new URL(url);
       expected.protocol = "https:";
-      expected.hostname = "member-pages-worker.malemodel-bkk.workers.dev";
+      expected.hostname = "mmdprive.webflow.io";
       assert.equal(response.status, 200, url);
       assert.equal(response.headers.get("location"), null);
+      assert.equal(response.headers.get("x-webflow-page"), "member-membership");
+      assert.notEqual(response.headers.get("x-mmd-worker"), "member-pages-worker", url);
+      assert.equal(response.headers.get("x-mmd-origin-pass-through"), "webflow-origin", url);
       assert.equal(passThroughRequests.at(-1).url, expected.toString());
+    }
+  });
+
+  it("preserves t, code, and promo on /member/membership without legacy redirects", async () => {
+    globalThis.fetch = async (request) => {
+      passThroughRequests.push(request);
+      return new Response("webflow membership", { status: 200 });
+    };
+
+    const urls = [
+      "https://mmdbkk.com/member/membership?t=abc&code=x&promo=y",
+      "https://www.mmdbkk.com/member/membership?t=abc&code=x&promo=y",
+      "https://mmdbkk.com/member/membership/?t=abc&code=x&promo=y",
+    ];
+
+    for (const url of urls) {
+      const response = await request(url);
+      const upstreamUrl = passThroughRequests.at(-1).url;
+
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.doesNotMatch(upstreamUrl, /\/pay\/membership|\/trust\/inme|\/membership\/benefits/i, url);
+      assert.match(upstreamUrl, /[?&]t=abc(?:&|$)/, url);
+      assert.match(upstreamUrl, /[?&]code=x(?:&|$)/, url);
+      assert.match(upstreamUrl, /[?&]promo=y(?:&|$)/, url);
     }
   });
 

--- a/mmd-redirect-worker/wrangler.toml
+++ b/mmd-redirect-worker/wrangler.toml
@@ -7,6 +7,9 @@ workers_dev = false
 enabled = true
 head_sampling_rate = 1
 
+[vars]
+WEBFLOW_ORIGIN_HOST = "mmdprive.webflow.io"
+
 [[services]]
 binding = "IMMIGRATE_WORKER"
 service = "immigrate-worker"


### PR DESCRIPTION
## Summary

- Preserve separation between MMD Privé public / white-world membership and SIGIL private access.
- `/member/membership` remains the public MMD Privé membership entry.
- `/member/membership` and `/member/membership/` pass through to the configured Webflow origin instead of hard-redirecting into SIGIL.
- `/membership` maps to `/member/membership` with query strings preserved.
- Nested legacy paths such as `/member/membership/benefits` map back to `/member/membership`.
- `/sigil/member/membership` remains available for future SIGIL/private access logic, but it does not replace the public membership route in this PR.
- `/member/dashboard` remains unchanged.
- `/member/profile` remains unchanged.
- `/trust/inme` route claims are removed from this worker config so ownership is not accidentally seized here.
- No deploy performed.

## Validation

Reported by Codex:
- `npm --prefix mmd-redirect-worker test` passed: 46/46
- `npm --prefix mmd-redirect-worker run check` passed

## Guardrails

- Do not merge until Boss Per confirms the Webflow-origin public membership behavior.
- Do not deploy from this PR without explicit approval.
- Do not touch Kenji member memory / LINE webhook work.