### PR TITLE
Add Model Session Contract V1

### DIFF
--- a/admin-worker/model-session-contract-v1.test.mjs
+++ b/admin-worker/model-session-contract-v1.test.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MODEL_SESSION_ALLOWED_ACTIONS,
+  MODEL_SESSION_CONTRACT_VERSION,
+  MODEL_SESSION_HARD_RULES,
+  MODEL_SESSION_STATES,
+  MODEL_SESSION_TRANSITIONS,
+  getAllowedModelSessionActions,
+  isModelSessionActionVisible,
+  normalizeSessionState,
+  resolveModelSessionPage,
+  resolveModelSessionTransition,
+} from "./src/modelSessionContractV1.js";
+
+test("declares canonical model session states in contract order", () => {
+  assert.equal(MODEL_SESSION_CONTRACT_VERSION, "model_session_contract_v1");
+  assert.deepEqual(MODEL_SESSION_STATES, [
+    "offered",
+    "offer_declined",
+    "offer_expired",
+    "confirmed",
+    "en_route",
+    "nearby",
+    "arrived",
+    "met_customer",
+    "final_payment_pending",
+    "final_payment_confirmed",
+    "work_started",
+    "work_finished",
+    "separated",
+    "under_review",
+    "payout_pending",
+    "closed",
+  ]);
+});
+
+test("normalizes MMD canonical aliases without changing the canonical state list", () => {
+  const cases = {
+    assigned: "confirmed",
+    traveling: "en_route",
+    met: "met_customer",
+    met_client: "met_customer",
+    payment_pending: "final_payment_pending",
+    payment_confirmed: "final_payment_confirmed",
+    working: "work_started",
+    finished: "work_finished",
+    review: "under_review",
+    payout: "payout_pending",
+    "Final Payment Confirmed": "final_payment_confirmed",
+    "on-the-way": "",
+  };
+
+  for (const [input, expected] of Object.entries(cases)) {
+    assert.equal(normalizeSessionState(input), expected, input);
+  }
+
+  assert.equal(MODEL_SESSION_STATES.includes("assigned"), false);
+  assert.equal(MODEL_SESSION_STATES.includes("traveling"), false);
+  assert.equal(MODEL_SESSION_STATES.includes("working"), false);
+});
+
+test("resolves model session page ownership from canonical states and aliases", () => {
+  assert.deepEqual(resolveModelSessionPage("offered"), {
+    path: "/model/session/offered",
+    state: "offered",
+    states: ["offered", "offer_declined", "offer_expired"],
+  });
+  assert.equal(resolveModelSessionPage("assigned").path, "/model/session/assigned");
+  assert.equal(resolveModelSessionPage("traveling").path, "/model/session/on-the-way");
+  assert.equal(resolveModelSessionPage("nearby").path, "/model/session/on-the-way");
+  assert.equal(resolveModelSessionPage("arrived").path, "/model/session/arrival-payment");
+  assert.equal(resolveModelSessionPage("payment_confirmed").path, "/model/session/arrival-payment");
+  assert.equal(resolveModelSessionPage("working").path, "/model/session/session-live");
+  assert.equal(resolveModelSessionPage("payout").path, "/model/session/wrap-up");
+  assert.equal(resolveModelSessionPage("unknown_state"), null);
+});
+
+test("keeps allowed actions as UI hints and only shows Start Work at final_payment_confirmed", () => {
+  for (const state of MODEL_SESSION_STATES) {
+    const actions = getAllowedModelSessionActions(state);
+    assert.deepEqual(actions, MODEL_SESSION_ALLOWED_ACTIONS[state] || []);
+    assert.equal(actions.includes("start_work"), state === "final_payment_confirmed", state);
+  }
+
+  assert.equal(isModelSessionActionVisible("final_payment_confirmed", "start_work"), true);
+  assert.equal(isModelSessionActionVisible("final_payment_pending", "start_work"), false);
+  assert.equal(isModelSessionActionVisible("met_customer", "start_work"), false);
+  assert.equal(MODEL_SESSION_HARD_RULES.allowedActionsAreUiHintsOnly, true);
+});
+
+test("defines future transition table with hard Start Work gate", () => {
+  assert.deepEqual(MODEL_SESSION_TRANSITIONS.start_work.from, ["final_payment_confirmed"]);
+  assert.equal(MODEL_SESSION_TRANSITIONS.start_work.to, "work_started");
+  assert.deepEqual(MODEL_SESSION_TRANSITIONS.start_work.requires, [
+    "current_state_recheck",
+    "payments_worker_live_check",
+  ]);
+  assert.equal(MODEL_SESSION_HARD_RULES.postTransitionMustRecheckServerState, true);
+  assert.equal(MODEL_SESSION_HARD_RULES.startWorkRequiresPaymentsWorkerLiveCheck, true);
+});
+
+test("future transition resolver rejects start_work unless current state is final_payment_confirmed", () => {
+  for (const state of MODEL_SESSION_STATES.filter((item) => item !== "final_payment_confirmed")) {
+    const result = resolveModelSessionTransition("start_work", state);
+    assert.equal(result.ok, false, state);
+    assert.equal(result.reason, "invalid_current_state", state);
+  }
+
+  assert.deepEqual(resolveModelSessionTransition("start_work", "final_payment_confirmed"), {
+    ok: true,
+    action: "start_work",
+    from: "final_payment_confirmed",
+    to: "work_started",
+    requires: ["current_state_recheck", "payments_worker_live_check"],
+  });
+});
+
+test("records future signed-link and Flash constraints without implementing issuers", () => {
+  assert.equal(MODEL_SESSION_HARD_RULES.telegramLinksRequireShortLivedSignedLinks, true);
+  assert.equal(MODEL_SESSION_HARD_RULES.flashUnlockMustNotUseSlipProofAlone, true);
+});

