### PR TITLE
Fix SIGIL membership canonical page owner

### DIFF
--- a/docs/sigil-start-route-migration-audit.md
+++ b/docs/sigil-start-route-migration-audit.md
@@ -159,3 +159,44 @@ Deployment guardrails honored:
 - No membership rendering logic changes.
 - No points, Black Card, webhook processing, admin auth, or unrelated logic
   changes.
+
+## PR #96 SIGIL Membership Canonical Page Owner Audit
+
+Live audit after PR #93, PR #94, and PR #95 found one remaining identity issue:
+
+```text
+/renew -> /sigil/membership
+/renewal -> /sigil/membership
+/sigil/membership -> 404 Kontrix - Not Found / Thai 401-style access heading
+```
+
+The redirect mapping is correct and must not be reverted to `/sigil/start`.
+The missing piece is a valid page owner/render path for `/sigil/membership`.
+
+Owner audit:
+
+| Question | Finding |
+| --- | --- |
+| Does `member-pages-worker` already support `/sigil/membership`? | No. Before PR #96, `member-pages-worker` only recognized `/member/membership`, `/pay/membership`, `/pay/pending-verification`, and `/member/profile`. |
+| Does `mmd-redirect-worker` pass `/sigil/membership` through to origin because `/sigil/*` is in `NEVER_TOUCH_PREFIXES`? | Yes. Before PR #96, `/sigil/membership` had no explicit handler, so it reached generic `/sigil/` never-touch pass-through. |
+| Is Webflow/origin returning Kontrix 404 for `/sigil/membership`? | Yes. Live GET/HEAD audit showed `HTTP 404`, title `Kontrix - Not Found`, and a Thai 401-style heading when the route passed through. |
+| Which worker should own the rendered page? | `member-pages-worker` should own the content for the renewal/access conditions page. `mmd-redirect-worker` remains the front route/proxy owner. |
+
+Target ownership:
+
+| Route | Front route/proxy owner | Content owner | Page identity | Behavior |
+| --- | --- | --- | --- | --- |
+| `/sigil/membership` | `mmd-redirect-worker` | `member-pages-worker` | `x-mmd-page: sigil-membership` | Delegate/proxy before generic `/sigil/*` pass-through; return `200` content, not origin 404. |
+| `/sigil/membership/` | `mmd-redirect-worker` | `member-pages-worker` | `x-mmd-page: sigil-membership` | Same as non-slash variant, preserving query string. |
+
+Page content policy:
+
+- Thai primary copy with concise English labels where useful.
+- Renewal/access conditions page, not checkout.
+- Trial, Standard, and Premium are the only customer-facing sold packages if
+  package context appears.
+- VIP and SVIP must not appear as customer-facing purchase/upgrade options.
+- Payment slip/proof must not imply membership confirmation.
+- Confirmation happens only after official verification.
+- Black Card may be described only as private consideration/review, not
+  automatic approval.

