### PR TITLE
fix(admin): add demo links table var

### DIFF
--- a/admin-worker/wrangler.toml
+++ b/admin-worker/wrangler.toml
@@ -22,6 +22,7 @@ AIRTABLE_TABLE_CONSOLE_INBOX_ID = "tblFHmfpB2TTrzO2e"
 AIRTABLE_TABLE_PAYMENT_PROOFS_ID = "tblfJfM4Sqag9zrLi"
 
 # Optional table names (ถ้าคุณใช้ name-based endpoints)
+AIRTABLE_TABLE_DEMO_LINKS = "Demo Links"
 AIRTABLE_TABLE_MEMBERS = "members"
 AIRTABLE_TABLE_MODELS = "models"
 MODEL_SOURCE_OWNER_DEFAULT = "lonelysomething"


### PR DESCRIPTION
## Summary

- Config-only fix for the admin-worker demo-links smoke env guard.
- Adds non-secret Worker var `AIRTABLE_TABLE_DEMO_LINKS = "Demo Links"` under `[vars]` in `admin-worker/wrangler.toml`.
- PR #105 is already live from the correct `origin/main` deploy at `9b79a06`; smoke is currently 3/4 green and blocked only by the missing `AIRTABLE_TABLE_DEMO_LINKS` var.

## Safety

- No code changes.
- No changes to `admin-worker/src/index.js`.
- No changes to `admin-worker/src/routes/demo-links.js`.
- No secrets touched.
- No route patterns added or changed.
- No Worker-to-Worker bindings added or changed.
- No production Airtable write routes run.
- No manual deploy performed from this PR branch.

## Validation

- `node --check admin-worker/src/index.js`: passed.
- `node --test admin-worker/model-schema-patch-v1.test.mjs`: passed, 9/9 tests.
- `npx wrangler deploy --config admin-worker/wrangler.toml --dry-run`: passed; dry-run only, no deployment. Dry-run shows `env.AIRTABLE_TABLE_DEMO_LINKS ("Demo Links")`.

## Post-merge / approved deploy smoke

After merge and approved deploy, re-run only Check 2:

`GET https://admin-worker.malemodel-bkk.workers.dev/v1/demo-links/get`

Expected:

`HTTP 400`

```json
{"ok":false,"error":"missing_demo_id"}
```