### PR TITLE
Fix SIGIL booking canonical page source

### DIFF
--- a/docs/sigil-route-ownership-registry.md
+++ b/docs/sigil-route-ownership-registry.md
@@ -1,15 +1,17 @@
 # SIGIL Route Ownership Registry
 
-Last updated: 2026-06-22
+Last updated: 2026-06-27
 
 This registry records canonical owners for SIGIL public routes fronted by
-`mmd-redirect-worker`. Routes listed here must not be served by generic Webflow
+Cloudflare Workers. Routes listed here must not be served by generic Webflow
 pass-through or an unrelated fallback page.
 
 | Public route | Canonical owner | Front gate behavior | Origin header | Page header |
 | --- | --- | --- | --- | --- |
 | `GET /sigil/apply` | `sigil-worker` | Delegate directly to `SIGIL_WORKER`. If the service binding is unavailable, fetch only `https://sigil.mmdbkk.com/sigil/apply` with the original query string. | `x-mmd-origin: service-binding:sigil-worker` or `https://sigil.mmdbkk.com` | `x-mmd-page: sigil-private-model-setup` |
 | `GET /sigil/apply/` | `sigil-worker` | Same as `/sigil/apply`, preserving the trailing slash and query string. | `x-mmd-origin: service-binding:sigil-worker` or `https://sigil.mmdbkk.com` | `x-mmd-page: sigil-private-model-setup` |
+| `GET /sigil/booking` | `sigil-booking-proxy-worker` | On `mmdbkk.com` and `www.mmdbkk.com`, redirect with HTTP 302 to `https://sigil.mmdbkk.com/sigil/booking`, preserving only `t`, `code`, `promo`, `model_id`, and `request_id`. On `sigil.mmdbkk.com`, proxy the live Webflow page from `https://mmdprive.webflow.io/sigil/booking`. | `x-mmd-origin: https://mmdprive.webflow.io` | `x-mmd-page: sigil-booking` |
+| `GET /sigil/booking/` | `sigil-booking-proxy-worker` | Same as `/sigil/booking`, normalized to the canonical path. | `x-mmd-origin: https://mmdprive.webflow.io` | `x-mmd-page: sigil-booking` |
 
 Required owner headers for `/sigil/apply` responses:
 
@@ -19,11 +21,22 @@ Required owner headers for `/sigil/apply` responses:
 - `x-mmd-front-gate: mmd-redirect-worker`
 - `x-mmd-front-version: 20260622T071500Z`
 
+Required owner headers for `/sigil/booking` responses:
+
+- `x-mmd-route-owner: sigil-booking-proxy-worker`
+- `x-mmd-page: sigil-booking`
+- `x-mmd-booking-source: webflow-live`
+- `x-mmd-page-source: https://mmdprive.webflow.io/sigil/booking`
+- `cache-control: no-store, no-cache, must-revalidate, max-age=0`
+
 Regression guard:
 
 - `/sigil/apply` and `/sigil/apply/` on both `mmdbkk.com` and
   `www.mmdbkk.com` must never render content from `/ceo/telegram-brief`.
+- `/sigil/booking` and `/sigil/booking/` on `sigil.mmdbkk.com` must render the
+  current Webflow booking page and must not render the old/default page with
+  `SIGIL / BOOKING / REQUEST`, `Standard Search`, or `Assisted Request`.
 - Tests must fail if the response body contains `Briefing HYPE TELEGRAMBOT`,
   `TELEGRAMBOT`, or `CEO TELEGRAM BRIEF`.
 - Query strings such as `?t=abc&code=x&promo=y` must be preserved exactly when
-  delegated to the owner.
+  delegated to the owner unless the route explicitly uses a safe-param allowlist.

