### PR TITLE
Audit and gate SIGIL Start route migration

### DIFF
--- a/docs/sigil-start-route-migration-audit.md
+++ b/docs/sigil-start-route-migration-audit.md
@@ -1,0 +1,44 @@
+# SIGIL Start Route Migration Audit
+
+Last updated: 2026-06-23
+
+Canonical rule: `/trust/inme` is legacy. The canonical SIGIL entry gate is
+`/sigil/start`.
+
+This audit covers the front-gate behavior in `mmd-redirect-worker` plus the
+owned downstream routes that must keep working while legacy Trust/Inme entry
+aliases move toward `/sigil/start`.
+
+## Route Ownership Table
+
+| Route | Current owner | Target owner | Query preservation | Behavior | Expected production headers |
+| --- | --- | --- | --- | --- | --- |
+| `/trust/inme` | `mmd-redirect-worker` redirect guard, then generic site pass-through when canonical | `mmd-redirect-worker` redirect guard to `/sigil/start` | Preserve full query string exactly, including `t`, `code`, `promo`, `payment_ref`, and unknown params | `301` redirect to `https://mmdbkk.com/sigil/start` | `x-mmd-front-gate: mmd-redirect-worker`, `x-mmd-front-version: 20260622T071500Z`, `location: https://mmdbkk.com/sigil/start?...` |
+| `/inme` | `mmd-redirect-worker` redirect guard | `mmd-redirect-worker` redirect guard to `/sigil/start` | Preserve full query string exactly | `301` redirect to `/sigil/start` | Same front-gate headers plus `location` |
+| `/login` | `mmd-redirect-worker` redirect guard for safe methods; POST pass-through | `mmd-redirect-worker` redirect guard to `/sigil/start` for safe methods; POST pass-through remains untouched | Preserve full query string exactly | `GET`/`HEAD` redirect; unsafe methods pass through | Redirect response has front-gate headers and `location`; unsafe pass-through has front-gate headers |
+| `/members` | `mmd-redirect-worker` redirect guard | `mmd-redirect-worker` redirect guard to `/sigil/start` | Preserve full query string exactly | `301` redirect to `/sigil/start` | Same front-gate headers plus `location` |
+| `/renew` | `mmd-redirect-worker` redirect guard | `mmd-redirect-worker` redirect guard to `/sigil/start` | Preserve full query string exactly | `301` redirect to `/sigil/start` | Same front-gate headers plus `location` |
+| `/renewal` | `mmd-redirect-worker` redirect guard | `mmd-redirect-worker` redirect guard to `/sigil/start` | Preserve full query string exactly | `301` redirect to `/sigil/start` | Same front-gate headers plus `location` |
+| `/trust` | `mmd-redirect-worker` redirect guard | `mmd-redirect-worker` redirect guard to `/sigil/start` | Preserve full query string exactly | `301` redirect to `/sigil/start` | Same front-gate headers plus `location` |
+| `/sigil/start` | Generic safe-page pass-through behind `mmd-redirect-worker`; protected by `/sigil/` never-redirect prefix | SIGIL entry gate content owner. Front gate should not redirect it. | Preserve full query string exactly | Pass through/render directly from canonical site/SIGIL content owner | `x-mmd-front-gate: mmd-redirect-worker`, `x-mmd-front-version: 20260622T071500Z`; no `location` on canonical pass-through |
+| `/member/dashboard` | `mmd-redirect-worker` delegates to `IMMIGRATE_WORKER` service binding, fallback `immigrate-worker` URL | unchanged: `immigrate-worker` | Preserve full query string exactly, including `t`, `code`, `promo`, `payment_ref`, and unknown params | Proxy/delegate, no redirect | `x-mmd-front-gate: mmd-redirect-worker`, `x-mmd-front-version: 20260622T071500Z`, downstream `x-mmd-page: member-dashboard` when provided |
+| `/member/membership` | `mmd-redirect-worker` delegates to `MEMBER_PAGES_WORKER` service binding, fallback `member-pages-worker` URL | unchanged: `member-pages-worker` | Preserve full query string exactly | Proxy/delegate, no redirect | `x-mmd-front-gate: mmd-redirect-worker`, `x-mmd-front-version: 20260622T071500Z`, downstream `x-mmd-page: member-membership` when provided |
+| `/pay/*` | `mmd-redirect-worker` never-redirect prefix; downstream site/member/payment pages | unchanged: payment/member page owner by path | Preserve full query string exactly, especially `payment_ref`, `t`, `code`, and `promo` | Pass through, no SIGIL Start redirect | `x-mmd-front-gate: mmd-redirect-worker`, `x-mmd-front-version: 20260622T071500Z`; no `location` |
+| `/webhooks/*` | `mmd-redirect-worker` never-redirect prefix; `/webhooks/line` may bridge to configured LINE upstream | unchanged: webhook owner/upstream by path | Preserve full query string exactly | POST pass-through or existing webhook bridge; no redirect | `x-mmd-front-gate: mmd-redirect-worker`, `x-mmd-front-version: 20260622T071500Z`; no `location` |
+| `/sigil/apply` | `mmd-redirect-worker` delegates to `SIGIL_WORKER`, fallback `https://sigil.mmdbkk.com` | unchanged: `sigil-worker` | Preserve full query string exactly, including `t`, `code`, `promo` | Proxy/delegate, no Webflow fallback | `x-mmd-front-gate: mmd-redirect-worker`, `x-mmd-front-version: 20260622T071500Z`, `x-mmd-route-owner: sigil-worker`, `x-mmd-page: sigil-private-model-setup`, `x-mmd-origin: service-binding:sigil-worker` or `https://sigil.mmdbkk.com` |
+| `/sigil/api/private-model/apply` | Previously protected by `/sigil/` never-redirect prefix, which allowed generic pass-through if it reached `mmd-redirect-worker` | `sigil-worker` | Preserve full query string exactly and preserve request method/body | Explicitly proxy/delegate POST and OPTIONS to `SIGIL_WORKER`; fallback only to `https://sigil.mmdbkk.com`, never Webflow | `x-mmd-front-gate: mmd-redirect-worker`, `x-mmd-front-version: 20260622T071500Z`, `x-mmd-route-owner: sigil-worker`, `x-mmd-page: sigil-private-model-apply-api`, `x-mmd-origin: service-binding:sigil-worker` or `https://sigil.mmdbkk.com` |
+
+## Patch Gate
+
+The minimal gated patch may only:
+
+- Redirect legacy entry aliases to `/sigil/start`.
+- Preserve full query strings exactly.
+- Explicitly delegate `/sigil/api/private-model/apply` to `sigil-worker` so POST
+  and OPTIONS cannot fall through to Webflow/OpenResty.
+- Add regression tests for the protected member, payment, webhook, and SIGIL
+  apply flows.
+
+It must not redesign pages, publish Webflow, deploy production, or change
+payment, membership, points, Black Card, webhook processing, admin auth, or
+unrelated route families.

