### PR TITLE
[codex] fix sigil apply route ownership

### DIFF
--- a/docs/sigil-route-ownership-registry.md
+++ b/docs/sigil-route-ownership-registry.md
@@ -1,0 +1,29 @@
+# SIGIL Route Ownership Registry
+
+Last updated: 2026-06-22
+
+This registry records canonical owners for SIGIL public routes fronted by
+`mmd-redirect-worker`. Routes listed here must not be served by generic Webflow
+pass-through or an unrelated fallback page.
+
+| Public route | Canonical owner | Front gate behavior | Origin header | Page header |
+| --- | --- | --- | --- | --- |
+| `GET /sigil/apply` | `sigil-worker` | Delegate directly to `SIGIL_WORKER`. If the service binding is unavailable, fetch only `https://sigil.mmdbkk.com/sigil/apply` with the original query string. | `x-mmd-origin: service-binding:sigil-worker` or `https://sigil.mmdbkk.com` | `x-mmd-page: sigil-private-model-setup` |
+| `GET /sigil/apply/` | `sigil-worker` | Same as `/sigil/apply`, preserving the trailing slash and query string. | `x-mmd-origin: service-binding:sigil-worker` or `https://sigil.mmdbkk.com` | `x-mmd-page: sigil-private-model-setup` |
+
+Required owner headers for `/sigil/apply` responses:
+
+- `x-mmd-route-owner: sigil-worker`
+- `x-mmd-page: sigil-private-model-setup`
+- `x-mmd-origin: service-binding:sigil-worker` for service binding responses
+- `x-mmd-front-gate: mmd-redirect-worker`
+- `x-mmd-front-version: 20260622T071500Z`
+
+Regression guard:
+
+- `/sigil/apply` and `/sigil/apply/` on both `mmdbkk.com` and
+  `www.mmdbkk.com` must never render content from `/ceo/telegram-brief`.
+- Tests must fail if the response body contains `Briefing HYPE TELEGRAMBOT`,
+  `TELEGRAMBOT`, or `CEO TELEGRAM BRIEF`.
+- Query strings such as `?t=abc&code=x&promo=y` must be preserved exactly when
+  delegated to the owner.

--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -14,8 +14,11 @@ export const CONFIRM_PAYMENT_PATH = "/confirm/payment-confirmation";
 export const MEMBER_DASHBOARD_UPSTREAM = "https://immigrate-worker.malemodel-bkk.workers.dev";
 export const MEMBER_PAGES_UPSTREAM = "https://member-pages-worker.malemodel-bkk.workers.dev";
 export const ADMIN_WORKER_UPSTREAM = "https://admin-worker.malemodel-bkk.workers.dev";
+export const SIGIL_WORKER_UPSTREAM = "https://sigil.mmdbkk.com";
 export const FRONT_GATE = "mmd-redirect-worker";
 export const FRONT_VERSION = "20260622T071500Z";
+export const SIGIL_APPLY_PAGE = "sigil-private-model-setup";
+export const SIGIL_APPLY_ROUTE_OWNER = "sigil-worker";
 
 export const REDIRECT_HOSTS = new Set(["www.mmdbkk.com", "mmdbkk.com", "mmdprive.com", "www.mmdprive.com", "malemodel-bkk.workers.dev"]);
 export const NEVER_TOUCH_HOSTS = new Set(["sigil.mmdbkk.com"]);
@@ -61,6 +64,14 @@ function withFrontGateHeaders(response) {
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
 }
 
+function withRouteOwnerHeaders(response, { owner, page, origin }) {
+  const frontGateResponse = withFrontGateHeaders(response);
+  frontGateResponse.headers.set("x-mmd-route-owner", owner);
+  frontGateResponse.headers.set("x-mmd-page", page);
+  frontGateResponse.headers.set("x-mmd-origin", origin);
+  return frontGateResponse;
+}
+
 function isConfirmPaymentPage(url) {
   return url.pathname === CONFIRM_PAYMENT_PATH || url.pathname === `${CONFIRM_PAYMENT_PATH}/`;
 }
@@ -89,6 +100,7 @@ async function fetchPassThrough(request) {
 }
 
 function isLineWebhookPath(url) { return LINE_WEBHOOK_PATHS.has(url.pathname.toLowerCase()); }