--- a/member-pages-worker/src/index.js
+++ b/member-pages-worker/src/index.js
@@ -2,6 +2,7 @@ const WORKER = "member-pages-worker";
 const VERSION = "20260622-payment-first-profile-flow";
 
 const PAGE_PATHS = new Set([
+  "/sigil/membership", "/sigil/membership/",
   "/member/membership", "/member/membership/",
   "/pay/membership", "/pay/membership/",
   "/pay/pending-verification", "/pay/pending-verification/",
@@ -31,6 +32,7 @@ export default {
     if (method !== "GET" && method !== "HEAD") return new Response("Method Not Allowed", { status: 405, headers: headers("text/plain; charset=utf-8") });
     if (!isMemberPagePath(url)) return new Response("Not Found", { status: 404, headers: headers("text/plain; charset=utf-8") });
     const p = url.pathname.toLowerCase().replace(/\/+$/, "") || "/";
+    if (p === "/sigil/membership") return renderSigilMembership(request);
     if (p === "/pay/membership") return renderPay(request, env);
     if (p === "/pay/pending-verification") return renderPending(request);
     if (p === "/member/profile") return renderProfile(request);
@@ -47,6 +49,16 @@ export function renderMembership(request) {
     <section class="hero"><div class="panel"><p class="eyebrow">Member-facing Package Selection</p><h1>Membership</h1><p>เลือก Trial, Standard หรือ Premium แล้วไปต่อที่หน้าโอนเงินก่อน ระบบจะตรวจสอบยอดจริงก่อนเปิดสถานะสมาชิกและ points เสมอ</p><p class="actions"><a class="btn" href="${attr(appendQuery("/pay/membership", url.search, plan ? { plan } : {}))}">Continue to Payment</a><a class="btn ghost" href="${attr(appendQuery("/member/dashboard", url.search))}">Member Dashboard</a></p></div>${doctrine()}</section>
     <section class="grid">${cards}</section>
     <section class="panel black"><p class="eyebrow">BLACK CARD NOTE</p><h2>ไม่ใช่แพ็กเกจที่กดซื้อ</h2><p>350 points คือ Black Card review eligible เท่านั้น ไม่ใช่ auto approved และไม่ใช่ทางลัดจากการส่งสลิป</p></section>
+  `);
+}
+
+export function renderSigilMembership(request) {
+  const url = new URL(request.url);
+  const packages = PACKAGES.map((pkg) => `<article class="pkg"><p class="eyebrow">${html(pkg.eyebrow)}</p><h2>${html(pkg.title)}</h2><p>${html(pkg.copy)}</p></article>`).join("");
+  return page(request, "sigil-membership", `
+    ${nav(url.search)}
+    <section class="hero"><div class="panel"><p class="eyebrow">SIGIL ACCESS CONDITIONS</p><h1>Renewal / Access Conditions</h1><p>หน้านี้คือเงื่อนไขการต่ออายุและการเข้าถึง ไม่ใช่หน้า checkout และไม่ใช่การยืนยันสถานะสมาชิกทันที</p><p>หากมีการชำระเงินหรือส่งหลักฐาน ระบบจะถือเป็นข้อมูลรอตรวจสอบเท่านั้น การยืนยันสมาชิกเกิดขึ้นหลัง official verification ครบถ้วนเท่านั้น</p><p class="actions"><a class="btn" href="${attr(appendQuery("/member/membership", url.search))}">ดูแพ็กเกจสมาชิก</a><a class="btn ghost" href="${attr(appendQuery("/member/dashboard", url.search))}">Member Dashboard</a></p></div><aside class="panel side"><h2>Access rule</h2><p>สถานะจริงอ้างอิงจากข้อมูลที่ตรวจสอบแล้วเท่านั้น ไม่ใช่จากสลิป ข้อความ หรือการกรอกฟอร์มเพียงอย่างเดียว</p><p>Black Card เป็น private consideration/review ไม่ใช่ automatic approval และไม่ใช่แพ็กเกจที่กดซื้อเอง</p></aside></section>
+    <section class="grid">${packages}</section>
   `);
 }
 
@@ -98,7 +110,7 @@ function doctrine() {
 
 function page(request, slug, body) {
   const output = `<!doctype html><html lang="th"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>MMD Privé | ${html(slug)}</title><style>${styles()}</style></head><body><main data-mmd-page="${attr(slug)}" data-mmd-version="${VERSION}">${body}<footer>Payment page accepts proof. Verification gate confirms money. Airtable records truth. Member Profile displays verified truth only.</footer></main></body></html>`;
-  return new Response(request.method.toUpperCase() === "HEAD" ? null : output, { status: 200, headers: { ...headers("text/html; charset=utf-8"), "cache-control": "no-store, no-cache, must-revalidate, max-age=0" } });
+  return new Response(request.method.toUpperCase() === "HEAD" ? null : output, { status: 200, headers: { ...headers("text/html; charset=utf-8"), "x-mmd-page": slug, "cache-control": "no-store, no-cache, must-revalidate, max-age=0" } });
 }
 
 function headers(type) {

--- a/member-pages-worker/test/membership.test.mjs
+++ b/member-pages-worker/test/membership.test.mjs
@@ -16,15 +16,46 @@ describe("member-pages-worker membership page", () => {
     assert.equal(response.headers.get("x-mmd-worker"), "member-pages-worker");
     assert.equal(response.headers.get("x-mmd-page"), "member-membership");
     assert.match(html, /Membership/);
+    assert.match(html, /Trial/);
     assert.match(html, /Standard/);
     assert.match(html, /Premium/);
-    assert.match(html, /VIP/);
     assert.match(html, /BLACK CARD NOTE/);
-    assert.match(html, /ไม่ใช่ซื้อ แต่ถูกพิจารณา/);
+    assert.match(html, /ไม่ใช่แพ็กเกจที่กดซื้อ/);
+    assert.doesNotMatch(html, /VIP/i);
     assert.doesNotMatch(html, /SVIP/i);
     assert.doesNotMatch(html, /name=["']token["']/i);
     assert.ok(html.includes("/pay/membership?t=abc&amp;code=x&amp;promo=y"));
     assert.ok(html.includes("/member/dashboard?t=abc&amp;code=x&amp;promo=y"));
+  });
+
+  it("renders SIGIL membership renewal/access conditions without checkout claims", async () => {
+    const response = await request("https://mmdbkk.com/sigil/membership?t=abc&code=x&promo=y&payment_ref=pay123&session_id=sess123");
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-mmd-worker"), "member-pages-worker");
+    assert.equal(response.headers.get("x-mmd-page"), "sigil-membership");
+    assert.match(html, /Renewal \/ Access Conditions/);
+    assert.match(html, /ไม่ใช่หน้า checkout/);
+    assert.match(html, /official verification/);
+    assert.match(html, /Trial/);
+    assert.match(html, /Standard/);
+    assert.match(html, /Premium/);
+    assert.match(html, /private consideration\/review/);
+    assert.doesNotMatch(html, /SVIP/i);
+    assert.doesNotMatch(html, /VIP/i);
+    assert.ok(html.includes("/member/membership?t=abc&amp;code=x&amp;promo=y&amp;payment_ref=pay123&amp;session_id=sess123"));
+    assert.ok(html.includes("/member/dashboard?t=abc&amp;code=x&amp;promo=y&amp;payment_ref=pay123&amp;session_id=sess123"));
+  });
+
+  it("returns no body for SIGIL membership HEAD while keeping ownership headers", async () => {
+    const response = await request("https://mmdbkk.com/sigil/membership/?t=abc", { method: "HEAD" });
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(body, "");
+    assert.equal(response.headers.get("x-mmd-worker"), "member-pages-worker");
+    assert.equal(response.headers.get("x-mmd-page"), "sigil-membership");
   });
 
   it("returns no body for HEAD while keeping ownership headers", async () => {

--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -102,6 +102,7 @@ async function fetchPassThrough(request) {
 
 function isLineWebhookPath(url) { return LINE_WEBHOOK_PATHS.has(url.pathname.toLowerCase()); }
 function isSigilApplyPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/apply" || p === "/sigil/apply/"; }
+function isSigilMembershipPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/membership" || p === "/sigil/membership/"; }
 function isSigilPrivateModelApplyApiPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/api/private-model/apply" || p === "/sigil/api/private-model/apply/"; }
 function isMemberDashboardPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/dashboard" || p === "/member/dashboard/"; }
 function isMemberPagePath(url) { return MEMBER_PAGE_PATHS.has(url.pathname.toLowerCase()); }
@@ -204,6 +205,7 @@ export default {
     if (isSigilPrivateModelApplyApiPath(url)) return fetchSigilPrivateModelApplyApi(request, env, url);
     if (!isSafePageRequest(request)) return withFrontGateHeaders(await fetch(request));
     if (isSigilApplyPath(url)) return fetchSigilApplyPage(request, env, url);
+    if (isSigilMembershipPath(url)) return fetchMemberPage(request, env, url);
     if (isMemberDashboardPath(url)) return fetchMemberFrontend(request, env, url);
     if (isMemberPagePath(url)) return fetchMemberPage(request, env, url);
     if (isMemberPaymentsPath(url)) return fetchAdminMemberPage(request, env, url);

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -207,6 +207,80 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 0);
   });
 
+  it("delegates /sigil/membership to member-pages-worker before generic SIGIL pass-through", async () => {
+    const serviceRequests = [];
+    const env = {
+      MEMBER_PAGES_WORKER: {
+        fetch: async (request) => {
+          serviceRequests.push(request);
+          return new Response("<main>Renewal / Access Conditions official verification</main>", {
+            status: 200,
+            headers: { "content-type": "text/html; charset=utf-8", "x-mmd-worker": "member-pages-worker", "x-mmd-page": "sigil-membership" },
+          });
+        },
+      },
+    };
+
+    for (const url of [
+      `https://mmdbkk.com/sigil/membership?${PRESERVED_QUERY}`,
+      `https://www.mmdbkk.com/sigil/membership/?${PRESERVED_QUERY}`,
+    ]) {
+      const response = await requestWithEnv(url, env);
+      const html = await response.text();
+
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.equal(response.headers.get("x-mmd-front-gate"), "mmd-redirect-worker", url);
+      assert.equal(response.headers.get("x-mmd-page"), "sigil-membership", url);
+      assert.equal(response.headers.get("x-mmd-worker"), "member-pages-worker", url);
+      assert.match(html, /Renewal \/ Access Conditions/, url);
+      assert.equal(serviceRequests.at(-1).url, url);
+    }
+
+    assert.equal(serviceRequests.length, 2);
+    assert.equal(passThroughRequests.length, 0);
+  });
+
+  it("falls back to member-pages-worker upstream for /sigil/membership without Webflow pass-through", async () => {
+    const response = await request(`https://www.mmdbkk.com/sigil/membership?${PRESERVED_QUERY}`);
+    const expected = new URL(`https://www.mmdbkk.com/sigil/membership?${PRESERVED_QUERY}`);
+    expected.protocol = "https:";
+    expected.hostname = "member-pages-worker.malemodel-bkk.workers.dev";
+
+    assert.equal(response.status, 209);
+    assert.equal(response.headers.get("location"), null);
+    assert.equal(response.headers.get("x-mmd-front-gate"), "mmd-redirect-worker");
+    assert.equal(passThroughRequests.at(-1).url, expected.toString());
+    assert.notEqual(new URL(passThroughRequests.at(-1).url).hostname, "mmdprive.webflow.io");
+  });
+
+  it("following renewal aliases reaches valid SIGIL membership content", async () => {
+    const env = {
+      MEMBER_PAGES_WORKER: {
+        fetch: async (request) => new Response("<main>Renewal / Access Conditions official verification</main>", {
+          status: 200,
+          headers: { "content-type": "text/html; charset=utf-8", "x-mmd-worker": "member-pages-worker", "x-mmd-page": "sigil-membership" },
+        }),
+      },
+    };
+
+    for (const alias of ["/renew", "/renewal"]) {
+      const first = await requestWithEnv(`https://www.mmdbkk.com${alias}?${PRESERVED_QUERY}`, env);
+      assert.equal(first.status, 301, alias);
+      assert.equal(first.headers.get("location"), `https://mmdbkk.com/sigil/membership?${PRESERVED_QUERY}`, alias);
+
+      const followed = await requestWithEnv(first.headers.get("location"), env);
+      const html = await followed.text();
+
+      assert.equal(followed.status, 200, alias);
+      assert.equal(followed.headers.get("location"), null, alias);
+      assert.equal(followed.headers.get("x-mmd-page"), "sigil-membership", alias);
+      assert.match(html, /Renewal \/ Access Conditions/, alias);
+    }
+
+    assert.equal(passThroughRequests.length, 0);
+  });
+
   it("delegates canonical /sigil/apply routes to sigil-worker with ownership headers and preserved query strings", async () => {
     const sigilRequests = [];
     const env = {
@@ -605,6 +679,7 @@ describe("MMD permanent redirect guard", () => {
       { url: `https://www.mmdbkk.com/pay/pending-verification?${PRESERVED_QUERY}`, expectedStatus: 209 },
       { url: `https://www.mmdbkk.com/webhooks/line?${PRESERVED_QUERY}`, expectedStatus: 209 },
       { url: `https://www.mmdbkk.com/sigil/start?${PRESERVED_QUERY}`, expectedStatus: 209 },
+      { url: `https://www.mmdbkk.com/sigil/membership?${PRESERVED_QUERY}`, expectedStatus: 209 },
       { url: `https://www.mmdbkk.com/sigil/apply?${PRESERVED_QUERY}`, expectedStatus: 209 },
     ];
 


### PR DESCRIPTION
## Summary
- Adds explicit front-gate handling for `/sigil/membership` and `/sigil/membership/` before generic `/sigil/*` pass-through.
- Delegates those routes from `mmd-redirect-worker` to `member-pages-worker` with front-gate headers preserved.
- Adds a minimal safe `member-pages-worker` rendered page for SIGIL renewal/access conditions with `x-mmd-page: sigil-membership`.
- Documents the owner audit and target route ownership in `docs/sigil-start-route-migration-audit.md`.

## Owner Audit
1. `member-pages-worker` did not previously support `/sigil/membership`; it only recognized member/package/payment page paths.
2. `mmd-redirect-worker` did pass `/sigil/membership` through to origin because `/sigil/*` is in `NEVER_TOUCH_PREFIXES` and there was no explicit handler.
3. Live origin/Webflow behavior returned `404 Kontrix - Not Found` with a Thai 401-style heading.
4. This PR sets content owner to `member-pages-worker` and keeps front route/proxy owner as `mmd-redirect-worker`.

## Guardrails
- Does not revert `/renew` or `/renewal`; they still redirect to `/sigil/membership` with query preservation.
- Does not change `/trust/inme`, `/sigil/start`, `/sigil/apply`, `/sigil/api/private-model/apply`, `/member/dashboard`, `/member/membership`, `/pay/membership`, `/pay/pending-verification`, payment verification logic, membership update logic, points, Black Card logic, webhook processing, admin auth, `sigil-worker`, or Webflow.
- No deploy.
- No Webflow publish.
- No real payment submission.

## Page Policy
The new `/sigil/membership` page is renewal/access conditions, not checkout. It uses Thai primary copy, keeps Trial/Standard/Premium as the visible package context, does not expose VIP/SVIP as customer-facing upgrades, does not imply proof confirms membership, and describes Black Card only as private consideration/review.

## Tests
```bash
npm --prefix mmd-redirect-worker run check
npm --prefix mmd-redirect-worker test
node --test mmd-redirect-worker/test/line-webhook-bridge.test.mjs
node --check member-pages-worker/src/index.js
node --test member-pages-worker/test/membership.test.mjs
```

Results:
- `npm --prefix mmd-redirect-worker run check` passed.
- `npm --prefix mmd-redirect-worker test` passed: 42 tests, 0 failed.
- `node --test mmd-redirect-worker/test/line-webhook-bridge.test.mjs` passed: 2 tests, 0 failed.
- `node --check member-pages-worker/src/index.js` passed.
- `node --test member-pages-worker/test/membership.test.mjs` passed: 5 tests, 0 failed.

Note: member-pages tests emit Node's existing MODULE_TYPELESS_PACKAGE_JSON warning because this worker lacks its own package `type: module`; no runtime/test failure.