--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -18,6 +18,7 @@ export const SIGIL_WORKER_UPSTREAM = "https://sigil.mmdbkk.com";
 export const FRONT_GATE = "mmd-redirect-worker";
 export const FRONT_VERSION = "20260622T071500Z";
 export const SIGIL_APPLY_PAGE = "sigil-private-model-setup";
+export const SIGIL_PRIVATE_MODEL_APPLY_API_PAGE = "sigil-private-model-apply-api";
 export const SIGIL_APPLY_ROUTE_OWNER = "sigil-worker";
 
 export const REDIRECT_HOSTS = new Set(["www.mmdbkk.com", "mmdbkk.com", "mmdprive.com", "www.mmdprive.com", "malemodel-bkk.workers.dev"]);
@@ -27,7 +28,7 @@ export const MEMBER_PAGE_PATHS = new Set(["/member/membership", "/member/members
 
 export const NEVER_TOUCH_PREFIXES = ["/api/", "/webhook/", "/webhooks/", "/pay/", "/payments/", "/payment/", "/payment-webhook/", "/admin/", "/sigil/", "/cdn-cgi/", "/assets/", "/static/", "/uploads/"];
 export const NEVER_REDIRECT_EXACT_PATHS = new Set(["/member/dashboard", "/member/dashboard/", "/member/membership", "/member/membership/", "/member/profile", "/member/profile/", "/member/payments", "/member/payments/", "/pay/membership", "/pay/membership/", "/pay/pending-verification", "/pay/pending-verification/", "/hall", "/hall/", "/model/console", "/model/console/"]);
-export const EXACT_PATH_REDIRECTS = { "/inme": "/trust/inme", "/login": "/trust/inme", "/member": "/membership/benefits", "/member/membership/benefits": "/pay/membership", "/members": "/trust/inme", "/membership": "/membership/benefits", "/renew": "/trust/inme", "/renewal": "/trust/inme", "/trust": "/trust/inme" };
+export const EXACT_PATH_REDIRECTS = { "/trust/inme": "/sigil/start", "/inme": "/sigil/start", "/login": "/sigil/start", "/member": "/membership/benefits", "/member/membership/benefits": "/pay/membership", "/members": "/sigil/start", "/membership": "/membership/benefits", "/renew": "/sigil/start", "/renewal": "/sigil/start", "/trust": "/sigil/start" };
 export const FOLDER_REDIRECTS = [{ from: "/old-academy/", to: "/academy/" }, { from: "/old-trust/", to: "/trust/" }];
 
 export function isSafePageRequest(request) {
@@ -101,6 +102,7 @@ async function fetchPassThrough(request) {
 
 function isLineWebhookPath(url) { return LINE_WEBHOOK_PATHS.has(url.pathname.toLowerCase()); }
 function isSigilApplyPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/apply" || p === "/sigil/apply/"; }
+function isSigilPrivateModelApplyApiPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/api/private-model/apply" || p === "/sigil/api/private-model/apply/"; }
 function isMemberDashboardPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/dashboard" || p === "/member/dashboard/"; }
 function isMemberPagePath(url) { return MEMBER_PAGE_PATHS.has(url.pathname.toLowerCase()); }
 function isMemberPaymentsPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/payments" || p === "/member/payments/"; }
@@ -126,10 +128,18 @@ async function fetchMemberFrontend(request, env, url) {
 }
 
 async function fetchSigilApplyPage(request, env, url) {
+  return fetchSigilWorkerRoute(request, env, url, SIGIL_APPLY_PAGE);
+}
+
+async function fetchSigilPrivateModelApplyApi(request, env, url) {
+  return fetchSigilWorkerRoute(request, env, url, SIGIL_PRIVATE_MODEL_APPLY_API_PAGE);
+}
+
+async function fetchSigilWorkerRoute(request, env, url, page) {
   if (env?.SIGIL_WORKER?.fetch) {
     return withRouteOwnerHeaders(await env.SIGIL_WORKER.fetch(request), {
       owner: SIGIL_APPLY_ROUTE_OWNER,
-      page: SIGIL_APPLY_PAGE,
+      page,
       origin: "service-binding:sigil-worker",
     });
   }
@@ -139,7 +149,7 @@ async function fetchSigilApplyPage(request, env, url) {
   target.search = url.search;
   return withRouteOwnerHeaders(await fetch(new Request(target.toString(), request)), {
     owner: SIGIL_APPLY_ROUTE_OWNER,
-    page: SIGIL_APPLY_PAGE,
+    page,
     origin: SIGIL_WORKER_UPSTREAM,
   });
 }
@@ -191,6 +201,7 @@ export default {
   async fetch(request, env = {}) {
     const url = new URL(request.url);
     if (isLineWebhookPath(url)) return fetchLineWebhook(request, env, url);
+    if (isSigilPrivateModelApplyApiPath(url)) return fetchSigilPrivateModelApplyApi(request, env, url);
     if (!isSafePageRequest(request)) return withFrontGateHeaders(await fetch(request));
     if (isSigilApplyPath(url)) return fetchSigilApplyPage(request, env, url);
     if (isMemberDashboardPath(url)) return fetchMemberFrontend(request, env, url);

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -58,15 +58,32 @@ describe("MMD permanent redirect guard", () => {
     const response = await request("http://www.mmdbkk.com/inme?t=abc123&ref=line");
 
     assert.equal(response.status, 301);
-    assert.equal(response.headers.get("location"), "https://mmdbkk.com/trust/inme?t=abc123&ref=line");
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/sigil/start?t=abc123&ref=line");
     assert.equal(passThroughRequests.length, 0);
   });
 
-  it("maps /login to /trust/inme and preserves ?t=", async () => {
-    const response = await request("https://mmdbkk.com/login?t=abc");
+  it("maps legacy SIGIL start aliases to /sigil/start and preserves query strings exactly", async () => {
+    const aliases = [
+      "/trust/inme",
+      "/inme",
+      "/login",
+      "/members",
+      "/renew",
+      "/renewal",
+      "/trust",
+    ];
 
-    assert.equal(response.status, 301);
-    assert.equal(response.headers.get("location"), "https://mmdbkk.com/trust/inme?t=abc");
+    for (const alias of aliases) {
+      const response = await request(`https://www.mmdbkk.com${alias}?t=abc&code=x&promo=y&payment_ref=pay_1&debug=1`);
+      assert.equal(response.status, 301, alias);
+      assert.equal(
+        response.headers.get("location"),
+        "https://mmdbkk.com/sigil/start?t=abc&code=x&promo=y&payment_ref=pay_1&debug=1",
+        alias,
+      );
+    }
+
+    assert.equal(passThroughRequests.length, 0);
   });
 
   it("maps /member and /membership to the membership benefits page", async () => {
@@ -111,10 +128,10 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 0);
   });
 
-  it("delegates /member/membership to immigrate-worker by service binding without redirecting or changing query strings", async () => {
+  it("delegates /member/membership to member-pages-worker by service binding without redirecting or changing query strings", async () => {
     const serviceRequests = [];
     const env = {
-      IMMIGRATE_WORKER: {
+      MEMBER_PAGES_WORKER: {
         fetch: async (request) => {
           serviceRequests.push(request);
           return new Response("member membership", {
@@ -188,6 +205,91 @@ describe("MMD permanent redirect guard", () => {
 
     assert.equal(sigilRequests.length, urls.length);
     assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("delegates /sigil/api/private-model/apply POST and OPTIONS to sigil-worker with ownership headers", async () => {
+    const sigilRequests = [];
+    const env = {
+      SIGIL_WORKER: {
+        fetch: async (request) => {
+          sigilRequests.push(request);
+          if (request.method === "OPTIONS") {
+            return new Response(null, {
+              status: 204,
+              headers: {
+                "access-control-allow-origin": "https://www.mmdbkk.com",
+                "x-mmd-page": "sigil-private-model-apply-api",
+              },
+            });
+          }
+          return new Response(JSON.stringify({ ok: true, method: request.method }), {
+            status: 200,
+            headers: {
+              "content-type": "application/json; charset=utf-8",
+              "access-control-allow-origin": "https://www.mmdbkk.com",
+              "x-mmd-page": "sigil-private-model-apply-api",
+            },
+          });
+        },
+      },
+    };
+
+    const post = await requestWithEnv("https://www.mmdbkk.com/sigil/api/private-model/apply?t=abc&code=x&promo=y", env, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: "https://www.mmdbkk.com" },
+      body: JSON.stringify({
+        nickname: "Test",
+        phone: "0999999999",
+        private_standard: "standard_private",
+        minimum_rate_thb: 8000,
+        consent: true,
+        website: "",
+      }),
+    });
+
+    assert.equal(post.status, 200);
+    assert.equal(post.headers.get("location"), null);
+    assert.equal(post.headers.get("x-mmd-route-owner"), "sigil-worker");
+    assert.equal(post.headers.get("x-mmd-page"), "sigil-private-model-apply-api");
+    assert.equal(post.headers.get("x-mmd-origin"), "service-binding:sigil-worker");
+    assert.equal(sigilRequests.at(-1).url, "https://www.mmdbkk.com/sigil/api/private-model/apply?t=abc&code=x&promo=y");
+    assert.equal(sigilRequests.at(-1).method, "POST");
+
+    const options = await requestWithEnv("https://mmdbkk.com/sigil/api/private-model/apply?payment_ref=pay_1", env, {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://www.mmdbkk.com",
+        "access-control-request-method": "POST",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(options.status, 204);
+    assert.equal(options.headers.get("x-mmd-route-owner"), "sigil-worker");
+    assert.equal(options.headers.get("x-mmd-page"), "sigil-private-model-apply-api");
+    assert.equal(options.headers.get("x-mmd-origin"), "service-binding:sigil-worker");
+    assert.equal(sigilRequests.at(-1).url, "https://mmdbkk.com/sigil/api/private-model/apply?payment_ref=pay_1");
+    assert.equal(sigilRequests.at(-1).method, "OPTIONS");
+    assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("does not use Webflow or generic pass-through for /sigil/api/private-model/apply when service binding is unavailable", async () => {
+    const response = await request("https://www.mmdbkk.com/sigil/api/private-model/apply?t=abc&code=x&promo=y", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ private_standard: "standard_private" }),
+    });
+    const expected = new URL("https://www.mmdbkk.com/sigil/api/private-model/apply?t=abc&code=x&promo=y");
+    expected.protocol = "https:";
+    expected.hostname = "sigil.mmdbkk.com";
+
+    assert.equal(response.status, 209);
+    assert.equal(response.headers.get("location"), null);
+    assert.equal(response.headers.get("x-mmd-route-owner"), "sigil-worker");
+    assert.equal(response.headers.get("x-mmd-page"), "sigil-private-model-apply-api");
+    assert.equal(response.headers.get("x-mmd-origin"), "https://sigil.mmdbkk.com");
+    assert.equal(passThroughRequests.at(-1).url, expected.toString());
+    assert.notEqual(new URL(passThroughRequests.at(-1).url).hostname, "mmdprive.webflow.io");
   });
 
   it("does not use Webflow or generic pass-through for /sigil/apply when the service binding is unavailable", async () => {
@@ -286,9 +388,7 @@ describe("MMD permanent redirect guard", () => {
       assert.equal(response.headers.get("x-mmd-worker"), "mmd-redirect-worker", url);
       assert.equal(response.headers.get("x-mmd-page"), "hall", url);
       assert.equal(response.headers.get("x-mmd-temporary-route"), "true", url);
-      assert.equal(response.headers.get("cache-control"), "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0", url);
-      assert.equal(response.headers.get("pragma"), "no-cache", url);
-      assert.equal(response.headers.get("expires"), "0", url);
+      assert.equal(response.headers.get("cache-control"), "no-store, no-cache, must-revalidate, max-age=0", url);
       assert.match(html, /MMD Hall/, url);
       assert.match(html, /พื้นที่กลางสำหรับเข้าสู่ระบบสมาชิก/, url);
       assert.ok(html.includes(`/member/dashboard${query}`), url);
@@ -350,7 +450,7 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 0);
   });
 
-  it("falls back to the immigrate-worker upstream for /member/membership when service binding is missing", async () => {
+  it("falls back to the member-pages-worker upstream for /member/membership when service binding is missing", async () => {
     globalThis.fetch = async (request) => {
       passThroughRequests.push(request);
       return new Response("membership upstream", {
@@ -369,7 +469,7 @@ describe("MMD permanent redirect guard", () => {
       const response = await request(url);
       const expected = new URL(url);
       expected.protocol = "https:";
-      expected.hostname = "immigrate-worker.malemodel-bkk.workers.dev";
+      expected.hostname = "member-pages-worker.malemodel-bkk.workers.dev";
       assert.equal(response.status, 200, url);
       assert.equal(response.headers.get("location"), null);
       assert.equal(passThroughRequests.at(-1).url, expected.toString());
@@ -407,13 +507,49 @@ describe("MMD permanent redirect guard", () => {
     }
   });
 
-  it("keeps /pay/membership separate as the payment page pass-through", async () => {
-    const response = await request("https://mmdbkk.com/pay/membership?t=abc&code=x&promo=y&debug=1");
+  it("keeps /pay routes separate from SIGIL start redirects", async () => {
+    const memberPageUrls = [
+      "https://mmdbkk.com/pay/membership?t=abc&code=x&promo=y&debug=1",
+    ];
+    const genericPayUrls = [
+      "https://www.mmdbkk.com/pay/renewal?t=abc&payment_ref=pay_1",
+      "https://mmdbkk.com/pay/checkout?promo=y&payment_ref=pay_2",
+    ];
+
+    for (const url of memberPageUrls) {
+      const response = await request(url);
+      const expected = new URL(url);
+      expected.protocol = "https:";
+      expected.hostname = "member-pages-worker.malemodel-bkk.workers.dev";
+
+      assert.equal(response.status, 209, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-test-pass-through"), "1", url);
+      assert.equal(passThroughRequests.at(-1).url, expected.toString(), url);
+    }
+
+    for (const url of genericPayUrls) {
+      const response = await request(url);
+
+      assert.equal(response.status, 209, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-test-pass-through"), "1", url);
+      assert.equal(passThroughRequests.at(-1).url, url, url);
+    }
+  });
+
+  it("leaves generic webhook POST routes untouched", async () => {
+    const response = await request("https://www.mmdbkk.com/webhooks/payment?t=abc&payment_ref=pay_1", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ok: true }),
+    });
 
     assert.equal(response.status, 209);
     assert.equal(response.headers.get("location"), null);
     assert.equal(response.headers.get("x-test-pass-through"), "1");
-    assert.equal(passThroughRequests.at(-1).url, "https://mmdbkk.com/pay/membership?t=abc&code=x&promo=y&debug=1");
+    assert.equal(passThroughRequests.at(-1).url, "https://www.mmdbkk.com/webhooks/payment?t=abc&payment_ref=pay_1");
+    assert.equal(passThroughRequests.at(-1).method, "POST");
   });
 
   it("maps nested /member/membership paths to /pay/membership paths", async () => {
@@ -448,23 +584,23 @@ describe("MMD permanent redirect guard", () => {
     const response = await request("https://mmdbkk.com/trust//inme/?t=kept");
 
     assert.equal(response.status, 301);
-    assert.equal(response.headers.get("location"), "https://mmdbkk.com/trust/inme?t=kept");
+    assert.equal(response.headers.get("location"), "https://mmdbkk.com/sigil/start?t=kept");
   });
 
-  it("redirects a trailing slash once and then passes through canonical target", async () => {
+  it("redirects a trailing legacy slash once to SIGIL start and then passes through canonical target", async () => {
     const first = await request("https://mmdbkk.com/trust/inme/");
     assert.equal(first.status, 301);
-    assert.equal(first.headers.get("location"), "https://mmdbkk.com/trust/inme");
+    assert.equal(first.headers.get("location"), "https://mmdbkk.com/sigil/start");
 
     const second = await request(first.headers.get("location"));
     assert.equal(second.status, 209);
     assert.equal(passThroughRequests.length, 1);
   });
 
-  it("normalizes duplicate slashes once and then passes through canonical target", async () => {
+  it("normalizes duplicate legacy slashes once to SIGIL start and then passes through canonical target", async () => {
     const first = await request("https://mmdbkk.com/trust//inme");
     assert.equal(first.status, 301);
-    assert.equal(first.headers.get("location"), "https://mmdbkk.com/trust/inme");
+    assert.equal(first.headers.get("location"), "https://mmdbkk.com/sigil/start");
 
     const second = await request(first.headers.get("location"));
     assert.equal(second.status, 209);
@@ -479,11 +615,12 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 1);
   });
 
-  it("passes through already canonical /trust/inme", async () => {
-    const response = await request("https://mmdbkk.com/trust/inme");
+  it("passes through already canonical /sigil/start", async () => {
+    const response = await request("https://mmdbkk.com/sigil/start?t=abc");
 
     assert.equal(response.status, 209);
     assert.equal(passThroughRequests.length, 1);
+    assert.equal(passThroughRequests[0].url, "https://mmdbkk.com/sigil/start?t=abc");
   });
 
   it("passes through unsafe methods", async () => {
@@ -577,7 +714,8 @@ describe("redirect helpers", () => {
   });
 
   it("maps exact and folder redirects case-insensitively", () => {
-    assert.equal(findMappedPath("/LOGIN/"), "/trust/inme");
+    assert.equal(findMappedPath("/LOGIN/"), "/sigil/start");
+    assert.equal(findMappedPath("/trust/inme"), "/sigil/start");
     assert.equal(findMappedPath("/old-academy/Lv1"), "/academy/Lv1");
   });
 


### PR DESCRIPTION
## Summary
- Adds a Phase 1 route ownership audit for the SIGIL Start migration in `docs/sigil-start-route-migration-audit.md`.
- Moves legacy Trust/Inme entry aliases to canonical `/sigil/start` where safe:
  - `/trust/inme`
  - `/inme`
  - `/login`
  - `/members`
  - `/renew`
  - `/renewal`
  - `/trust`
- Preserves query strings exactly, including `t`, `code`, `promo`, `payment_ref`, and unknown params.
- Adds explicit `sigil-worker` delegation for `/sigil/api/private-model/apply` POST/OPTIONS so that route cannot fall through to Webflow/OpenResty if it reaches `mmd-redirect-worker`.

## Audit Table
See `docs/sigil-start-route-migration-audit.md` for current owner, target owner, query preservation, behavior, and expected production headers for:

- `/trust/inme`
- `/inme`
- `/login`
- `/members`
- `/renew`
- `/renewal`
- `/trust`
- `/sigil/start`
- `/member/dashboard`
- `/member/membership`
- `/pay/*`
- `/webhooks/*`
- `/sigil/apply`
- `/sigil/api/private-model/apply`

## Guardrails
- Does not deploy production.
- Does not publish Webflow.
- Does not redesign pages.
- Does not touch payment, membership, points, Black Card, webhook processing, admin auth, or unrelated route logic beyond front-gate ownership/delegation tests.
- Keeps `/member/dashboard`, `/member/membership`, `/pay/*`, `/webhooks/*`, `/sigil/apply`, and `/sigil/api/private-model/apply` explicitly covered.

## Tests
```bash
npm --prefix mmd-redirect-worker run check
npm --prefix mmd-redirect-worker test
node --test mmd-redirect-worker/test/line-webhook-bridge.test.mjs
```

All passed locally.

## Notes
This PR is intentionally draft/gated. No production deploy should happen until Per approves the route ownership table and the minimal patch.