--- a/package.json
+++ b/package.json
@@ -10,13 +10,17 @@
     "deploy:events": "wrangler deploy --config workers/events-worker/wrangler.toml",
     "deploy:telegram": "wrangler deploy --config telegram-worker/wrangler.toml",
     "deploy:sigil-board": "wrangler deploy --config workers/sigil-board-worker/wrangler.toml",
+    "deploy:sigil-booking-proxy": "wrangler deploy --config workers/sigil-booking-proxy-worker/wrangler.toml",
 
     "dev:payments": "wrangler dev --config workers/payments-worker/wrangler.toml",
     "dev:admin": "wrangler dev --config workers/admin-worker/wrangler.toml",
     "dev:events": "wrangler dev --config workers/events-worker/wrangler.toml",
     "dev:telegram": "wrangler dev --config telegram-worker/wrangler.toml",
     "dev:sigil-board": "wrangler dev --config workers/sigil-board-worker/wrangler.toml",
+    "dev:sigil-booking-proxy": "wrangler dev --config workers/sigil-booking-proxy-worker/wrangler.toml",
     "check:sigil-board": "node --check workers/sigil-board-worker/src/index.js",
+    "check:sigil-booking-proxy": "node --check workers/sigil-booking-proxy-worker/src/index.js",
+    "test:sigil-booking-proxy": "node --test workers/sigil-booking-proxy-worker/test/index.test.mjs",
     "check:kenji-member-memory": "node --check shared/kenji-member-memory-snapshot.mjs && node --check immigrate-worker/netlify/functions/kenji-member-memory-context.mjs",
     "test:kenji-line": "node --test shared/kenji-member-concierge-core.test.mjs",
     "test:kenji-member-memory": "node --test shared/kenji-member-memory-snapshot.test.mjs"

--- a/workers/sigil-booking-proxy-worker/package.json
+++ b/workers/sigil-booking-proxy-worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "sigil-booking-proxy-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "node --check src/index.js",
+    "test": "node --test test/index.test.mjs",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.10.0"
+  }
+}

