### PR TITLE
Add Model Session Runtime V1a

### DIFF
--- a/admin-worker/model-session-runtime-v1a.test.mjs
+++ b/admin-worker/model-session-runtime-v1a.test.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "./src/index.js";
+
+const CONFIRM_KEY = "test_confirm_key_runtime_v1a";
+const BASE_ENV = {
+  CONFIRM_KEY,
+  AIRTABLE_API_KEY: "test_airtable_key",
+  AIRTABLE_BASE_ID: "appRuntime",
+  AIRTABLE_TABLE_SESSIONS: "sessions",
+};
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function base64UrlEncode(input) {
+  const bytes = new TextEncoder().encode(String(input || ""));
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+}
+
+function bytesToHex(buffer) {
+  return [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function hmacSha256Hex(message, secret) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return bytesToHex(await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(message)));
+}
+
+async function signedModelT(overrides = {}) {
+  const encoded = base64UrlEncode(JSON.stringify({
+    kind: "model_confirm",
+    role: "model",
+    session_id: "session_runtime_v1a",
+    payment_ref: "payment_runtime_v1a",
+    model_record_id: "model_runtime_v1a",
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    ...overrides,
+  }));
+  return `${encoded}.${await hmacSha256Hex(encoded, CONFIRM_KEY)}`;
+}
+
+function makeSession(state) {
+  return {
+    id: "recRuntimeSession",
+    fields: {
+      session_id: "session_runtime_v1a",
+      payment_ref: "payment_runtime_v1a",
+      model_record_id: "model_runtime_v1a",
+      state,
+    },
+  };
+}
+
+function installRuntimeFetchMock({ initialState = "offered", paymentTruth = null } = {}) {
+  const previousFetch = globalThis.fetch;
+  const calls = [];
+  let session = makeSession(initialState);
+
+  globalThis.fetch = async (input, init = {}) => {
+    const request = input instanceof Request ? input : new Request(String(input), init);
+    const url = new URL(request.url);
+    const method = request.method.toUpperCase();
+    calls.push({ method, url: request.url });
+
+    if (url.hostname === "payments.test") {
+      if (paymentTruth instanceof Response) return paymentTruth;
+      return jsonResponse(paymentTruth || { ok: true, final_payment_confirmed: false });
+    }
+
+    const parts = url.pathname.split("/").filter(Boolean);
+    const table = decodeURIComponent(parts[2] || parts.at(-1) || "");
+
+    if (table === "sessions" && method === "GET") {
+      return jsonResponse({ records: [session] });
+    }
+
+    if (table === "sessions" && method === "PATCH") {
+      const body = await request.json();
+      session = {
+        id: session.id,
+        fields: {
+          ...session.fields,
+          ...(body.fields || {}),
+        },
+      };
+      return jsonResponse({ id: session.id, fields: session.fields });
+    }
+
+    return jsonResponse({ records: [] }, 404);
+  };
+
+  return {
+    calls,
+    get session() {
+      return session;
+    },
+    restore() {
+      globalThis.fetch = previousFetch;
+    },
+  };
+}
+
+async function getCurrent(t, env = BASE_ENV) {
+  const url = t
+    ? `https://admin-worker.test/v1/model/session/current?t=${encodeURIComponent(t)}`
+    : "https://admin-worker.test/v1/model/session/current";
+  const response = await worker.fetch(new Request(url), env);
+  return { response, body: await response.json() };
+}
+
+async function postAction(t, action, options = {}) {
+  const response = await worker.fetch(
+    new Request("https://admin-worker.test/v1/model/session/action", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ t, action, ...(options.body || {}) }),
+    }),
+    options.env || BASE_ENV,
+  );
+  return { response, body: await response.json() };
+}
+
+test("GET /v1/model/session/current requires signed t before Airtable access", async () => {
+  const mock = installRuntimeFetchMock();
+  try {
+    const { response, body } = await getCurrent("");
+    assert.equal(response.status, 401);
+    assert.equal(body.error, "unauthorized");
+    assert.equal(mock.calls.length, 0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("invalid signed t returns 401 before Airtable access", async () => {
+  const mock = installRuntimeFetchMock();
+  try {
+    const { response, body } = await getCurrent("bad.access.value");
+    assert.equal(response.status, 401);
+    assert.equal(body.error, "unauthorized");
+    assert.equal(mock.calls.length, 0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("wrong model/session returns 403 after signed t resolves", async () => {
+  const t = await signedModelT({ model_record_id: "different_model_runtime_v1a" });
+  const mock = installRuntimeFetchMock({ initialState: "confirmed" });
+  try {
+    const { response, body } = await getCurrent(t);
+    assert.equal(response.status, 403);
+    assert.equal(body.error, "forbidden");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("GET /v1/model/session/current returns normalized state, page, route, and allowed actions", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "assigned" });
+  try {
+    const { response, body } = await getCurrent(t);
+    assert.equal(response.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.session.state, "assigned");
+    assert.equal(body.session.normalized_state, "confirmed");
+    assert.equal(body.session.page, "assigned");
+    assert.equal(body.session.route, "/model/session/assigned");
+    assert.deepEqual(body.session.allowed_actions, ["start_travel"]);
+    assert.equal(body.session.t, undefined);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("valid transition: offered + accept_job -> confirmed", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "offered" });
+  try {
+    const { response, body } = await postAction(t, "accept_job");
+    assert.equal(response.status, 200);
+    assert.equal(body.session.normalized_state, "confirmed");
+    assert.equal(mock.session.fields.state, "confirmed");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("valid transition: confirmed + start_travel -> en_route", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "confirmed" });
+  try {
+    const { response, body } = await postAction(t, "start_travel");
+    assert.equal(response.status, 200);
+    assert.equal(body.session.normalized_state, "en_route");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("legacy action alias: confirmed + go_en_route -> en_route", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "confirmed" });
+  try {
+    const { response, body } = await postAction(t, "go_en_route");
+    assert.equal(response.status, 200);
+    assert.equal(body.session.normalized_state, "en_route");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("valid transition: en_route + mark_arrived -> arrived", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "en_route" });
+  try {
+    const { response, body } = await postAction(t, "mark_arrived");
+    assert.equal(response.status, 200);
+    assert.equal(body.session.normalized_state, "arrived");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("valid transition: nearby + mark_arrived -> arrived", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "nearby" });
+  try {
+    const { response, body } = await postAction(t, "mark_arrived");
+    assert.equal(response.status, 200);
+    assert.equal(body.session.normalized_state, "arrived");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("valid transition: arrived + mark_met_customer -> met_customer", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "arrived" });
+  try {
+    const { response, body } = await postAction(t, "mark_met_customer");
+    assert.equal(response.status, 200);
+    assert.equal(body.session.normalized_state, "met_customer");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("valid transition: work_started + mark_work_finished -> work_finished", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "work_started" });
+  try {
+    const { response, body } = await postAction(t, "mark_work_finished");
+    assert.equal(response.status, 200);
+    assert.equal(body.session.normalized_state, "work_finished");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("valid transition: work_finished + confirm_separated -> separated", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "work_finished" });
+  try {
+    const { response, body } = await postAction(t, "confirm_separated");
+    assert.equal(response.status, 200);
+    assert.equal(body.session.normalized_state, "separated");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("invalid transition returns 409 invalid_transition", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "offered" });
+  try {
+    const { response, body } = await postAction(t, "mark_arrived");
+    assert.equal(response.status, 409);
+    assert.equal(body.error, "invalid_transition");
+    assert.equal(mock.session.fields.state, "offered");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("allowed_actions is a UI hint but POST revalidates current server state", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "confirmed" });
+  try {
+    const current = await getCurrent(t);
+    assert.deepEqual(current.body.session.allowed_actions, ["start_travel"]);
+
+    mock.session.fields.state = "offered";
+    const action = await postAction(t, "start_travel");
+    assert.equal(action.response.status, 409);
+    assert.equal(action.body.error, "invalid_transition");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("model cannot call confirm_final_payment", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "final_payment_pending" });
+  try {
+    const { response, body } = await postAction(t, "confirm_final_payment");
+    assert.equal(response.status, 409);
+    assert.equal(body.error, "invalid_transition");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("model cannot set final_payment_confirmed", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "final_payment_pending" });
+  try {
+    const { response, body } = await postAction(t, "set_final_payment_confirmed");
+    assert.equal(response.status, 409);
+    assert.equal(body.error, "invalid_transition");
+    assert.equal(mock.session.fields.state, "final_payment_pending");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("start_work is rejected when payment truth endpoint is unavailable", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({ initialState: "final_payment_confirmed" });
+  try {
+    const { response, body } = await postAction(t, "start_work");
+    assert.equal(response.status, 403);
+    assert.equal(body.error, "payment_gate_not_ready");
+    assert.equal(mock.session.fields.state, "final_payment_confirmed");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("start_work is rejected when live payment truth is not confirmed", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({
+    initialState: "final_payment_confirmed",
+    paymentTruth: { ok: true, final_payment_confirmed: false },
+  });
+  try {
+    const { response, body } = await postAction(t, "start_work", {
+      env: { ...BASE_ENV, MODEL_SESSION_PAYMENT_TRUTH_URL: "https://payments.test/final-payment/status" },
+    });
+    assert.equal(response.status, 403);
+    assert.equal(body.error, "payment_not_confirmed");
+    assert.equal(mock.session.fields.state, "final_payment_confirmed");
+  } finally {
+    mock.restore();
+  }
+});

--- a/admin-worker/model-session-runtime-v1a.test.mjs
+++ b/admin-worker/model-session-runtime-v1a.test.mjs
@@ -371,3 +371,28 @@ test("start_work is rejected when live payment truth is not confirmed", async ()
     mock.restore();
   }
 });
+
+test("start_work succeeds after live payment truth confirms final payment", async () => {
+  const t = await signedModelT();
+  const mock = installRuntimeFetchMock({
+    initialState: "final_payment_confirmed",
+    paymentTruth: { ok: true, final_payment_confirmed: true },
+  });
+  try {
+    const { response, body } = await postAction(t, "start_work", {
+      env: { ...BASE_ENV, MODEL_SESSION_PAYMENT_TRUTH_URL: "https://payments.test/final-payment/status" },
+    });
+    assert.equal(response.status, 200);
+    assert.equal(body.ok, true);
+    assert.equal(body.session.normalized_state, "work_started");
+    assert.equal(mock.session.fields.state, "work_started");
+
+    const paymentCallIndex = mock.calls.findIndex((call) => call.url === "https://payments.test/final-payment/status");
+    const patchCallIndex = mock.calls.findIndex((call) => call.method === "PATCH" && call.url.includes("/sessions/"));
+    assert.notEqual(paymentCallIndex, -1);
+    assert.notEqual(patchCallIndex, -1);
+    assert(paymentCallIndex < patchCallIndex);
+  } finally {
+    mock.restore();
+  }
+});

--- a/admin-worker/src/index.js
+++ b/admin-worker/src/index.js
@@ -25,6 +25,13 @@
 // ==========================================================
 
 import { demoLinksCreate, demoLinksGet } from "./routes/demo-links.js";
+import {
+  getAllowedModelSessionActions,
+  normalizeModelSessionAction,
+  normalizeSessionState,
+  resolveModelSessionPage,
+  resolveModelSessionTransition,
+} from "./modelSessionContractV1.js";
 
 const LOCK = "admin-worker-v2026-03-11-full";
 const AIRTABLE_API = "https://api.airtable.com/v0";
@@ -86,6 +93,25 @@ export const MODEL_SCHEMA_PATCH_V1_ROUTES = Object.freeze({
   privateFlashAuthorize: "/v1/model/private-flash/authorize",
 });
 const MODEL_SCHEMA_PATCH_V1_ROUTE_SET = new Set(Object.values(MODEL_SCHEMA_PATCH_V1_ROUTES));
+const MODEL_SESSION_CURRENT_PATH = "/v1/model/session/current";
+const MODEL_SESSION_ACTION_PATH = "/v1/model/session/action";
+const MODEL_SESSION_MODEL_BLOCKED_ACTIONS = new Set([
+  "confirm_final_payment",
+  "mark_final_payment_confirmed",
+  "set_final_payment_confirmed",
+  "mark_final_payment_pending",
+]);
+const MODEL_SESSION_MODEL_ALLOWED_ACTIONS = new Set([
+  "accept_job",
+  "decline_job",
+  "start_travel",
+  "mark_arrived",
+  "mark_met_customer",
+  "mark_work_finished",
+  "confirm_separated",
+  "start_work",
+  "go_en_route",
+]);
 
 export default {
   async fetch(req, env) {
@@ -126,6 +152,14 @@ export default {
 
     if (method === "POST" && MODEL_SCHEMA_PATCH_V1_ROUTE_SET.has(path)) {
       return withCors(await handleModelSchemaPatchV1Route(req, env, path), cors);
+    }
+
+    if (method === "GET" && path === MODEL_SESSION_CURRENT_PATH) {
+      return withCors(await handleModelSessionCurrent(req, env), cors);
+    }
+
+    if (method === "POST" && path === MODEL_SESSION_ACTION_PATH) {
+      return withCors(await handleModelSessionAction(req, env), cors);
     }
 
     // ------------------------------------------------------
@@ -1082,6 +1116,301 @@ function modelSchemaPatchJson(payload, status = 200) {
   const response = json(payload, status);
   response.headers.set("cache-control", "no-store");
   return response;
+}
+
+/* =========================
+   Model Session Runtime V1a
+========================= */
+function modelSessionJson(payload, status = 200) {
+  const response = json(payload, status);
+  response.headers.set("cache-control", "no-store");
+  return response;
+}
+
+function modelSessionTables(env = {}) {
+  return {
+    sessions: {
+      table: str(env.AIRTABLE_TABLE_SESSIONS || "sessions"),
+      fields: {
+        sessionId: str(env.AT_SESSIONS__SESSION_ID || "session_id"),
+        paymentRef: str(env.AT_SESSIONS__PAYMENT_REF || "payment_ref"),
+        state: str(env.AT_SESSIONS__STATE || env.AT_SESSIONS__STATE_FIELD || "state"),
+        status: str(env.AT_SESSIONS__STATUS || "status"),
+        modelRecordId: str(env.AT_SESSIONS__MODEL_RECORD_ID || "model_record_id"),
+        modelName: str(env.AT_SESSIONS__MODEL_NAME || "model_name"),
+      },
+    },
+  };
+}
+
+function readModelSessionT(req, body = null) {
+  const url = new URL(req.url);
+  return str(url.searchParams.get("t") || body?.t || "");
+}
+
+function base64UrlDecodeUtf8(input) {
+  const normalized = String(input || "").replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+function bytesToHex(buffer) {
+  return [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function hmacSha256Hex(message, secret) {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(String(secret || "")),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  return bytesToHex(await crypto.subtle.sign("HMAC", key, enc.encode(String(message || ""))));
+}
+
+function isModelSessionPayload(payload) {
+  if (!payload || payload.role !== "model") return false;
+  if (payload.kind === "model_confirm") return true;
+  if (payload.kind === "customer_invite" && payload.lane === "model_console") return true;
+  if (payload.kind === "model_session" || payload.kind === "model_console") return true;
+  return false;
+}
+
+async function verifyModelSessionT(t, env) {
+  const secret = str(env.CONFIRM_KEY || env.INTERNAL_TOKEN);
+  if (!secret || !t) return null;
+  const parts = String(t).split(".");
+  if (parts.length !== 2) return null;
+  const [encoded, signature] = parts;
+  if (!encoded || !signature) return null;
+  const expected = await hmacSha256Hex(encoded, secret);
+  if (signature !== expected) return null;
+
+  let payload = null;
+  try {
+    payload = JSON.parse(base64UrlDecodeUtf8(encoded));
+  } catch (_) {
+    return null;
+  }
+
+  const exp = Number(payload?.exp || 0);
+  if (exp && exp <= Math.floor(Date.now() / 1000)) return null;
+  if (!isModelSessionPayload(payload)) return null;
+  return payload;
+}
+
+function modelSessionAssignmentKeys(payload) {
+  return [
+    str(payload?.session_id),
+    str(payload?.immigration_id),
+    str(payload?.assignment_key),
+    str(payload?.payment_ref),
+  ].filter(Boolean);
+}
+
+function modelSessionFieldValues(fields, names) {
+  const values = [];
+  for (const name of names) {
+    const value = fields?.[name];
+    if (Array.isArray(value)) {
+      for (const item of value) values.push(str(item));
+    } else {
+      values.push(str(value));
+    }
+  }
+  return [...new Set(values.filter(Boolean))];
+}
+
+function exactFormula(field, value) {
+  return `{${field}}="${escapeFormulaValue(value)}"`;
+}
+
+function modelSessionLookupFormulas(env, payload) {
+  const tables = modelSessionTables(env);
+  const fields = tables.sessions.fields;
+  const formulas = [];
+  const sessionKeys = [str(payload?.session_id), str(payload?.immigration_id), str(payload?.assignment_key)].filter(Boolean);
+  const paymentRef = str(payload?.payment_ref);
+  for (const key of sessionKeys) formulas.push(exactFormula(fields.sessionId, key));
+  if (paymentRef) formulas.push(exactFormula(fields.paymentRef, paymentRef));
+  return [...new Set(formulas)];
+}
+
+async function modelSessionFindOne(env, tableName, filterByFormula) {
+  const params = new URLSearchParams();
+  params.set("pageSize", "1");
+  params.set("filterByFormula", filterByFormula);
+  const result = await airtableFetch(env, `/${encodeURIComponent(tableName)}?${params.toString()}`);
+  if (!result.ok) return { ok: false, detail: result };
+  const record = result.data?.records?.[0];
+  return { ok: true, record: record ? { id: record.id, fields: record.fields || {} } : null };
+}
+
+function modelSessionOwnsRecord(env, payload, record) {
+  const fields = record?.fields || {};
+  const tables = modelSessionTables(env);
+  const names = tables.sessions.fields;
+  const assignmentKeys = new Set(modelSessionAssignmentKeys(payload));
+  const sessionValues = modelSessionFieldValues(fields, [names.sessionId, names.paymentRef]);
+  if (sessionValues.length && !sessionValues.some((value) => assignmentKeys.has(value))) return false;
+
+  const payloadModelId = str(payload?.model_record_id || payload?.model_id);
+  const recordModelIds = modelSessionFieldValues(fields, [names.modelRecordId, "Model Record ID", "model_id", "Model"]);
+  if (payloadModelId && recordModelIds.length && !recordModelIds.includes(payloadModelId)) return false;
+
+  const payloadModelName = str(payload?.model_name).toLowerCase();
+  const recordModelNames = modelSessionFieldValues(fields, [names.modelName, "Model Name", "working_name"]).map((value) => value.toLowerCase());
+  if (payloadModelName && recordModelNames.length && !recordModelNames.includes(payloadModelName)) return false;
+
+  return true;
+}
+
+async function resolveModelSessionContext(req, env, body = null) {
+  const t = readModelSessionT(req, body);
+  const payload = await verifyModelSessionT(t, env);
+  if (!payload) return { ok: false, status: 401, error: "unauthorized" };
+
+  const tables = modelSessionTables(env);
+  const formulas = modelSessionLookupFormulas(env, payload);
+  if (!formulas.length) return { ok: false, status: 403, error: "forbidden" };
+
+  for (const formula of formulas) {
+    const found = await modelSessionFindOne(env, tables.sessions.table, formula);
+    if (!found.ok) return { ok: false, status: 503, error: "schema_not_ready" };
+    if (!found.record) continue;
+    if (!modelSessionOwnsRecord(env, payload, found.record)) {
+      return { ok: false, status: 403, error: "forbidden" };
+    }
+    return { ok: true, payload, session: found.record, tables };
+  }
+
+  return { ok: false, status: 403, error: "forbidden" };
+}
+
+function resolveModelSessionStateField(tables, fields) {
+  const preferred = [tables.sessions.fields.state, tables.sessions.fields.status, "state", "status"];
+  for (const field of [...new Set(preferred)]) {
+    if (Object.prototype.hasOwnProperty.call(fields || {}, field)) return field;
+  }
+  return "";
+}
+
+function modelSessionStateFromRecord(tables, record) {
+  const field = resolveModelSessionStateField(tables, record?.fields || {});
+  return { field, state: field ? str(record.fields[field]) : "" };
+}
+
+function modelSessionPageSlug(page) {
+  return str(page?.path).replace(/^\/model\/session\//, "").replace(/-/g, "_");
+}
+
+function modelSessionResponseSession(tables, record) {
+  const fields = record?.fields || {};
+  const stateInfo = modelSessionStateFromRecord(tables, record);
+  const normalized = normalizeSessionState(stateInfo.state);
+  const page = resolveModelSessionPage(normalized);
+  return {
+    session_id: str(fields[tables.sessions.fields.sessionId] || ""),
+    state: stateInfo.state,
+    normalized_state: normalized,
+    page: modelSessionPageSlug(page),
+    route: page?.path || "",
+    allowed_actions: getAllowedModelSessionActions(normalized),
+  };
+}
+
+async function handleModelSessionCurrent(req, env) {
+  const context = await resolveModelSessionContext(req, env);
+  if (!context.ok) return modelSessionJson({ ok: false, error: context.error }, context.status);
+
+  const stateInfo = modelSessionStateFromRecord(context.tables, context.session);
+  if (!stateInfo.field || !normalizeSessionState(stateInfo.state)) {
+    return modelSessionJson({ ok: false, error: "schema_not_ready" }, 503);
+  }
+
+  return modelSessionJson({
+    ok: true,
+    session: modelSessionResponseSession(context.tables, context.session),
+  });
+}
+
+async function verifyStartWorkPaymentTruth(env, session) {
+  const truthUrl = str(env.MODEL_SESSION_PAYMENT_TRUTH_URL || env.PAYMENTS_WORKER_FINAL_PAYMENT_STATUS_URL);
+  // Runtime V1a must fail closed until payments-worker exposes a stable final-payment truth endpoint.
+  if (!truthUrl) return { ok: false, error: "payment_gate_not_ready" };
+
+  const res = await fetch(truthUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(env.CONFIRM_KEY ? { "X-Confirm-Key": env.CONFIRM_KEY } : {}),
+    },
+    body: JSON.stringify({
+      session_id: session.session_id,
+      action: "start_work_preflight",
+    }),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok || data.ok === false) return { ok: false, error: "payment_not_confirmed" };
+  const confirmed =
+    data.final_payment_confirmed === true ||
+    data.official_final_payment_confirmed === true ||
+    normalizeSessionState(data.final_payment_status) === "final_payment_confirmed";
+  return confirmed ? { ok: true } : { ok: false, error: "payment_not_confirmed" };
+}
+
+async function handleModelSessionAction(req, env) {
+  const body = await safeJson(req);
+  const authContext = await resolveModelSessionContext(req, env, body);
+  if (!authContext.ok) return modelSessionJson({ ok: false, error: authContext.error }, authContext.status);
+
+  const action = normalizeModelSessionAction(body?.action);
+  if (!MODEL_SESSION_MODEL_ALLOWED_ACTIONS.has(str(body?.action)) && !MODEL_SESSION_MODEL_ALLOWED_ACTIONS.has(action)) {
+    return modelSessionJson({ ok: false, error: "invalid_transition" }, 409);
+  }
+  if (MODEL_SESSION_MODEL_BLOCKED_ACTIONS.has(action) || action.includes("final_payment_confirmed")) {
+    return modelSessionJson({ ok: false, error: "invalid_transition" }, 409);
+  }
+
+  const reread = await resolveModelSessionContext(req, env, body);
+  if (!reread.ok) return modelSessionJson({ ok: false, error: reread.error }, reread.status);
+
+  const stateInfo = modelSessionStateFromRecord(reread.tables, reread.session);
+  if (!stateInfo.field || !normalizeSessionState(stateInfo.state)) {
+    return modelSessionJson({ ok: false, error: "schema_not_ready" }, 503);
+  }
+
+  const transition = resolveModelSessionTransition(action, stateInfo.state);
+  if (!transition.ok) return modelSessionJson({ ok: false, error: "invalid_transition" }, 409);
+
+  if (transition.to === "final_payment_confirmed") {
+    return modelSessionJson({ ok: false, error: "invalid_transition" }, 409);
+  }
+
+  const currentSession = modelSessionResponseSession(reread.tables, reread.session);
+  if (action === "start_work") {
+    const payment = await verifyStartWorkPaymentTruth(env, currentSession);
+    if (!payment.ok) return modelSessionJson({ ok: false, error: payment.error }, 403);
+  }
+
+  const patch = { [stateInfo.field]: transition.to };
+  if (action === "decline_job" && str(body?.reason)) {
+    const reasonField = str(env.AT_SESSIONS__DECLINE_REASON || "decline_reason");
+    patch[reasonField] = str(body.reason).slice(0, 500);
+  }
+
+  const updated = await airtablePatchById(env, reread.tables.sessions.table, reread.session.id, patch);
+  if (!updated.ok) return modelSessionJson({ ok: false, error: "schema_not_ready" }, 503);
+
+  return modelSessionJson({
+    ok: true,
+    session: modelSessionResponseSession(reread.tables, { id: updated.id, fields: updated.fields }),
+  });
 }
 
 function schemaPatchError(code, status, message) {

--- a/admin-worker/src/modelSessionContractV1.js
+++ b/admin-worker/src/modelSessionContractV1.js
@@ -34,6 +34,14 @@ export const MODEL_SESSION_STATE_ALIASES = Object.freeze({
   payout: "payout_pending",
 });
 
+export const MODEL_SESSION_ACTION_ALIASES = Object.freeze({
+  go_en_route: "start_travel",
+  accept_offer: "accept_job",
+  decline_offer: "decline_job",
+  finish_work: "mark_work_finished",
+  mark_separated: "confirm_separated",
+});
+
 export const MODEL_SESSION_PAGE_OWNERSHIP = Object.freeze([
   Object.freeze({
     path: "/model/session/offered",
@@ -62,18 +70,18 @@ export const MODEL_SESSION_PAGE_OWNERSHIP = Object.freeze([
 ]);
 
 export const MODEL_SESSION_ALLOWED_ACTIONS = Object.freeze({
-  offered: Object.freeze(["accept_offer", "decline_offer"]),
+  offered: Object.freeze(["accept_job", "decline_job"]),
   offer_declined: Object.freeze([]),
   offer_expired: Object.freeze([]),
-  confirmed: Object.freeze(["go_en_route"]),
+  confirmed: Object.freeze(["start_travel"]),
   en_route: Object.freeze(["mark_nearby", "mark_arrived", "send_eta"]),
   nearby: Object.freeze(["mark_arrived", "send_eta"]),
   arrived: Object.freeze(["mark_met_customer", "report_delay"]),
   met_customer: Object.freeze(["mark_final_payment_pending", "request_payment_check"]),
   final_payment_pending: Object.freeze(["request_payment_check"]),
   final_payment_confirmed: Object.freeze(["start_work"]),
-  work_started: Object.freeze(["finish_work", "emergency"]),
-  work_finished: Object.freeze(["mark_separated"]),
+  work_started: Object.freeze(["mark_work_finished", "emergency"]),
+  work_finished: Object.freeze(["confirm_separated"]),
   separated: Object.freeze(["request_review"]),
   under_review: Object.freeze(["mark_payout_pending"]),
   payout_pending: Object.freeze(["close_session"]),
@@ -81,11 +89,11 @@ export const MODEL_SESSION_ALLOWED_ACTIONS = Object.freeze({
 });
 
 export const MODEL_SESSION_TRANSITIONS = Object.freeze({
-  accept_offer: Object.freeze({
+  accept_job: Object.freeze({
     from: Object.freeze(["offered"]),
     to: "confirmed",
   }),
-  decline_offer: Object.freeze({
+  decline_job: Object.freeze({
     from: Object.freeze(["offered"]),
     to: "offer_declined",
   }),
@@ -93,7 +101,7 @@ export const MODEL_SESSION_TRANSITIONS = Object.freeze({
     from: Object.freeze(["offered"]),
     to: "offer_expired",
   }),
-  go_en_route: Object.freeze({
+  start_travel: Object.freeze({
     from: Object.freeze(["confirmed"]),
     to: "en_route",
   }),
@@ -123,11 +131,11 @@ export const MODEL_SESSION_TRANSITIONS = Object.freeze({
     to: "work_started",
     requires: Object.freeze(["current_state_recheck", "payments_worker_live_check"]),
   }),
-  finish_work: Object.freeze({
+  mark_work_finished: Object.freeze({
     from: Object.freeze(["work_started"]),
     to: "work_finished",
   }),
-  mark_separated: Object.freeze({
+  confirm_separated: Object.freeze({
     from: Object.freeze(["work_finished"]),
     to: "separated",
   }),
@@ -162,6 +170,11 @@ function normalizeInput(value) {
     .replace(/^_+|_+$/g, "");
 }
 
+export function normalizeModelSessionAction(value) {
+  const action = normalizeInput(value);
+  return MODEL_SESSION_ACTION_ALIASES[action] || action;
+}
+
 export function normalizeSessionState(value) {
   const state = normalizeInput(value);
   if (!state) return "";
@@ -189,11 +202,11 @@ export function getAllowedModelSessionActions(value) {
 }
 
 export function isModelSessionActionVisible(value, action) {
-  return getAllowedModelSessionActions(value).includes(normalizeInput(action));
+  return getAllowedModelSessionActions(value).includes(normalizeModelSessionAction(action));
 }
 
 export function resolveModelSessionTransition(action, currentState) {
-  const actionKey = normalizeInput(action);
+  const actionKey = normalizeModelSessionAction(action);
   const transition = MODEL_SESSION_TRANSITIONS[actionKey];
   const state = normalizeSessionState(currentState);
 


### PR DESCRIPTION
## Summary
- Wire Contract V1 into admin-worker with `GET /v1/model/session/current` and `POST /v1/model/session/action`.
- Resolve model/session server-side from signed `t`, before Airtable access, and return current normalized state/page/action hints.
- Add model-triggered transition validation using Contract V1, with `start_travel` as canonical and `go_en_route` as an alias.
- Keep payment truth fail-closed for `start_work`: no configured live truth endpoint returns `payment_gate_not_ready`; unconfirmed live truth returns `payment_not_confirmed`.

## Scope
- admin-worker only.
- No deploy.
- No immigrate-worker, mmd-redirect-worker, webflow, telegram runtime, Private Flash runtime, package, lockfile, tmp, or route-worker changes.

## Tests
- `node --check admin-worker/src/modelSessionContractV1.js`
- `node --check admin-worker/src/index.js`
- `node --test admin-worker/model-session-contract-v1.test.mjs admin-worker/model-session-runtime-v1a.test.mjs`