### PR TITLE
fix(telegram): validate webhook secret token

### DIFF
--- a/telegram-worker/src/index.js
+++ b/telegram-worker/src/index.js
@@ -235,10 +235,23 @@ function parseStartArg(text) {
 }
 
 function requireTelegramSecret(req, env) {
-  const expected = clean(env.TELEGRAM_WEBHOOK_SECRET);
+  const expected = clean(env.TELEGRAM_WEBHOOK_SECRET_TOKEN);
   if (!expected) return;
   const actual = clean(req.headers.get("X-Telegram-Bot-Api-Secret-Token"));
-  if (actual !== expected) throw new HttpError(403, { ok: false, error: "telegram_secret_required" });
+  if (!actual || !timingSafeEqual(actual, expected)) {
+    throw new HttpError(401, { ok: false, error: "unauthorized" });
+  }
+}
+
+function timingSafeEqual(left, right) {
+  const a = String(left || "");
+  const b = String(right || "");
+  let diff = a.length ^ b.length;
+  const max = Math.max(a.length, b.length);
+  for (let index = 0; index < max; index += 1) {
+    diff |= (a.charCodeAt(index) || 0) ^ (b.charCodeAt(index) || 0);
+  }
+  return diff === 0;
 }
 
 function previewUserKey(userId) {

--- a/telegram-worker/test/webhook-secret-token.test.mjs
+++ b/telegram-worker/test/webhook-secret-token.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "../src/index.js";
+
+const WEBHOOK_URL = "https://telegram-worker.mmd.test/telegram/webhook";
+const PREVIEW_POST_URL = "https://telegram-worker.mmd.test/telegram/preview/post";
+
+function env(overrides = {}) {
+  return {
+    TELEGRAM_WEBHOOK_SECRET_TOKEN: "expected-secret",
+    INTERNAL_API_TOKEN: "internal-secret",
+    TELEGRAM_PREVIEW_CHANNEL_ID: "-100123",
+    TELEGRAM_BOT_USERNAME: "mmdprivebot",
+    ...overrides,
+  };
+}
+
+function webhookRequest(headers = {}) {
+  return new Request(WEBHOOK_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+    body: JSON.stringify({
+      update_id: 1,
+      message: {
+        message_id: 10,
+        text: "hello",
+        chat: { id: 999 },
+        from: { id: 111 },
+      },
+    }),
+  });
+}
+
+test("/telegram/webhook rejects missing secret token when configured", async () => {
+  const response = await worker.fetch(webhookRequest(), env());
+  const body = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(body, { ok: false, error: "unauthorized" });
+  assert.doesNotMatch(JSON.stringify(body), /expected-secret|X-Telegram-Bot-Api-Secret-Token/i);
+});
+
+test("/telegram/webhook rejects wrong secret token when configured", async () => {
+  const response = await worker.fetch(
+    webhookRequest({ "X-Telegram-Bot-Api-Secret-Token": "wrong-secret" }),
+    env(),
+  );
+  const body = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(body, { ok: false, error: "unauthorized" });
+  assert.doesNotMatch(JSON.stringify(body), /expected-secret|wrong-secret|X-Telegram-Bot-Api-Secret-Token/i);
+});
+
+test("/telegram/webhook with correct secret token reaches update handler", async () => {
+  const response = await worker.fetch(
+    webhookRequest({ "X-Telegram-Bot-Api-Secret-Token": "expected-secret" }),
+    env(),
+  );
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.received, true);
+  assert.equal(body.handled, false);
+  assert.equal(body.reason, "no_matching_command");
+});
+
+test("/telegram/webhook remains open when secret token is not configured", async () => {
+  const response = await worker.fetch(
+    webhookRequest(),
+    env({ TELEGRAM_WEBHOOK_SECRET_TOKEN: "" }),
+  );
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.reason, "no_matching_command");
+});
+
+test("/telegram/preview/post remains protected by INTERNAL_API_TOKEN", async () => {
+  const missing = await worker.fetch(new Request(PREVIEW_POST_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ dry_run: true }),
+  }), env());
+  const missingBody = await missing.json();
+
+  assert.equal(missing.status, 403);
+  assert.equal(missingBody.error, "internal_token_required");
+
+  const allowed = await worker.fetch(new Request(PREVIEW_POST_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "X-Internal-Token": "internal-secret",
+    },
+    body: JSON.stringify({ dry_run: true }),
+  }), env());
+  const allowedBody = await allowed.json();
+
+  assert.equal(allowed.status, 200);
+  assert.equal(allowedBody.ok, true);
+  assert.equal(allowedBody.dry_run, true);
+});

--- a/telegram-worker/wrangler.toml
+++ b/telegram-worker/wrangler.toml
@@ -19,7 +19,7 @@ AIRTABLE_TABLE_POINTS_LEDGER = "points_ledger"
 # Do not put secrets here.
 # Configure these with wrangler secret put:
 # TELEGRAM_BOT_TOKEN
-# TELEGRAM_WEBHOOK_SECRET
+# TELEGRAM_WEBHOOK_SECRET_TOKEN
 # INTERNAL_API_TOKEN
 # PREVIEW_PROMO_SECRET
 #


### PR DESCRIPTION
## Summary
- Validate `X-Telegram-Bot-Api-Secret-Token` on `/telegram/webhook` when `TELEGRAM_WEBHOOK_SECRET_TOKEN` is configured
- Return a generic unauthorized response for missing/wrong webhook secret tokens
- Keep `/telegram/preview/post` protected by `INTERNAL_API_TOKEN`

## Tests
- `node --check telegram-worker/src/index.js`
- `node --test telegram-worker/**/*.test.mjs`
- `npx wrangler deploy --config telegram-worker/wrangler.toml --dry-run`