### PR TITLE
Own Trust/Inme routes in redirect worker

### DIFF
--- a/docs/sigil-start-route-migration-audit.md
+++ b/docs/sigil-start-route-migration-audit.md
@@ -42,3 +42,27 @@ The minimal gated patch may only:
 It must not redesign pages, publish Webflow, deploy production, or change
 payment, membership, points, Black Card, webhook processing, admin auth, or
 unrelated route families.
+
+## `/trust/inme*` Worker Route Ownership Correction
+
+Production investigation after the initial SIGIL Start migration found that
+`/trust/inme` was still intercepted before `mmd-redirect-worker` by more
+specific Cloudflare Worker routes:
+
+| Production route | Previous production owner | Correct owner |
+| --- | --- | --- |
+| `mmdbkk.com/trust/inme*` | `member-dashboard-chat-worker` | `mmd-redirect-worker` |
+| `www.mmdbkk.com/trust/inme*` | `member-dashboard-chat-worker` | `mmd-redirect-worker` |
+
+`mmd-redirect-worker/wrangler.toml` now declares both explicit route patterns
+so the canonical redirect logic in `mmd-redirect-worker/src/index.js` can own:
+
+`/trust/inme?t=...` -> `/sigil/start?t=...`
+
+The full query string must remain preserved exactly.
+
+The current `main` branch used for this PR does not contain a tracked
+`member-dashboard-chat-worker/wrangler.toml`, so this PR cannot remove those
+older declarations from that worker's config. Future changes to
+`member-dashboard-chat-worker` must not reintroduce ownership of
+`mmdbkk.com/trust/inme*` or `www.mmdbkk.com/trust/inme*`.

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { afterEach, beforeEach, describe, it } from "node:test";
 
 import worker, {
@@ -45,6 +46,7 @@ const VISIBLE_DEBUG_TEXT = [
 ];
 
 const TELEGRAM_BRIEF_FORBIDDEN_TEXT = /Briefing HYPE TELEGRAMBOT|TELEGRAMBOT|CEO TELEGRAM BRIEF/i;
+const wranglerConfig = readFileSync(new URL("../wrangler.toml", import.meta.url), "utf8");
 
 function assertPolishedShell(html, url) {
   assert.doesNotMatch(html, /name=["']token["']/i, url);
@@ -54,6 +56,11 @@ function assertPolishedShell(html, url) {
 }
 
 describe("MMD permanent redirect guard", () => {
+  it("declares explicit /trust/inme route ownership for mmd-redirect-worker", () => {
+    assert.ok(wranglerConfig.includes('pattern = "mmdbkk.com/trust/inme*"'));
+    assert.ok(wranglerConfig.includes('pattern = "www.mmdbkk.com/trust/inme*"'));
+  });
+
   it("canonicalizes www legacy paths and preserves query strings", async () => {
     const response = await request("http://www.mmdbkk.com/inme?t=abc123&ref=line");
 

--- a/mmd-redirect-worker/wrangler.toml
+++ b/mmd-redirect-worker/wrangler.toml
@@ -20,6 +20,14 @@ binding = "SIGIL_WORKER"
 service = "sigil-worker"
 
 [[routes]]
+pattern = "mmdbkk.com/trust/inme*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/trust/inme*"
+zone_name = "mmdbkk.com"
+
+[[routes]]
 pattern = "mmdbkk.com/*"
 zone_name = "mmdbkk.com"
 


### PR DESCRIPTION
## Summary
- Adds explicit `mmd-redirect-worker` Cloudflare routes for:
  - `mmdbkk.com/trust/inme*`
  - `www.mmdbkk.com/trust/inme*`
- Adds a config regression test proving those route patterns are declared in `mmd-redirect-worker/wrangler.toml`.
- Documents the production route ownership correction in `docs/sigil-start-route-migration-audit.md`.

## Root Cause
`/trust/inme` is intercepted before `mmd-redirect-worker` because these more-specific Cloudflare Worker routes currently point to `member-dashboard-chat-worker`:

```text
www.mmdbkk.com/trust/inme* -> member-dashboard-chat-worker
mmdbkk.com/trust/inme*     -> member-dashboard-chat-worker
```

Observed production route IDs:

```text
www.mmdbkk.com/trust/inme*: 4ed3a4273b0043aa80645f518240e039
mmdbkk.com/trust/inme*:     2a17886e4a5c4515a413ec9603c5cfb8
```

Current production symptom:

```text
/trust/inme -> 302 https://mmdbkk.com/sigil/pay/renewal?...
No x-mmd-front-gate header
```

## Desired Behavior

```text
/trust/inme?t=... -> /sigil/start?t=...
```

Full query string preservation must include `t`, `code`, `promo`, `payment_ref`, and unknown params.

## member-dashboard-chat-worker Config Note
The current `main` branch used for this PR does not contain a tracked `member-dashboard-chat-worker/wrangler.toml`, so this PR cannot remove those older declarations from that worker config. The production route ownership fix is to have `mmd-redirect-worker` claim the same specific route patterns. Future changes to `member-dashboard-chat-worker` must not reintroduce ownership of `mmdbkk.com/trust/inme*` or `www.mmdbkk.com/trust/inme*`.

## Scope Guardrails
- Route config only, plus docs/tests.
- No Webflow publish.
- No deploy.
- No `sigil-worker` changes.
- No payment logic, membership logic, points logic, Black Card logic, webhook processing changes, or admin auth changes.
- No redirect logic change in `mmd-redirect-worker/src/index.js`; PR #92 already contains `/trust/inme -> /sigil/start`.

## Tests
```bash
npm --prefix mmd-redirect-worker run check
npm --prefix mmd-redirect-worker test
node --test mmd-redirect-worker/test/line-webhook-bridge.test.mjs
```

All passed locally.