--- a/workers/sigil-booking-proxy-worker/src/index.js
+++ b/workers/sigil-booking-proxy-worker/src/index.js
@@ -1,0 +1,190 @@
+/**
+ * SIGIL Booking Canonical Proxy Worker
+ *
+ * Purpose:
+ * - Keep /sigil/booking canonical on https://sigil.mmdbkk.com/sigil/booking
+ * - Route the canonical page to the current Webflow page source
+ * - Prevent the old/default SIGIL booking page from being served on the canonical host
+ * - Redirect mmdbkk.com and www.mmdbkk.com front-gate requests to the canonical host
+ * - Preserve only safe access/query params during front-gate redirects
+ *
+ * This worker owns page HTML only. It does not handle /api/sigil/*.
+ */
+
+export const WORKER_NAME = "sigil-booking-proxy-worker";
+export const RUNTIME_VERSION = "20260627-sigil-booking-canonical-proxy";
+export const CANONICAL_HOST = "sigil.mmdbkk.com";
+export const CANONICAL_PROTOCOL = "https:";
+export const SIGIL_BOOKING_PATH = "/sigil/booking";
+export const WEBFLOW_ORIGIN = "https://mmdprive.webflow.io";
+export const WEBFLOW_BOOKING_PATH = "/sigil/booking";
+
+export const FRONT_GATE_HOSTS = new Set(["mmdbkk.com", "www.mmdbkk.com"]);
+export const CANONICAL_HOSTS = new Set([CANONICAL_HOST]);
+export const SAFE_FRONT_GATE_PARAMS = new Set(["t", "code", "promo", "model_id", "request_id"]);
+
+export function normalizePath(pathname) {
+  let path = pathname || "/";
+  path = path.replace(/\/{2,}/g, "/");
+  if (path.length > 1) path = path.replace(/\/+$/g, "");
+  return path || "/";
+}
+
+export function isSigilBookingPath(url) {
+  return normalizePath(url.pathname).toLowerCase() === SIGIL_BOOKING_PATH;
+}
+
+export function isFrontGateHost(url) {
+  return FRONT_GATE_HOSTS.has(url.hostname.toLowerCase());
+}
+
+export function isCanonicalHost(url) {
+  return CANONICAL_HOSTS.has(url.hostname.toLowerCase());
+}
+
+export function isSafePageMethod(request) {
+  const method = request.method.toUpperCase();
+  return method === "GET" || method === "HEAD";
+}
+
+export function canonicalBookingUrl(url) {
+  const target = new URL(`${CANONICAL_PROTOCOL}//${CANONICAL_HOST}${SIGIL_BOOKING_PATH}`);
+
+  for (const [key, value] of url.searchParams.entries()) {
+    if (SAFE_FRONT_GATE_PARAMS.has(key)) target.searchParams.set(key, value);
+  }
+
+  return target;
+}
+
+function pageHeaders(extra = {}) {
+  const headers = new Headers({
+    "cache-control": "no-store, no-cache, must-revalidate, max-age=0",
+    "x-mmd-worker": WORKER_NAME,
+    "x-mmd-route-owner": WORKER_NAME,
+    "x-mmd-page": "sigil-booking",
+    "x-mmd-runtime-version": RUNTIME_VERSION,
+    ...extra,
+  });
+  return headers;
+}
+
+function redirectToCanonical(url) {
+  const target = canonicalBookingUrl(url);
+  const response = Response.redirect(target.toString(), 302);
+  const headers = pageHeaders({
+    location: response.headers.get("location") || target.toString(),
+    "x-mmd-redirect-reason": "canonical_sigil_host",
+  });
+
+  return new Response(null, {
+    status: 302,
+    statusText: "Found",
+    headers,
+  });
+}
+
+function withProxyHeaders(response, extra = {}) {
+  const headers = new Headers(response.headers);
+
+  for (const [key, value] of pageHeaders(extra).entries()) {
+    headers.set(key, value);
+  }
+
+  headers.set("x-mmd-origin", WEBFLOW_ORIGIN);
+  headers.set("x-mmd-booking-source", "webflow-live");
+  headers.set("x-mmd-page-source", `${WEBFLOW_ORIGIN}${WEBFLOW_BOOKING_PATH}`);
+  headers.delete("content-length");
+
+  return headers;
+}
+
+function injectPageMarkers(html) {
+  const marker = `<meta name="mmd-page-owner" content="${WORKER_NAME}">
+<meta name="mmd-page-source" content="mmdprive.webflow.io/sigil/booking">
+<meta name="mmd-page-version" content="sigil-booking-next">`;
+
+  if (html.includes("mmd-page-owner")) return html;
+  if (html.includes("</head>")) return html.replace("</head>", `${marker}\n</head>`);
+  return `${marker}\n${html}`;
+}
+
+async function fetchBookingFromWebflow(request, url) {
+  const upstream = new URL(`${WEBFLOW_ORIGIN}${WEBFLOW_BOOKING_PATH}`);
+  upstream.search = url.search;
+
+  const upstreamRequest = new Request(upstream.toString(), {
+    method: "GET",
+    headers: {
+      accept: request.headers.get("accept") || "text/html,application/xhtml+xml",
+      "accept-language": request.headers.get("accept-language") || "th,en;q=0.9",
+      "user-agent": request.headers.get("user-agent") || WORKER_NAME,
+    },
+  });
+
+  const upstreamResponse = await fetch(upstreamRequest);
+
+  if (!upstreamResponse.ok) {
+    return new Response("SIGIL Booking is temporarily unavailable.", {
+      status: 502,
+      headers: pageHeaders({
+        "content-type": "text/plain; charset=utf-8",
+        "x-mmd-origin": WEBFLOW_ORIGIN,
+        "x-mmd-booking-error": "webflow_upstream_failed",
+      }),
+    });
+  }
+
+  const contentType = upstreamResponse.headers.get("content-type") || "";
+  const headers = withProxyHeaders(upstreamResponse);
+
+  if (!contentType.toLowerCase().includes("text/html")) {
+    return new Response(request.method.toUpperCase() === "HEAD" ? null : upstreamResponse.body, {
+      status: upstreamResponse.status,
+      statusText: upstreamResponse.statusText,
+      headers,
+    });
+  }
+
+  const html = injectPageMarkers(await upstreamResponse.text());
+
+  return new Response(request.method.toUpperCase() === "HEAD" ? null : html, {
+    status: 200,
+    headers,
+  });
+}
+
+function methodNotAllowed() {
+  return new Response(JSON.stringify({ ok: false, error: "METHOD_NOT_ALLOWED" }), {
+    status: 405,
+    headers: pageHeaders({
+      "content-type": "application/json; charset=utf-8",
+      allow: "GET, HEAD, OPTIONS",
+    }),
+  });
+}
+
+function notFound(url) {
+  return new Response(JSON.stringify({ ok: false, error: "NOT_FOUND", path: url.pathname }), {
+    status: 404,
+    headers: pageHeaders({ "content-type": "application/json; charset=utf-8" }),
+  });
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    if (request.method.toUpperCase() === "OPTIONS") {
+      return new Response(null, { status: 204, headers: pageHeaders({ allow: "GET, HEAD, OPTIONS" }) });
+    }
+
+    if (!isSigilBookingPath(url)) return notFound(url);
+    if (!isSafePageMethod(request)) return methodNotAllowed();
+
+    if (isFrontGateHost(url)) return redirectToCanonical(url);
+    if (isCanonicalHost(url)) return fetchBookingFromWebflow(request, url);
+
+    return notFound(url);
+  },
+};

