### PR TITLE
Fix Sigil apply submit endpoint

### DIFF
--- a/sigil-worker/src/index.ts
+++ b/sigil-worker/src/index.ts
@@ -12,8 +12,20 @@ const SIGIL_APPLY_PATH = "/sigil/apply";
 const SIGIL_MODEL_APPLY_PATH = "/sigil/model/apply";
 const SIGIL_MODEL_APPLY_PRIVATE_PATH = "/sigil/model/apply/private-model";
 const SIGIL_MODEL_APPLY_PRIVATE_RECEIVED_PATH = "/sigil/model/apply/private-model/received";
+const SIGIL_PRIVATE_MODEL_APPLY_API_PATH = "/sigil/api/private-model/apply";
+const SIGIL_PRIVATE_MODEL_APPLY_ENDPOINT = `https://sigil.mmdbkk.com${SIGIL_PRIVATE_MODEL_APPLY_API_PATH}`;
 const SIGIL_LOGO_URL = "https://cdn.prod.website-files.com/68f879d546d2f4e2ab186e90/6a0f2cbc7e26b6735aee4cb2_SIGIL%20LOGO%20Transp.webp";
 const SIGIL_LOGIN_BG_URL = "https://cdn.prod.website-files.com/68f879d546d2f4e2ab186e90/6a0802e10402165b8404527c_BPEWPRIVELogin.png";