+function isSigilApplyPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/apply" || p === "/sigil/apply/"; }
 function isMemberDashboardPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/dashboard" || p === "/member/dashboard/"; }
 function isMemberPagePath(url) { return MEMBER_PAGE_PATHS.has(url.pathname.toLowerCase()); }
 function isMemberPaymentsPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/payments" || p === "/member/payments/"; }
@@ -111,6 +123,25 @@ async function fetchMemberFrontend(request, env, url) {
   target.pathname = url.pathname;
   target.search = url.search;
   return withFrontGateHeaders(await fetch(new Request(target.toString(), request)));
+}
+
+async function fetchSigilApplyPage(request, env, url) {
+  if (env?.SIGIL_WORKER?.fetch) {
+    return withRouteOwnerHeaders(await env.SIGIL_WORKER.fetch(request), {
+      owner: SIGIL_APPLY_ROUTE_OWNER,
+      page: SIGIL_APPLY_PAGE,
+      origin: "service-binding:sigil-worker",
+    });
+  }
+
+  const target = new URL(SIGIL_WORKER_UPSTREAM);
+  target.pathname = url.pathname;
+  target.search = url.search;
+  return withRouteOwnerHeaders(await fetch(new Request(target.toString(), request)), {
+    owner: SIGIL_APPLY_ROUTE_OWNER,
+    page: SIGIL_APPLY_PAGE,
+    origin: SIGIL_WORKER_UPSTREAM,
+  });
 }
 
 async function fetchMemberPage(request, env, url) {
@@ -161,6 +192,7 @@ export default {
     const url = new URL(request.url);
     if (isLineWebhookPath(url)) return fetchLineWebhook(request, env, url);
     if (!isSafePageRequest(request)) return withFrontGateHeaders(await fetch(request));
+    if (isSigilApplyPath(url)) return fetchSigilApplyPage(request, env, url);
     if (isMemberDashboardPath(url)) return fetchMemberFrontend(request, env, url);
     if (isMemberPagePath(url)) return fetchMemberPage(request, env, url);
     if (isMemberPaymentsPath(url)) return fetchAdminMemberPage(request, env, url);

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -44,6 +44,8 @@ const VISIBLE_DEBUG_TEXT = [
   "recovery",
 ];
 
+const TELEGRAM_BRIEF_FORBIDDEN_TEXT = /Briefing HYPE TELEGRAMBOT|TELEGRAMBOT|CEO TELEGRAM BRIEF/i;
+
 function assertPolishedShell(html, url) {
   assert.doesNotMatch(html, /name=["']token["']/i, url);
   for (const text of VISIBLE_DEBUG_TEXT) {
@@ -141,6 +143,77 @@ describe("MMD permanent redirect guard", () => {
     }
 
     assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("delegates canonical /sigil/apply routes to sigil-worker with ownership headers and preserved query strings", async () => {
+    const sigilRequests = [];
+    const env = {
+      SIGIL_WORKER: {
+        fetch: async (request) => {
+          sigilRequests.push(request);
+          const url = new URL(request.url);
+          return new Response(`<main>SIGIL Private Model Setup ${url.search}</main>`, {
+            status: 200,
+            headers: {
+              "content-type": "text/html; charset=utf-8",
+              "x-mmd-page": "sigil-private-model-setup",
+              "x-mmd-sigil-page-source": "webflow/private-model-setup",
+            },
+          });
+        },
+      },
+    };
+
+    const urls = [
+      "https://mmdbkk.com/sigil/apply",
+      "https://mmdbkk.com/sigil/apply/",
+      "https://www.mmdbkk.com/sigil/apply?t=abc&code=x&promo=y",
+      "https://www.mmdbkk.com/sigil/apply/?t=abc&code=x&promo=y",
+    ];
+
+    for (const url of urls) {
+      const response = await requestWithEnv(url, env);
+      const html = await response.text();
+
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-mmd-route-owner"), "sigil-worker", url);
+      assert.equal(response.headers.get("x-mmd-page"), "sigil-private-model-setup", url);
+      assert.equal(response.headers.get("x-mmd-origin"), "service-binding:sigil-worker", url);
+      assert.equal(response.headers.get("x-mmd-front-gate"), "mmd-redirect-worker", url);
+      assert.equal(response.headers.get("x-mmd-front-version"), "20260622T071500Z", url);
+      assert.doesNotMatch(html, TELEGRAM_BRIEF_FORBIDDEN_TEXT, url);
+      assert.equal(sigilRequests.at(-1).url, url);
+    }
+
+    assert.equal(sigilRequests.length, urls.length);
+    assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("does not use Webflow or generic pass-through for /sigil/apply when the service binding is unavailable", async () => {
+    const urls = [
+      "https://mmdbkk.com/sigil/apply?t=abc&code=x&promo=y",
+      "https://www.mmdbkk.com/sigil/apply/?t=abc&code=x&promo=y",
+    ];
+
+    for (const url of urls) {
+      const response = await request(url);
+      const html = await response.text();
+      const expected = new URL(url);
+      expected.protocol = "https:";
+      expected.hostname = "sigil.mmdbkk.com";
+
+      assert.equal(response.status, 209, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-mmd-route-owner"), "sigil-worker", url);
+      assert.equal(response.headers.get("x-mmd-page"), "sigil-private-model-setup", url);
+      assert.equal(response.headers.get("x-mmd-origin"), "https://sigil.mmdbkk.com", url);
+      assert.equal(passThroughRequests.at(-1).url, expected.toString(), url);
+      assert.notEqual(new URL(passThroughRequests.at(-1).url).hostname, "mmdprive.webflow.io", url);
+      assert.doesNotMatch(html, TELEGRAM_BRIEF_FORBIDDEN_TEXT, url);
+    }
+
+    assert.equal(passThroughRequests.length, urls.length);
   });
 
   it("delegates /member/payments to admin-worker without redirecting or changing query strings", async () => {

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -216,6 +216,23 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, urls.length);
   });
 
+  it("fails closed without Webflow or generic pass-through when /sigil/apply service binding throws", async () => {
+    const env = {
+      SIGIL_WORKER: {
+        fetch: async () => {
+          throw new Error("sigil service unavailable");
+        },
+      },
+    };
+
+    await assert.rejects(
+      requestWithEnv("https://www.mmdbkk.com/sigil/apply?t=abc&code=x&promo=y", env),
+      /sigil service unavailable/,
+    );
+
+    assert.equal(passThroughRequests.length, 0);
+  });
+
   it("delegates /member/payments to admin-worker without redirecting or changing query strings", async () => {
     const adminRequests = [];
     const env = {

--- a/mmd-redirect-worker/wrangler.toml
+++ b/mmd-redirect-worker/wrangler.toml
@@ -15,6 +15,10 @@ service = "immigrate-worker"
 binding = "MEMBER_PAGES_WORKER"
 service = "member-pages-worker"
 
+[[services]]
+binding = "SIGIL_WORKER"
+service = "sigil-worker"
+
 [[routes]]
 pattern = "mmdbkk.com/*"
 zone_name = "mmdbkk.com"
@@ -53,6 +57,22 @@ zone_name = "mmdbkk.com"
 
 [[routes]]
 pattern = "www.mmdbkk.com/member/membership/"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/sigil/apply"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/sigil/apply/"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/sigil/apply"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/sigil/apply/"
 zone_name = "mmdbkk.com"
 
 # Temporary safety catch for old SIGIL admin route leakage.


### PR DESCRIPTION
## Summary

Fixes the production route collision risk where `/sigil/apply` can be served by generic pass-through and show unrelated Webflow content from `/ceo/telegram-brief`.

This PR gives `/sigil/apply` and `/sigil/apply/` one explicit canonical owner in `mmd-redirect-worker`: `sigil-worker`.

## Root Cause

`/sigil/apply` matched the generic `/sigil/` never-touch/pass-through path in the front gate. That allowed Cloudflare/Webflow route precedence or fallback behavior to serve unrelated Webflow content instead of the intended Sigil apply page.

## What Changed

- Added exact `/sigil/apply` and `/sigil/apply/` handling before generic Sigil pass-through.
- Added `SIGIL_WORKER` service binding pointing to Cloudflare Worker service `sigil-worker`.
- Added exact route claims for both hosts and slash variants:
  - `mmdbkk.com/sigil/apply`
  - `mmdbkk.com/sigil/apply/`
  - `www.mmdbkk.com/sigil/apply`
  - `www.mmdbkk.com/sigil/apply/`
- Added owner headers:
  - `x-mmd-route-owner`
  - `x-mmd-page`
  - `x-mmd-origin`
  - existing `x-mmd-front-gate`
  - existing `x-mmd-front-version`
- Added regression tests that fail if `/sigil/apply` contains:
  - `Briefing HYPE TELEGRAMBOT`
  - `TELEGRAMBOT`
  - `CEO TELEGRAM BRIEF`
- Added `docs/sigil-route-ownership-registry.md`.

## Sigil Worker Handler Confirmation

Read-only verification from the local Sigil worker source in this workspace confirms:

- `sigil-worker/wrangler.toml` declares `name = "sigil-worker"`.
- `sigil-worker/wrangler.toml` owns `sigil.mmdbkk.com/sigil/*`.
- `sigil-worker/src/index.ts` defines `SIGIL_APPLY_PATH = "/sigil/apply"`.
- `isPrivateModelSetupRoute(pathname)` explicitly matches both:
  - `/sigil/apply`
  - `/sigil/apply/`
- Matching requests render `renderPrivateModelSetupPage(request)`, which returns:
  - `x-mmd-page: sigil-private-model-setup`
  - `x-mmd-sigil-webflow-package: private-model-setup`

Read-only Wrangler verification confirms `sigil-worker` has existing Cloudflare deployments. No deploy was run.

## Fallback Behavior

If `SIGIL_WORKER` binding is present, the front gate delegates directly to that service binding.

If the binding is unavailable, the front gate fetches only `https://sigil.mmdbkk.com/sigil/apply` or `https://sigil.mmdbkk.com/sigil/apply/`, preserving the original query string.

It does not fall back to Webflow or generic pass-through for `/sigil/apply`.

If the `SIGIL_WORKER` service call itself throws at runtime, this code does not catch and reroute to Webflow; it fails rather than serving unrelated content.

## Scope Guard

This PR does not intentionally change payment, membership, points, Black Card, webhook, admin, or unrelated route family behavior.

Changed files are limited to:

- `mmd-redirect-worker/src/index.js`
- `mmd-redirect-worker/test/redirect.test.mjs`
- `mmd-redirect-worker/wrangler.toml`
- `docs/sigil-route-ownership-registry.md`

## Validation

Passed:

```bash
npm --prefix mmd-redirect-worker run check
node --test --test-name-pattern='sigil/apply' mmd-redirect-worker/test/redirect.test.mjs
npx wrangler deployments list --config sigil-worker/wrangler.toml
```

Note: `node --test mmd-redirect-worker/test/redirect.test.mjs` currently has unrelated pre-existing failures on `main` around member/payment route expectations. Those were not changed here because this PR is intentionally scoped to `/sigil/apply` route ownership.

## Production Smoke Commands For Reviewer To Run After Deploy Approval

```bash
for url in \
  'https://mmdbkk.com/sigil/apply?t=abc&code=x&promo=y' \
  'https://mmdbkk.com/sigil/apply/?t=abc&code=x&promo=y' \
  'https://www.mmdbkk.com/sigil/apply?t=abc&code=x&promo=y' \
  'https://www.mmdbkk.com/sigil/apply/?t=abc&code=x&promo=y'; do
  echo "--- $url"
  curl -sS -D - "$url" -o /tmp/sigil-apply.html | awk 'BEGIN{IGNORECASE=1} /^x-mmd-route-owner:|^x-mmd-page:|^x-mmd-origin:|^x-mmd-front-gate:|^x-mmd-front-version:|^location:/ {print}'
  grep -Eiq 'Briefing HYPE TELEGRAMBOT|TELEGRAMBOT|CEO TELEGRAM BRIEF' /tmp/sigil-apply.html && echo 'FAIL telegram brief content found' && exit 1
  grep -Eq 'SIGIL Private Model Setup|sigil-private-setup|private-model' /tmp/sigil-apply.html || echo 'WARN expected Sigil apply marker not found'
done
```

No production deployment has been performed by this PR.