--- a/workers/sigil-booking-proxy-worker/test/index.test.mjs
+++ b/workers/sigil-booking-proxy-worker/test/index.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import worker from "../src/index.js";
+
+let originalFetch;
+let upstreamRequests;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  upstreamRequests = [];
+  globalThis.fetch = async (request) => {
+    upstreamRequests.push(request);
+    return new Response("<!doctype html><html><head><title>Booking</title></head><body><main>Choose Your Preference</main></body></html>", {
+      status: 200,
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function request(url, init) {
+  return worker.fetch(new Request(url, init));
+}
+
+describe("sigil-booking-proxy-worker", () => {
+  it("redirects mmdbkk.com /sigil/booking to canonical SIGIL host and preserves only safe params", async () => {
+    const response = await request("https://www.mmdbkk.com/sigil/booking?t=diag&code=abc&promo=test&model_id=mdl1&request_id=req1&bad=drop");
+
+    assert.equal(response.status, 302);
+    assert.equal(response.headers.get("location"), "https://sigil.mmdbkk.com/sigil/booking?t=diag&code=abc&promo=test&model_id=mdl1&request_id=req1");
+    assert.equal(response.headers.get("x-mmd-redirect-reason"), "canonical_sigil_host");
+    assert.equal(response.headers.get("x-mmd-page"), "sigil-booking");
+    assert.equal(upstreamRequests.length, 0);
+  });
+
+  it("serves canonical SIGIL booking from Webflow live source", async () => {
+    const response = await request("https://sigil.mmdbkk.com/sigil/booking?t=diag&cb=123");
+    const html = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-mmd-page"), "sigil-booking");
+    assert.equal(response.headers.get("x-mmd-booking-source"), "webflow-live");
+    assert.equal(response.headers.get("x-mmd-page-source"), "https://mmdprive.webflow.io/sigil/booking");
+    assert.match(html, /Choose Your Preference/);
+    assert.match(html, /mmd-page-owner/);
+    assert.equal(upstreamRequests.at(-1).url, "https://mmdprive.webflow.io/sigil/booking?t=diag&cb=123");
+  });
+
+  it("returns no body for HEAD while keeping route headers", async () => {
+    const response = await request("https://sigil.mmdbkk.com/sigil/booking?t=diag", { method: "HEAD" });
+    const body = await response.text();
+
+    assert.equal(response.status, 200);
+    assert.equal(body, "");
+    assert.equal(response.headers.get("x-mmd-page"), "sigil-booking");
+    assert.equal(response.headers.get("x-mmd-booking-source"), "webflow-live");
+  });
+
+  it("rejects non-page paths", async () => {
+    const response = await request("https://sigil.mmdbkk.com/api/sigil/models/search");
+    const payload = await response.json();
+
+    assert.equal(response.status, 404);
+    assert.equal(payload.error, "NOT_FOUND");
+  });
+});

--- a/workers/sigil-booking-proxy-worker/wrangler.toml
+++ b/workers/sigil-booking-proxy-worker/wrangler.toml
@@ -1,0 +1,34 @@
+name = "sigil-booking-proxy-worker"
+main = "src/index.js"
+compatibility_date = "2026-06-07"
+workers_dev = false
+
+[observability]
+enabled = true
+head_sampling_rate = 1
+
+# Exact canonical page owner. This must win over the generic sigil.mmdbkk.com/* owner.
+[[routes]]
+pattern = "sigil.mmdbkk.com/sigil/booking"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "sigil.mmdbkk.com/sigil/booking/"
+zone_name = "mmdbkk.com"
+
+# Front-gate redirects. These routes must win over the generic mmd-redirect-worker mmdbkk.com/* route.
+[[routes]]
+pattern = "mmdbkk.com/sigil/booking"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/sigil/booking/"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/sigil/booking"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/sigil/booking/"
+zone_name = "mmdbkk.com"


### PR DESCRIPTION
## Summary

Fixes the root cause where `https://sigil.mmdbkk.com/sigil/booking` can serve the old/default `SIGIL / BOOKING / REQUEST` page while the updated page exists on `https://mmdprive.webflow.io/sigil/booking`.

This adds a dedicated `sigil-booking-proxy-worker` that owns only the booking page HTML route:

- `sigil.mmdbkk.com/sigil/booking` proxies the current Webflow booking page
- `mmdbkk.com/sigil/booking` and `www.mmdbkk.com/sigil/booking` redirect to canonical SIGIL host
- front-gate redirects preserve only safe params: `t`, `code`, `promo`, `model_id`, `request_id`
- no `/api/sigil/*` ownership is changed
- no payment/member/points behavior is touched

## Why this approach

A separate highly-specific route avoids modifying the existing generic `sigil-worker` or the large `mmd-redirect-worker` runtime. Cloudflare route specificity lets this worker win for `/sigil/booking` without risking existing SIGIL/admin/API flows.

## Tests

Added node tests for:

- main/www 302 canonical redirect
- safe param preservation and unsafe param drop
- canonical host serving Webflow source with route headers
- HEAD response behavior
- non-page path rejection

Run:

```bash
npm run check:sigil-booking-proxy
npm run test:sigil-booking-proxy
```

Deploy:

```bash
npm run deploy:sigil-booking-proxy
```

Smoke after deploy:

```bash
curl -I "https://www.mmdbkk.com/sigil/booking?t=diag&code=abc&promo=test&model_id=mdl1&bad=drop"
curl -I "https://sigil.mmdbkk.com/sigil/booking?t=diag&cb=$(date +%s)"
curl -s "https://sigil.mmdbkk.com/sigil/booking?t=diag&cb=$(date +%s)" | grep -E "Choose Your Preference|sigil-booking-next|mmd-page-source"
curl -s "https://sigil.mmdbkk.com/sigil/booking?t=diag&cb=$(date +%s)" | grep -E "SIGIL / BOOKING / REQUEST|Standard Search|Assisted Request"
```

Expected: first grep finds new page markers; second grep returns no match.