+const PRIVATE_MODEL_APPLY_ALLOWED_ORIGINS = new Set([
+  "https://mmdbkk.com",
+  "https://www.mmdbkk.com",
+  "https://sigil.mmdbkk.com",
+]);
+const PRIVATE_MODEL_STANDARD_VALUES = new Set([
+  "standard_private",
+  "premium_private",
+  "selective_case_by_case",
+]);
 
 const PRIVATE_MODEL_SETUP_CSS = `#sigil-private-setup {
   --sps-ink: #fff4df;
@@ -222,7 +234,7 @@ const PRIVATE_MODEL_SETUP_SCRIPT = `(function () {
   var form = root.querySelector("[data-private-setup-form]");
   var status = root.querySelector("[data-private-setup-status]");
   if (!form) return;
-  var endpoint = root.getAttribute("data-endpoint") || "/sigil/api/private-model/apply";
+  var endpoint = root.getAttribute("data-endpoint") || "https://sigil.mmdbkk.com/sigil/api/private-model/apply";
   var dashboardUrl = root.getAttribute("data-dashboard-url") || "/sigil/model/apply/private-model/received";
   function clean(value) { return String(value || "").trim(); }
   function field(name) { return form.elements[name]; }
@@ -262,6 +274,7 @@ const PRIVATE_MODEL_SETUP_SCRIPT = `(function () {
       minimum_rate_thb: Number.isFinite(rate) ? rate : 0,
       private_note: value("private_note"),
       consent: Boolean(field("consent") && field("consent").checked),
+      website: value("website"),
       page_url: window.location.href.split("?")[0],
       language: "th",
       timezone: "Asia/Bangkok",
@@ -317,6 +330,8 @@ const FIRST_WAVE_ROUTES = new Set<string>([
   "POST /sigil/admin/verify-access-code",
   "GET /sigil/apply",
   "GET /sigil/apply/",
+  "OPTIONS /sigil/api/private-model/apply",
+  "POST /sigil/api/private-model/apply",
   "GET /sigil/model/apply",
   "GET /sigil/model/apply/",
   "GET /sigil/model/apply/private-model",
@@ -400,6 +415,22 @@ export default {
       return response;
     }
 
+    if (url.pathname === SIGIL_PRIVATE_MODEL_APPLY_API_PATH) {
+      const response = request.method === "OPTIONS"
+        ? privateModelApplyOptions(request)
+        : request.method === "POST"
+          ? await handlePrivateModelApply(request)
+          : withPrivateModelApplyCors(
+            json({ ok: false, error: "method_not_allowed", message: "Use POST for this endpoint." }, 405),
+            request,
+          );
+      const owned = withSigilHeaders(response, build);
+      owned.headers.set("x-mmd-route-owner", OWNER);
+      owned.headers.set("x-mmd-page", "sigil-private-model-apply-api");
+      owned.headers.set("x-mmd-sigil-migration-wave", "first");
+      return owned;
+    }
+
     const upstreamUrl = toUpstreamUrl(url, upstreamBaseUrl);
     const upstreamRequest = new Request(upstreamUrl.toString(), request);
     const upstream = await fetch(upstreamRequest);
@@ -418,6 +449,150 @@ export default {
     return response;
   },
 };
+
+type PrivateModelApplyPayload = {
+  nickname?: unknown;
+  phone?: unknown;
+  telegram_username?: unknown;
+  line_id?: unknown;
+  private_standard?: unknown;
+  minimum_rate_thb?: unknown;
+  private_note?: unknown;
+  consent?: unknown;
+  website?: unknown;
+};
+
+async function handlePrivateModelApply(request: Request): Promise<Response> {
+  const contentType = request.headers.get("content-type") || "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return withPrivateModelApplyCors(
+      json({
+        ok: false,
+        error: "invalid_request",
+        message: "Send this application as JSON.",
+      }, 400),
+      request,
+    );
+  }
+
+  let payload: PrivateModelApplyPayload;
+  try {
+    const parsed = await request.json();
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("invalid payload");
+    }
+    payload = parsed as PrivateModelApplyPayload;
+  } catch {
+    return withPrivateModelApplyCors(
+      json({
+        ok: false,
+        error: "invalid_request",
+        message: "Check the application fields and try again.",
+      }, 400),
+      request,
+    );
+  }
+
+  const validationMessage = validatePrivateModelApplyPayload(payload);
+  if (validationMessage) {
+    return withPrivateModelApplyCors(
+      json({ ok: false, error: "invalid_request", message: validationMessage }, 400),
+      request,
+    );
+  }
+
+  if (cleanPayloadString(payload.website)) {
+    return withPrivateModelApplyCors(
+      json({
+        ok: true,
+        status: "received",
+        application_id: "",
+        received_url: SIGIL_MODEL_APPLY_PRIVATE_RECEIVED_PATH,
+      }),
+      request,
+    );
+  }
+
+  const applicationId = `sigil_private_${Date.now().toString(36)}_${crypto.randomUUID().slice(0, 8)}`;
+  return withPrivateModelApplyCors(
+    json({
+      ok: true,
+      status: "received",
+      application_id: applicationId,
+      id: applicationId,
+      received_url: SIGIL_MODEL_APPLY_PRIVATE_RECEIVED_PATH,
+      dashboard_url: SIGIL_MODEL_APPLY_PRIVATE_RECEIVED_PATH,
+      message: "Application received.",
+    }),
+    request,
+  );
+}
+
+function validatePrivateModelApplyPayload(payload: PrivateModelApplyPayload): string {
+  if (!cleanPayloadString(payload.nickname)) {
+    return "Please add the name TarT should use.";
+  }
+
+  if (!(
+    cleanPayloadString(payload.phone) ||
+    cleanPayloadString(payload.telegram_username) ||
+    cleanPayloadString(payload.line_id)
+  )) {
+    return "Please add at least one contact channel.";
+  }
+
+  const standard = cleanPayloadString(payload.private_standard);
+  if (!standard || !PRIVATE_MODEL_STANDARD_VALUES.has(standard)) {
+    return "Please choose a private standard.";
+  }
+
+  const rate = Number(payload.minimum_rate_thb);
+  if (!Number.isFinite(rate) || rate <= 0) {
+    return "Please add a valid minimum rate.";
+  }
+
+  if (payload.consent !== true) {
+    return "Please confirm consent before submitting.";
+  }
+
+  return "";
+}
+
+function cleanPayloadString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function privateModelApplyOptions(request: Request): Response {
+  return withPrivateModelApplyCors(new Response(null, {
+    status: 204,
+    headers: {
+      "cache-control": "no-store",
+      "access-control-max-age": "86400",
+    },
+  }), request);
+}
+
+function withPrivateModelApplyCors(response: Response, request: Request): Response {
+  const headers = new Headers(response.headers);
+  const origin = request.headers.get("origin") || "";
+  if (PRIVATE_MODEL_APPLY_ALLOWED_ORIGINS.has(origin)) {
+    headers.set("access-control-allow-origin", origin);
+    headers.set("access-control-allow-methods", "POST, OPTIONS");
+    headers.set("access-control-allow-headers", request.headers.get("access-control-request-headers") || "content-type");
+    headers.set("vary", appendVary(headers.get("vary"), "Origin"));
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function appendVary(current: string | null, value: string): string {
+  if (!current) return value;
+  const parts = current.split(",").map((part) => part.trim().toLowerCase());
+  return parts.includes(value.toLowerCase()) ? current : `${current}, ${value}`;
+}
 
 function renderAdminLoginPage(url: URL): Response {
   const next = normalizeLocalNext(url.searchParams.get("next") || "") || DEFAULT_ADMIN_NEXT;
@@ -812,7 +987,7 @@ function renderPrivateModelSetupPage(request: Request): Response {
   <section
     id="sigil-private-setup"
     class="sps sps-private-apply"
-    data-endpoint="https://mmdbkk.com/sigil/api/private-model/apply"
+    data-endpoint="${SIGIL_PRIVATE_MODEL_APPLY_ENDPOINT}"
     data-dashboard-url="${SIGIL_MODEL_APPLY_PRIVATE_RECEIVED_PATH}"
     data-received-url="${SIGIL_MODEL_APPLY_PRIVATE_RECEIVED_PATH}"
   >

--- a/sigil-worker/test/apply-page.test.mjs
+++ b/sigil-worker/test/apply-page.test.mjs
@@ -1,23 +1,166 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import test from "node:test";
+import ts from "typescript";
 
 const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
-
 const forbiddenTelegramBrief = /Briefing HYPE TELEGRAMBOT|TELEGRAMBOT|CEO TELEGRAM BRIEF/i;
 
-assert.match(source, /SIGIL_APPLY_PATH = "\/sigil\/apply"/);
-assert.match(source, /function renderPrivateModelSetupPage/);
-assert.match(source, /x-mmd-page": "sigil-private-model-setup"/);
-assert.match(source, /SIGIL Private Model Setup \| MMD Privé/);
-assert.match(source, /id="sigil-private-setup"/);
-assert.match(source, /class="sps sps-private-apply"/);
-assert.match(source, /#sigil-private-setup \{/);
-assert.match(source, /data-private-setup-form/);
-assert.match(source, /data-endpoint="https:\/\/mmdbkk\.com\/sigil\/api\/private-model\/apply"/);
-assert.match(source, /name="nickname"/);
-assert.match(source, /name="telegram_username"/);
-assert.match(source, /name="line_id"/);
-assert.match(source, /name="minimum_rate_thb"/);
-assert.match(source, /name="private_note"/);
-assert.doesNotMatch(source, /Rollback:/);
-assert.doesNotMatch(source, forbiddenTelegramBrief);
+const compiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+  },
+});
+const workerModule = await import(`data:text/javascript;base64,${Buffer.from(compiled.outputText).toString("base64")}`);
+const worker = workerModule.default;
+
+async function runWorker(request) {
+  const originalFetch = globalThis.fetch;
+  let upstreamCalls = 0;
+  globalThis.fetch = async () => {
+    upstreamCalls += 1;
+    throw new Error("unexpected upstream fallback");
+  };
+
+  try {
+    const response = await worker.fetch(request, { SIGIL_ROUTE_MIGRATION_BUILD: "TEST_BUILD" });
+    return { response, upstreamCalls };
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+function validPayload() {
+  return {
+    nickname: "Test Private Model",
+    phone: "0812345678",
+    telegram_username: "@sigiltest",
+    line_id: "sigiltest",
+    private_standard: "standard_private",
+    minimum_rate_thb: 12000,
+    private_note: "Available for private review.",
+    consent: true,
+    website: "",
+  };
+}
+
+test("sigil apply page keeps polished private apply package", async () => {
+  assert.match(source, /SIGIL_APPLY_PATH = "\/sigil\/apply"/);
+  assert.match(source, /function renderPrivateModelSetupPage/);
+  assert.match(source, /x-mmd-page": "sigil-private-model-setup"/);
+  assert.match(source, /SIGIL Private Model Setup \| MMD Privé/);
+  assert.match(source, /id="sigil-private-setup"/);
+  assert.match(source, /class="sps sps-private-apply"/);
+  assert.match(source, /#sigil-private-setup \{/);
+  assert.match(source, /data-private-setup-form/);
+  assert.match(source, /data-endpoint="\$\{SIGIL_PRIVATE_MODEL_APPLY_ENDPOINT\}"/);
+  assert.match(source, /https:\/\/sigil\.mmdbkk\.com\/sigil\/api\/private-model\/apply/);
+  assert.match(source, /name="nickname"/);
+  assert.match(source, /name="phone"/);
+  assert.match(source, /name="telegram_username"/);
+  assert.match(source, /name="line_id"/);
+  assert.match(source, /name="private_standard"/);
+  assert.match(source, /name="minimum_rate_thb"/);
+  assert.match(source, /name="private_note"/);
+  assert.match(source, /name="consent"/);
+  assert.match(source, /name="website"/);
+  assert.doesNotMatch(source, /Rollback:/);
+  assert.doesNotMatch(source, forbiddenTelegramBrief);
+
+  const { response, upstreamCalls } = await runWorker(
+    new Request("https://sigil.mmdbkk.com/sigil/apply?t=abc&code=x&promo=y"),
+  );
+  const html = await response.text();
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("x-mmd-route-owner"), "sigil-worker");
+  assert.equal(response.headers.get("x-mmd-page"), "sigil-private-model-setup");
+  assert.equal(upstreamCalls, 0);
+  assert.match(html, /id="sigil-private-setup"/);
+  assert.match(html, /class="sps sps-private-apply"/);
+  assert.match(html, /data-private-setup-form/);
+  assert.match(html, /data-endpoint="https:\/\/sigil\.mmdbkk\.com\/sigil\/api\/private-model\/apply"/);
+  assert.doesNotMatch(html, /Rollback:/);
+  assert.doesNotMatch(html, forbiddenTelegramBrief);
+});
+
+test("private model apply API accepts valid POSTs from apex and www pages", async () => {
+  for (const origin of ["https://mmdbkk.com", "https://www.mmdbkk.com"]) {
+    const { response, upstreamCalls } = await runWorker(
+      new Request("https://sigil.mmdbkk.com/sigil/api/private-model/apply", {
+        method: "POST",
+        headers: {
+          origin,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(validPayload()),
+      }),
+    );
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "application/json; charset=utf-8");
+    assert.equal(response.headers.get("access-control-allow-origin"), origin);
+    assert.equal(response.headers.get("x-mmd-sigil-owner"), "sigil-worker");
+    assert.equal(response.headers.get("x-mmd-route-owner"), "sigil-worker");
+    assert.equal(response.headers.get("x-mmd-page"), "sigil-private-model-apply-api");
+    assert.equal(response.headers.has("x-mmd-sigil-upstream"), false);
+    assert.equal(upstreamCalls, 0);
+    assert.equal(body.ok, true);
+    assert.equal(body.status, "received");
+    assert.match(body.application_id, /^sigil_private_/);
+    assert.equal(body.received_url, "/sigil/model/apply/private-model/received");
+  }
+});
+
+test("private model apply API returns a user-safe validation error", async () => {
+  const invalid = validPayload();
+  invalid.nickname = "";
+
+  const { response, upstreamCalls } = await runWorker(
+    new Request("https://sigil.mmdbkk.com/sigil/api/private-model/apply", {
+      method: "POST",
+      headers: {
+        origin: "https://www.mmdbkk.com",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(invalid),
+    }),
+  );
+  const body = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(response.headers.get("access-control-allow-origin"), "https://www.mmdbkk.com");
+  assert.equal(response.headers.get("x-mmd-sigil-owner"), "sigil-worker");
+  assert.equal(response.headers.get("x-mmd-route-owner"), "sigil-worker");
+  assert.equal(response.headers.get("x-mmd-page"), "sigil-private-model-apply-api");
+  assert.equal(response.headers.has("x-mmd-sigil-upstream"), false);
+  assert.equal(upstreamCalls, 0);
+  assert.equal(body.ok, false);
+  assert.equal(body.error, "invalid_request");
+  assert.match(body.message, /name TarT/);
+  assert.doesNotMatch(JSON.stringify(body), forbiddenTelegramBrief);
+});
+
+test("private model apply API handles CORS preflight without fallback", async () => {
+  const { response, upstreamCalls } = await runWorker(
+    new Request("https://sigil.mmdbkk.com/sigil/api/private-model/apply", {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://www.mmdbkk.com",
+        "access-control-request-headers": "content-type",
+      },
+    }),
+  );
+
+  assert.equal(response.status, 204);
+  assert.equal(response.headers.get("access-control-allow-origin"), "https://www.mmdbkk.com");
+  assert.equal(response.headers.get("access-control-allow-methods"), "POST, OPTIONS");
+  assert.equal(response.headers.get("access-control-allow-headers"), "content-type");
+  assert.equal(response.headers.get("x-mmd-sigil-owner"), "sigil-worker");
+  assert.equal(response.headers.get("x-mmd-route-owner"), "sigil-worker");
+  assert.equal(response.headers.get("x-mmd-page"), "sigil-private-model-apply-api");
+  assert.equal(response.headers.has("x-mmd-sigil-upstream"), false);
+  assert.equal(upstreamCalls, 0);
+});


### PR DESCRIPTION
## Summary
- Keeps the polished `/sigil/apply` page package from PR #90 and changes its submit target to the Sigil-owned API endpoint: `https://sigil.mmdbkk.com/sigil/api/private-model/apply`.
- Adds an explicit `POST` and `OPTIONS` handler for `/sigil/api/private-model/apply` in `sigil-worker` so valid form submissions do not fall through to Webflow or the auth-gated upstream worker.
- Adds CORS for `https://mmdbkk.com`, `https://www.mmdbkk.com`, and `https://sigil.mmdbkk.com`, preserving the page submit flow from both apex and www.
- Returns user-safe validation errors for missing/invalid fields.

## Root Cause Confirmed
- Current production `/sigil/apply` renders with `data-endpoint="https://mmdbkk.com/sigil/api/private-model/apply"`.
- Posting through `mmdbkk.com` or `www.mmdbkk.com` reaches `mmd-redirect-worker` and falls through to Webflow/OpenResty with `405 Not Allowed`.
- Posting directly to `https://sigil.mmdbkk.com/sigil/api/private-model/apply` reaches `sigil-worker`, but before this PR it fell through to the auth-gated upstream and returned `401 Unauthorized`.
- This PR fixes the owned Sigil endpoint and makes the page submit directly to it with CORS, avoiding a route-ownership change in `mmd-redirect-worker`.

## Submit Endpoint After This PR
- Page endpoint: `https://sigil.mmdbkk.com/sigil/api/private-model/apply`
- Worker handler: `POST /sigil/api/private-model/apply`
- Preflight handler: `OPTIONS /sigil/api/private-model/apply`

## Preserved Fields
- `nickname`
- `phone`
- `telegram_username`
- `line_id`
- `private_standard`
- `minimum_rate_thb`
- `private_note`
- `consent`
- honeypot `website`

## Scope Guardrails
- Changed files are limited to `sigil-worker/src/index.ts` and `sigil-worker/test/apply-page.test.mjs`.
- No `mmd-redirect-worker` route ownership changes.
- No Webflow publish.
- No payment, membership, webhook, admin auth, Black Card, points, or unrelated route-family changes.
- No production deploy.

## Tests
```bash
npm --prefix sigil-worker test
npm --prefix sigil-worker run typecheck
```

Both passed locally.

## Regression Coverage
- Valid POST submissions from `https://mmdbkk.com` and `https://www.mmdbkk.com` succeed.
- Invalid POST submission returns a clear user-safe `400` JSON error.
- `OPTIONS` preflight succeeds with the expected CORS headers.
- API tests assert no upstream fallback is called and no `x-mmd-sigil-upstream` header is present.
- Page test confirms the polished scoped apply package remains present and forbidden text stays absent: `Rollback:`, `Briefing HYPE TELEGRAMBOT`, `TELEGRAMBOT`, `CEO TELEGRAM BRIEF`.