### PR TITLE
[codex] Harden member profile display truth

### DIFF
--- a/member-pages-worker/src/index.js
+++ b/member-pages-worker/src/index.js
@@ -107,14 +107,9 @@ export function renderPending(request) {
 
 export function renderProfile(request) {
   const url = new URL(request.url);
-  const status = String(url.searchParams.get("status") || "pending_verification").toLowerCase();
-  const verified = status === "verified" || status === "active";
   const plan = normalizePlan(url.searchParams.get("plan") || url.searchParams.get("package")) || "standard";
   const pkg = getPackage(plan);
-  const ref = url.searchParams.get("payment_ref") || url.searchParams.get("transaction_ref") || "";
-  const amount = positive(url.searchParams.get("amount")) || pkg.amount;
-  const points = verified ? Math.floor(amount / 100) : 0;
-  return page(request, "member-profile", `${nav(url.search)}<section class="panel center"><p class="eyebrow">MEMBER PROFILE</p><h1>${verified ? "Active Profile" : "Pending Profile"}</h1><p>Member Profile แสดง verified truth เท่านั้น หากเพิ่งส่งหลักฐานการโอน โปรไฟล์จะอยู่ในสถานะ pending verification และยังไม่เพิ่ม points จนกว่ายอดจริงจะถูกตรวจสอบครบชุด</p><div class="profile"><span>Membership Status</span><b>${verified ? "Active" : "Pending Verification"}</b><span>Package</span><b>${html(pkg.title)}</b><span>Payment Status</span><b>${verified ? "Verified" : "Evidence Received"}</b><span>Payment Ref</span><b>${html(ref || "Waiting")}</b><span>Verified Points</span><b>${points} points</b><span>Black Card</span><b>${points >= 350 ? "Review Eligible" : "Not Eligible"}</b></div><p class="actions"><a class="btn" href="${attr(appendQuery("/member/dashboard", url.search))}">Member Dashboard</a><a class="btn ghost" href="${attr(appendQuery("/pay/membership", url.search, { plan }))}">Continue Payment</a></p></section>`);
+  return page(request, "member-profile", `${nav(url.search)}<section class="panel center"><p class="eyebrow">MEMBER PROFILE</p><h1>Pending Profile</h1><p>Member Profile แสดง verified truth จาก official verification เท่านั้น URL query, payment_ref, amount, status, proof หรือ slip เป็นข้อมูลประกอบ ไม่ใช่ payment truth และไม่ใช่การยืนยันสมาชิก</p><div class="profile"><span>Membership Status</span><b>Pending Verification</b><span>Requested Package</span><b>${html(pkg.title)}</b><span>Payment Status</span><b>Evidence Received</b><span>Payment Ref</span><b>Waiting official verification</b><span>Points Status</span><b>points pending official verification</b><span>Black Card</span><b>review unavailable until official verification</b></div><div class="notice">proof is not payment truth · verified funds only · points follow verified funds only</div><p class="actions"><a class="btn" href="${attr(appendQuery("/member/dashboard", url.search))}">Member Dashboard</a><a class="btn ghost" href="${attr(appendQuery("/pay/membership", url.search, { plan }))}">Continue Payment</a></p></section>`);
 }
 
 function packageCard(pkg, selected, query) {

--- a/member-pages-worker/test/membership.test.mjs
+++ b/member-pages-worker/test/membership.test.mjs
@@ -72,6 +72,60 @@ describe("member-pages-worker membership page", () => {
     assert.equal(response.headers.get("x-mmd-page"), "member-membership");
   });
 
+  it("renders member profile in pending safe state by default", async () => {
+    const response = await request("https://mmdbkk.com/member/profile");
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-mmd-worker"), "member-pages-worker");
+    assert.equal(response.headers.get("x-mmd-page"), "member-profile");
+    assert.match(html, /Pending Profile/);
+    assert.match(html, /Pending Verification/);
+    assert.match(html, /Waiting official verification/);
+    assert.match(html, /verified funds only/);
+    assert.match(html, /proof is not payment truth/);
+    assert.match(html, /points pending official verification/);
+    assert.match(html, /review unavailable until official verification/);
+    assert.doesNotMatch(html, /Active Profile/);
+    assert.doesNotMatch(html, /Verified Points/);
+    assert.doesNotMatch(html, /Review Eligible/);
+  });
+
+  it("does not trust verified status, amount, points, or payment ref from query params", async () => {
+    const response = await request("https://mmdbkk.com/member/profile?status=verified&amount=35000&plan=premium&payment_ref=fake-ref");
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-mmd-worker"), "member-pages-worker");
+    assert.equal(response.headers.get("x-mmd-page"), "member-profile");
+    assert.match(html, /Pending Profile/);
+    assert.match(html, /Pending Verification/);
+    assert.match(html, /official verification/);
+    assert.match(html, /proof is not payment truth/);
+    assert.match(html, /verified funds only/);
+    assert.doesNotMatch(html, /Active Profile/);
+    assert.doesNotMatch(html, /350 points/);
+    assert.doesNotMatch(html, /Review Eligible/);
+    assert.match(html, /<span>Payment Ref<\/span><b>Waiting official verification<\/b>/);
+    assert.doesNotMatch(html, /Verified payment truth/i);
+  });
+
+  it("keeps member profile slash variant in pending safe state", async () => {
+    const response = await request("https://mmdbkk.com/member/profile/?status=active&amount=35000&payment_ref=fake-ref");
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-mmd-worker"), "member-pages-worker");
+    assert.equal(response.headers.get("x-mmd-page"), "member-profile");
+    assert.match(html, /Pending Profile/);
+    assert.match(html, /Pending Verification/);
+    assert.match(html, /points pending official verification/);
+    assert.doesNotMatch(html, /Active Profile/);
+    assert.doesNotMatch(html, /350 points/);
+    assert.doesNotMatch(html, /Review Eligible/);
+    assert.match(html, /<span>Payment Ref<\/span><b>Waiting official verification<\/b>/);
+  });
+
   it("keeps unknown paths closed", async () => {
     const response = await request("https://mmdbkk.com/member/dashboard?t=abc");
 


### PR DESCRIPTION
## Summary

- Hardens `/member/profile` display so URL query params cannot render official verified membership truth.
- Defaults `/member/profile` and `/member/profile/` to Pending Profile / Pending Verification display.
- Stops displaying Active Profile, verified points, query-derived 350 points, Black Card Review Eligible, and query `payment_ref` as verified truth.
- Keeps route ownership unchanged: `member-pages-worker`, `x-mmd-page: member-profile`.

## Scope

Display-only safety fix in `member-pages-worker`.

Changed files:

- `member-pages-worker/src/index.js`
- `member-pages-worker/test/membership.test.mjs`

## Guardrails

- No `mmd-redirect-worker` change.
- No route ownership change.
- No deploy.
- No Webflow publish.
- No payment verification change.
- No membership activation/update change.
- No points update logic change.
- No Black Card approval logic change.
- No webhook processing change.
- No admin auth change.
- No `sigil-worker` change.

## Validation

```bash
node --check member-pages-worker/src/index.js
node --test member-pages-worker/test/membership.test.mjs
```

Result: 8 tests passed, 0 failed. Node emitted the existing `MODULE_TYPELESS_PACKAGE_JSON` warning; tests passed.