--- a/admin-worker/src/modelSessionContractV1.js
+++ b/admin-worker/src/modelSessionContractV1.js
@@ -1,0 +1,221 @@
+export const MODEL_SESSION_CONTRACT_VERSION = "model_session_contract_v1";
+
+export const MODEL_SESSION_STATES = Object.freeze([
+  "offered",
+  "offer_declined",
+  "offer_expired",
+  "confirmed",
+  "en_route",
+  "nearby",
+  "arrived",
+  "met_customer",
+  "final_payment_pending",
+  "final_payment_confirmed",
+  "work_started",
+  "work_finished",
+  "separated",
+  "under_review",
+  "payout_pending",
+  "closed",
+]);
+
+export const MODEL_SESSION_STATE_SET = new Set(MODEL_SESSION_STATES);
+
+export const MODEL_SESSION_STATE_ALIASES = Object.freeze({
+  assigned: "confirmed",
+  traveling: "en_route",
+  met: "met_customer",
+  met_client: "met_customer",
+  payment_pending: "final_payment_pending",
+  payment_confirmed: "final_payment_confirmed",
+  working: "work_started",
+  finished: "work_finished",
+  review: "under_review",
+  payout: "payout_pending",
+});
+
+export const MODEL_SESSION_PAGE_OWNERSHIP = Object.freeze([
+  Object.freeze({
+    path: "/model/session/offered",
+    states: Object.freeze(["offered", "offer_declined", "offer_expired"]),
+  }),
+  Object.freeze({
+    path: "/model/session/assigned",
+    states: Object.freeze(["confirmed"]),
+  }),
+  Object.freeze({
+    path: "/model/session/on-the-way",
+    states: Object.freeze(["en_route", "nearby"]),
+  }),
+  Object.freeze({
+    path: "/model/session/arrival-payment",
+    states: Object.freeze(["arrived", "met_customer", "final_payment_pending", "final_payment_confirmed"]),
+  }),
+  Object.freeze({
+    path: "/model/session/session-live",
+    states: Object.freeze(["work_started"]),
+  }),
+  Object.freeze({
+    path: "/model/session/wrap-up",
+    states: Object.freeze(["work_finished", "separated", "under_review", "payout_pending", "closed"]),
+  }),
+]);
+
+export const MODEL_SESSION_ALLOWED_ACTIONS = Object.freeze({
+  offered: Object.freeze(["accept_offer", "decline_offer"]),
+  offer_declined: Object.freeze([]),
+  offer_expired: Object.freeze([]),
+  confirmed: Object.freeze(["go_en_route"]),
+  en_route: Object.freeze(["mark_nearby", "mark_arrived", "send_eta"]),
+  nearby: Object.freeze(["mark_arrived", "send_eta"]),
+  arrived: Object.freeze(["mark_met_customer", "report_delay"]),
+  met_customer: Object.freeze(["mark_final_payment_pending", "request_payment_check"]),
+  final_payment_pending: Object.freeze(["request_payment_check"]),
+  final_payment_confirmed: Object.freeze(["start_work"]),
+  work_started: Object.freeze(["finish_work", "emergency"]),
+  work_finished: Object.freeze(["mark_separated"]),
+  separated: Object.freeze(["request_review"]),
+  under_review: Object.freeze(["mark_payout_pending"]),
+  payout_pending: Object.freeze(["close_session"]),
+  closed: Object.freeze([]),
+});
+
+export const MODEL_SESSION_TRANSITIONS = Object.freeze({
+  accept_offer: Object.freeze({
+    from: Object.freeze(["offered"]),
+    to: "confirmed",
+  }),
+  decline_offer: Object.freeze({
+    from: Object.freeze(["offered"]),
+    to: "offer_declined",
+  }),
+  expire_offer: Object.freeze({
+    from: Object.freeze(["offered"]),
+    to: "offer_expired",
+  }),
+  go_en_route: Object.freeze({
+    from: Object.freeze(["confirmed"]),
+    to: "en_route",
+  }),
+  mark_nearby: Object.freeze({
+    from: Object.freeze(["en_route"]),
+    to: "nearby",
+  }),
+  mark_arrived: Object.freeze({
+    from: Object.freeze(["en_route", "nearby"]),
+    to: "arrived",
+  }),
+  mark_met_customer: Object.freeze({
+    from: Object.freeze(["arrived"]),
+    to: "met_customer",
+  }),
+  mark_final_payment_pending: Object.freeze({
+    from: Object.freeze(["met_customer"]),
+    to: "final_payment_pending",
+  }),
+  confirm_final_payment: Object.freeze({
+    from: Object.freeze(["met_customer", "final_payment_pending"]),
+    to: "final_payment_confirmed",
+    requires: Object.freeze(["backend_official_payment_confirmation"]),
+  }),
+  start_work: Object.freeze({
+    from: Object.freeze(["final_payment_confirmed"]),
+    to: "work_started",
+    requires: Object.freeze(["current_state_recheck", "payments_worker_live_check"]),
+  }),
+  finish_work: Object.freeze({
+    from: Object.freeze(["work_started"]),
+    to: "work_finished",
+  }),
+  mark_separated: Object.freeze({
+    from: Object.freeze(["work_finished"]),
+    to: "separated",
+  }),
+  request_review: Object.freeze({
+    from: Object.freeze(["separated"]),
+    to: "under_review",
+  }),
+  mark_payout_pending: Object.freeze({
+    from: Object.freeze(["under_review"]),
+    to: "payout_pending",
+  }),
+  close_session: Object.freeze({
+    from: Object.freeze(["payout_pending"]),
+    to: "closed",
+  }),
+});
+
+export const MODEL_SESSION_HARD_RULES = Object.freeze({
+  startWorkVisibleOnlyInState: "final_payment_confirmed",
+  allowedActionsAreUiHintsOnly: true,
+  postTransitionMustRecheckServerState: true,
+  startWorkRequiresPaymentsWorkerLiveCheck: true,
+  telegramLinksRequireShortLivedSignedLinks: true,
+  flashUnlockMustNotUseSlipProofAlone: true,
+});
+
+function normalizeInput(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+export function normalizeSessionState(value) {
+  const state = normalizeInput(value);
+  if (!state) return "";
+  if (MODEL_SESSION_STATE_SET.has(state)) return state;
+  return MODEL_SESSION_STATE_ALIASES[state] || "";
+}
+
+export function resolveModelSessionPage(value) {
+  const state = normalizeSessionState(value);
+  if (!state) return null;
+
+  const page = MODEL_SESSION_PAGE_OWNERSHIP.find((entry) => entry.states.includes(state));
+  if (!page) return null;
+
+  return {
+    path: page.path,
+    state,
+    states: [...page.states],
+  };
+}
+
+export function getAllowedModelSessionActions(value) {
+  const state = normalizeSessionState(value);
+  return state ? [...(MODEL_SESSION_ALLOWED_ACTIONS[state] || [])] : [];
+}
+
+export function isModelSessionActionVisible(value, action) {
+  return getAllowedModelSessionActions(value).includes(normalizeInput(action));
+}
+
+export function resolveModelSessionTransition(action, currentState) {
+  const actionKey = normalizeInput(action);
+  const transition = MODEL_SESSION_TRANSITIONS[actionKey];
+  const state = normalizeSessionState(currentState);
+
+  if (!transition || !state) {
+    return { ok: false, reason: "unknown_transition", action: actionKey, state };
+  }
+
+  if (!transition.from.includes(state)) {
+    return {
+      ok: false,
+      reason: "invalid_current_state",
+      action: actionKey,
+      state,
+      required_states: [...transition.from],
+    };
+  }
+
+  return {
+    ok: true,
+    action: actionKey,
+    from: state,
+    to: transition.to,
+    requires: [...(transition.requires || [])],
+  };
+}

--- a/docs/architecture/MODEL_SESSION_CONTRACT_V1.md
+++ b/docs/architecture/MODEL_SESSION_CONTRACT_V1.md
@@ -1,0 +1,85 @@
+# Model Session Contract V1
+
+Status: additive contract only. This PR does not add runtime wiring, transition endpoints, route changes, deploy behavior, Telegram link issuance, or Flash validation.
+
+## Purpose
+
+Model Session Contract V1 gives later APIs and UI one source of truth for model-side lifecycle naming, route ownership, UI action hints, and future server transition validation.
+
+The contract keeps MMD canonical names as the source of truth. Legacy or review inputs may normalize into canonical states, but they are not added as production state names.
+
+## Canonical States
+
+The canonical state order is:
+
+1. `offered`
+2. `offer_declined`
+3. `offer_expired`
+4. `confirmed`
+5. `en_route`
+6. `nearby`
+7. `arrived`
+8. `met_customer`
+9. `final_payment_pending`
+10. `final_payment_confirmed`
+11. `work_started`
+12. `work_finished`
+13. `separated`
+14. `under_review`
+15. `payout_pending`
+16. `closed`
+
+## Normalized Inputs
+
+Accepted aliases normalize as follows:
+
+| Input | Canonical |
+| --- | --- |
+| `assigned` | `confirmed` |
+| `traveling` | `en_route` |
+| `met` | `met_customer` |
+| `met_client` | `met_customer` |
+| `payment_pending` | `final_payment_pending` |
+| `payment_confirmed` | `final_payment_confirmed` |
+| `working` | `work_started` |
+| `finished` | `work_finished` |
+| `review` | `under_review` |
+| `payout` | `payout_pending` |
+
+## Page Ownership
+
+| Page | States |
+| --- | --- |
+| `/model/session/offered` | `offered`, `offer_declined`, `offer_expired` |
+| `/model/session/assigned` | `confirmed` |
+| `/model/session/on-the-way` | `en_route`, `nearby` |
+| `/model/session/arrival-payment` | `arrived`, `met_customer`, `final_payment_pending`, `final_payment_confirmed` |
+| `/model/session/session-live` | `work_started` |
+| `/model/session/wrap-up` | `work_finished`, `separated`, `under_review`, `payout_pending`, `closed` |
+
+## UI Action Hints
+
+`allowed_actions[]` is a UI hint only. It must never be treated as the security gate for a POST transition.
+
+Start Work may be visible only when the current state is `final_payment_confirmed`.
+
+## Future Server Validation Rules
+
+Future POST transition handlers must re-check current server state immediately before writing a new state. They must not trust a page state, hidden field, client payload, or `allowed_actions[]`.
+
+The future `start_work` transition has these hard requirements:
+
+- current server state must be `final_payment_confirmed`
+- handler must call `payments-worker` live before writing `work_started`
+- slip/proof alone must never unlock the action
+
+## Future Link And Flash Rules
+
+Telegram deep links must be short-lived signed links, not plain session IDs.
+
+Flash unlock must never come from slip/proof alone.
+
+## Files
+
+- `admin-worker/src/modelSessionContractV1.js`
+- `admin-worker/model-session-contract-v1.test.mjs`


### PR DESCRIPTION
## Summary
- Add additive Model Session Contract V1 config for canonical states, aliases, page ownership, UI action hints, and future transition validation.
- Add focused contract tests for normalization, page ownership, Start Work visibility, and the future hard gate.
- Document the contract boundaries and future server/payment/Telegram/Flash rules.

## Scope
- Contract only.
- No runtime wiring.
- No transition endpoint.
- No route changes.
- No deploy.
- No immigrate-worker changes.

## Tests
- `node --check admin-worker/src/modelSessionContractV1.js`
- `node --test admin-worker/model-session-contract-v1.test.mjs`