### PR TITLE
Map auth worker access log and entitlement schemas

### DIFF
--- a/auth-worker/README.md
+++ b/auth-worker/README.md
@@ -1,0 +1,167 @@
+# MMD / SIGIL Access Core
+
+First-party auth starter for MMD Privé.
+
+This package replaces Memberstack as the future core identity layer while keeping Airtable ledger as the source of truth.
+
+## What it includes
+
+- Cloudflare Worker auth API
+- Passwordless 6-digit login code flow
+- HttpOnly secure session cookie
+- Airtable-backed members, identities, login codes, public auth sessions, entitlements, and access log
+- Membership tier derivation from `member_packages`
+- Webflow login page embed
+- Webflow protected-page gate script
+- Deploy checklist and Airtable schema
+
+## Core routes
+
+```text
+GET  /ping
+POST /v1/auth/request-code
+POST /v1/auth/verify-code
+GET  /v1/auth/me
+POST /v1/auth/logout
+POST /v1/admin/access/grant
+```
+
+## Worker ownership
+
+Keep `auth-worker` as a separate Cloudflare Worker inside the existing `mmd-workers` repo. Do not merge it into `admin-worker`, `payments-worker`, `chat-worker`, `events-worker`, `telegram-worker`, or `realtime-worker`.
+
+- `auth-worker` owns login, 6-digit code issuance/verification, the auth session cookie, `GET /v1/auth/me`, logout, and Webflow gate checks.
+- `admin-worker` owns internal admin approval flows and broader member/access operations.
+- `payments-worker` owns payments, `payment_ref`, `member_packages`, `points_ledger`, and package lifecycle.
+- `telegram-worker` may later deliver login codes, but must not own auth sessions.
+- Airtable's existing `MMD Commerce Operating System` base is the source of truth. Do not create a new base unless explicitly approved.
+- Do not reuse `Admin Sessions` for public member login. `Admin Sessions` belongs to admin auth only.
+- `auth-worker` writes public login sessions only to `MMD — Auth Sessions`.
+- `auth-worker` reads entitlement/access status from `MMD — Member Entitlements`.
+- `member_packages` remains the membership ledger source of truth.
+
+`POST /v1/admin/access/grant` remains in `auth-worker` for the MVP and is guarded by `ADMIN_BEARER`. Long term, admin ownership should move behind `admin-worker` or be proxied by `admin-worker`.
+
+## Airtable base and tables
+
+Use existing base: `MMD Commerce Operating System`.
+
+Reuse existing tables:
+
+- `Members`
+- `member_packages`
+- `packages`
+- `Payments`
+- `Sessions`
+- `MMD — Points Ledger`
+- `MMD — Member Entitlements`
+- `System — Access Log`
+
+Create only missing auth-specific tables:
+
+- `MMD — Auth Identities` (`tbl1AM0GE1tHzZXFD`)
+- `MMD — Auth Login Codes` (`tblbcWun1fUqXhzJZ`)
+- `MMD — Auth Sessions` (`tblgu2ZDdmu6bTJqc`)
+
+Do not create `access_grants`; use `MMD — Member Entitlements`. Do not create `audit_log`; use `System — Access Log`.
+
+## Member ID Rule
+
+`member_id` is an internal normalized SIGIL/MMD auth key. It must not assume or reuse Memberstack identity.
+
+Derivation order:
+
+- Use an existing MMD-owned member key if the `Members` record already has `member_id`, `Member ID`, or `auth_member_id`.
+- Otherwise, for existing Airtable `Members` rows, derive `member_id` as `mmd_rec_<AirtableRecordId>`.
+- For auth-created member rows, derive `member_id` from the normalized login identity as `mmd_<identity_type>_<sha256(identity_key)[0..16]>`, for example from normalized email, phone, or Telegram username.
+
+Memberstack remains optional backup only and is not a source for `member_id`, tier, package status, access, or session state.
+
+## Environment
+
+- `AIRTABLE_API_KEY`
+- `AIRTABLE_BASE_ID`
+- `AUTH_HMAC_SECRET`
+- `ADMIN_BEARER`
+- `ALLOWED_ORIGINS`
+- `WEB_BASE_URL`
+- `COOKIE_DOMAIN`
+- `MMD_AUTH_DEV_MODE`
+- `AIRTABLE_TABLE_MEMBERS`
+- `AIRTABLE_TABLE_MEMBER_PACKAGES`
+- `AIRTABLE_TABLE_PACKAGES`
+- `AIRTABLE_TABLE_PAYMENTS`
+- `AIRTABLE_TABLE_SESSIONS`
+- `AIRTABLE_TABLE_POINTS_LEDGER`
+- `AIRTABLE_TABLE_MEMBER_ENTITLEMENTS`
+- `AIRTABLE_TABLE_ACCESS_LOG`
+- `AIRTABLE_TABLE_AUTH_IDENTITIES`
+- `AIRTABLE_TABLE_AUTH_LOGIN_CODES`
+- `AIRTABLE_TABLE_AUTH_SESSIONS`
+- `AIRTABLE_ENTITLEMENT_MEMBERSTACK_ID_FIELD`
+- `AIRTABLE_ENTITLEMENT_MEMBER_EMAIL_FIELD`
+- `AIRTABLE_ENTITLEMENT_TELEGRAM_USER_ID_FIELD`
+- `AIRTABLE_ENTITLEMENT_TELEGRAM_USERNAME_FIELD`
+- `AIRTABLE_ENTITLEMENT_LINE_USER_ID_FIELD`
+- `AIRTABLE_ENTITLEMENT_ACCESS_STATUS_FIELDS`
+- `AIRTABLE_ENTITLEMENT_MEMBER_STATUS_FIELDS`
+- `AIRTABLE_ENTITLEMENT_ACTIVE_VALUES`
+- `AIRTABLE_ENTITLEMENT_BLOCKED_MEMBER_STATUS_VALUES`
+- `AIRTABLE_ENTITLEMENT_RESOURCE_FIELDS`
+- `AIRTABLE_ENTITLEMENT_TIER_FIELDS`
+- `AIRTABLE_ENTITLEMENT_EXPIRES_AT_FIELDS`
+- `AIRTABLE_ACCESS_LOG_EVENT_ID_FIELD`
+- `AIRTABLE_ACCESS_LOG_ACTION_FIELD`
+- `AIRTABLE_ACCESS_LOG_RESULT_FIELD`
+- `AIRTABLE_ACCESS_LOG_MEMBER_FIELD`
+- `AIRTABLE_ACCESS_LOG_METADATA_FIELD`
+- `AIRTABLE_ACCESS_LOG_IP_HASH_FIELD`
+- `AIRTABLE_ACCESS_LOG_USER_AGENT_FIELD`
+- `AIRTABLE_ACCESS_LOG_CREATED_AT_FIELD`
+
+`MMD_AUTH_DEV_MODE=true` returns `dev_code` from `POST /v1/auth/request-code` for local testing only. Keep it `false` in production.
+
+## Access log mapping
+
+`System — Access Log` is mapped without requiring an `access_log_id` field. The MVP write uses:
+
+- `Event ID`
+- `Action`
+- `Result`
+
+`Result` is normalized to `success` or `fail` only. Additional audit details are intentionally optional. Set the `AIRTABLE_ACCESS_LOG_*_FIELD` variables only after those fields exist in Airtable. Access-log writes are non-blocking; auth must continue even if this table rejects a write.
+
+## Entitlement mapping
+
+`MMD — Member Entitlements` is not assumed to have a `member_id` field. Entitlements are looked up from the full member/profile identity context using real public/member identity fields only:
+
+- `memberstack_id`
+- `member_email`
+- `telegram_user_id`
+- `telegram_username`
+- `line_user_id`
+
+Current auth-facing filters:
+
+| Concept | Current mapping |
+|---|---|
+| access status | `access_status`; only `active` and `grace` pass |
+| member status | `member_status`; `inactive` and `blocked` are rejected |
+| expiry | `expire_at`; blank or future passes |
+| package/tier | `package_code`, `tier`, or `min_tier` |
+| resource/scope | `resource_key`, `access_key`, or `package_code` |
+
+If Airtable rejects the entitlement lookup because a mapped field is not present, `/v1/auth/me` must fail safe and return empty `entitlements`/`grants`.
+
+## Intended architecture
+
+```text
+Webflow page
+  -> MMD Gate Script
+  -> mmd-auth-worker
+  -> Airtable ledger/member tables
+  -> profile/tier/access response
+```
+
+Memberstack is no longer required for new logins.
+Memberstack can remain as an optional backup, but it is not the source of truth for tier or status.

--- a/auth-worker/scripts/smoke-test.mjs
+++ b/auth-worker/scripts/smoke-test.mjs
@@ -17,6 +17,12 @@ try {
     assert(data?.ok === true, "expected ok=true");
   });
 
+  await step("GET /v1/auth/me unauthenticated", async () => {
+    const { response, data } = await request("/v1/auth/me");
+    assert(response.status === 401, `expected 401, got ${response.status}`);
+    assert(data?.authenticated === false, "expected authenticated=false");
+  });
+
   let devCode = "";
   await step("POST /v1/auth/request-code", async () => {
     const { response, data } = await request("/v1/auth/request-code", {
@@ -49,6 +55,19 @@ try {
     assert(data?.ok === true, "expected ok=true");
     assert(data?.authenticated === true, "expected authenticated=true");
     assert(data?.profile, "expected profile");
+    assert(data.profile.member_id, "expected profile.member_id");
+    assert(data.profile.status, "expected profile.status");
+    assert(Array.isArray(data.profile.entitlements), "expected profile.entitlements array");
+    assert(Array.isArray(data.profile.grants), "expected profile.grants array");
+  });
+
+  await step("GET /v1/auth/me grants shape", async () => {
+    const { response, data } = await request("/v1/auth/me", {
+      headers: { Cookie: sessionCookie },
+    });
+    assert(response.ok, `expected 2xx, got ${response.status}`);
+    assert(data?.authenticated === true, "expected authenticated=true");
+    assert(Array.isArray(data?.profile?.grants), "expected grants array");
   });
 
   await step("POST /v1/auth/logout", async () => {

--- a/auth-worker/scripts/smoke-test.mjs
+++ b/auth-worker/scripts/smoke-test.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+const baseUrl = normalizeBaseUrl(process.env.AUTH_WORKER_BASE_URL);
+const testIdentity = String(process.env.TEST_IDENTITY || "").trim();
+
+if (!baseUrl || !testIdentity) {
+  console.error("Usage: AUTH_WORKER_BASE_URL=https://auth.example.com TEST_IDENTITY=test@example.com node auth-worker/scripts/smoke-test.mjs");
+  process.exit(2);
+}
+
+const steps = [];
+
+try {
+  await step("GET /ping", async () => {
+    const { response, data } = await request("/ping");
+    assert(response.ok, `expected 2xx, got ${response.status}`);
+    assert(data?.ok === true, "expected ok=true");
+  });
+
+  let devCode = "";
+  await step("POST /v1/auth/request-code", async () => {
+    const { response, data } = await request("/v1/auth/request-code", {
+      method: "POST",
+      body: { identifier: testIdentity },
+    });
+    assert(response.ok, `expected 2xx, got ${response.status}`);
+    assert(data?.ok === true, "expected ok=true");
+    assert(/^\d{6}$/.test(String(data?.dev_code || "")), "expected 6-digit dev_code; confirm MMD_AUTH_DEV_MODE=true");
+    devCode = data.dev_code;
+  });
+
+  let sessionCookie = "";
+  await step("POST /v1/auth/verify-code", async () => {
+    const { response, data, setCookie } = await request("/v1/auth/verify-code", {
+      method: "POST",
+      body: { identifier: testIdentity, code: devCode },
+    });
+    assert(response.ok, `expected 2xx, got ${response.status}`);
+    assert(data?.ok === true, "expected ok=true");
+    sessionCookie = cookieHeaderFromSetCookie(setCookie);
+    assert(sessionCookie, "expected Set-Cookie session header");
+  });
+
+  await step("GET /v1/auth/me with cookie", async () => {
+    const { response, data } = await request("/v1/auth/me", {
+      headers: { Cookie: sessionCookie },
+    });
+    assert(response.ok, `expected 2xx, got ${response.status}`);
+    assert(data?.ok === true, "expected ok=true");
+    assert(data?.authenticated === true, "expected authenticated=true");
+    assert(data?.profile, "expected profile");
+  });
+
+  await step("POST /v1/auth/logout", async () => {
+    const { response, data } = await request("/v1/auth/logout", {
+      method: "POST",
+      headers: { Cookie: sessionCookie },
+    });
+    assert(response.ok, `expected 2xx, got ${response.status}`);
+    assert(data?.ok === true, "expected ok=true");
+  });
+
+  await step("GET /v1/auth/me after logout", async () => {
+    const { response, data } = await request("/v1/auth/me", {
+      headers: { Cookie: sessionCookie },
+    });
+    assert(response.status === 401, `expected 401, got ${response.status}`);
+    assert(data?.authenticated === false, "expected authenticated=false");
+  });
+
+  for (const item of steps) {
+    console.log(`PASS ${item}`);
+  }
+} catch (error) {
+  for (const item of steps) {
+    console.log(`PASS ${item}`);
+  }
+  console.error(`FAIL ${error.message}`);
+  process.exit(1);
+}
+
+async function step(name, fn) {
+  await fn();
+  steps.push(name);
+}
+
+async function request(path, options = {}) {
+  const headers = {
+    Accept: "application/json",
+    ...(options.headers || {}),
+  };
+  const init = {
+    method: options.method || "GET",
+    headers,
+  };
+
+  if (options.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(options.body);
+  }
+
+  const response = await fetch(`${baseUrl}${path}`, init);
+  const text = await response.text();
+  const data = parseJson(text);
+
+  if (!response.ok && !data) {
+    throw new Error(`${init.method} ${path} returned ${response.status}`);
+  }
+
+  return {
+    response,
+    data,
+    setCookie: getSetCookie(response.headers),
+  };
+}
+
+function getSetCookie(headers) {
+  if (typeof headers.getSetCookie === "function") {
+    return headers.getSetCookie().join(", ");
+  }
+  return headers.get("set-cookie") || "";
+}
+
+function cookieHeaderFromSetCookie(setCookie) {
+  const firstCookie = String(setCookie || "").split(/,(?=\s*[^;,]+=)/)[0] || "";
+  const cookiePair = firstCookie.split(";")[0].trim();
+  return cookiePair && cookiePair.includes("=") ? cookiePair : "";
+}
+
+function parseJson(text) {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeBaseUrl(value) {
+  const raw = String(value || "").trim();
+  return raw ? raw.replace(/\/+$/, "") : "";
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}

--- a/auth-worker/src/index.js
+++ b/auth-worker/src/index.js
@@ -1,0 +1,748 @@
+// MMD / SIGIL Access Core
+// First-party passwordless auth for Webflow + Cloudflare Workers + Airtable.
+// Endpoints:
+//   GET  /ping
+//   POST /v1/auth/request-code
+//   POST /v1/auth/verify-code
+//   GET  /v1/auth/me
+//   POST /v1/auth/logout
+//   POST /v1/admin/access/grant
+
+const DEFAULT_ALLOWED_ORIGINS = [
+  "https://mmdbkk.com",
+  "https://mmdprive.webflow.io",
+  "https://mmdprive.com",
+];
+
+const TIER_RANK = {
+  guest: 0,
+  guest_pass: 1,
+  standard: 2,
+  lite: 2,
+  premium: 3,
+  vip: 4,
+  svip: 5,
+  blackcard: 6,
+};
+
+export default {
+  async fetch(request, env, ctx) {
+    try {
+      if (request.method === "OPTIONS") return new Response(null, { status: 204, headers: corsHeaders(request, env) });
+
+      const url = new URL(request.url);
+      const path = url.pathname.replace(/\/+$/, "") || "/";
+
+      if (path === "/health" || path === "/ping") {
+        return json(request, env, 200, { ok: true, service: "mmd-auth-worker", time: nowIso() });
+      }
+
+      if (path === "/v1/auth/request-code" && request.method === "POST") {
+        return handleRequestCode(request, env);
+      }
+
+      if (path === "/v1/auth/verify-code" && request.method === "POST") {
+        return handleVerifyCode(request, env);
+      }
+
+      if (path === "/v1/auth/me" && request.method === "GET") {
+        return handleMe(request, env);
+      }
+
+      if (path === "/v1/auth/logout" && request.method === "POST") {
+        return handleLogout(request, env);
+      }
+
+      if (path === "/v1/admin/access/grant" && request.method === "POST") {
+        return handleAdminGrant(request, env);
+      }
+
+      return json(request, env, 404, { ok: false, error: { code: "NOT_FOUND", message: "Route not found" } });
+    } catch (error) {
+      return json(request, env, 500, {
+        ok: false,
+        error: { code: "INTERNAL_ERROR", message: safeErrorMessage(error) },
+      });
+    }
+  },
+};
+
+async function handleRequestCode(request, env) {
+  const body = await readJson(request);
+  const identity = normalizeIdentity(body);
+  if (!identity.ok) {
+    return json(request, env, 400, { ok: false, error: { code: "IDENTITY_REQUIRED", message: "Provide email, phone, or telegram_username." } });
+  }
+
+  const member = await findOrCreateMember(env, identity);
+  await upsertIdentity(env, member.member_id, identity);
+
+  const code = randomDigits(toInt(env.AUTH_CODE_LENGTH, 6));
+  const nonce = randomId("nonce");
+  const codeHash = await hashSecret(env, `${identity.identity_key}:${nonce}:${code}`);
+  const ttlMinutes = toInt(env.AUTH_CODE_TTL_MINUTES, 10);
+  const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000).toISOString();
+
+  const codeId = randomId("code");
+  await airtableCreate(env, table(env, "AUTH_LOGIN_CODES"), compactFields({
+    code_id: codeId,
+    member_id: member.member_id,
+    identity_type: identity.type,
+    identity_value: identity.value,
+    identity_key: identity.identity_key,
+    code_hash: codeHash,
+    nonce,
+    attempts: 0,
+    expires_at: expiresAt,
+    consumed_at: "",
+    requester_ip_hash: await hashClientValue(env, getClientIp(request)),
+    user_agent: request.headers.get("user-agent") || "",
+    created_at: nowIso(),
+  }));
+
+  await audit(env, request, member.member_id, "auth.request_code", "success", { identity_type: identity.type, identity_key: identity.identity_key });
+
+  const payload = {
+    ok: true,
+    delivery_mode: "manual_or_provider",
+    identity_type: identity.type,
+    expires_at: expiresAt,
+    message: "Login code created. Connect email/SMS/Telegram delivery for production, or use dev_code while testing.",
+  };
+
+  if (String(env.MMD_AUTH_DEV_MODE || "").toLowerCase() === "true") {
+    payload.dev_code = code;
+  }
+
+  return json(request, env, 200, payload);
+}
+
+async function handleVerifyCode(request, env) {
+  const body = await readJson(request);
+  const identity = normalizeIdentity(body);
+  const code = String(body.code || "").trim();
+  const codeLength = toInt(env.AUTH_CODE_LENGTH, 6);
+
+  if (!identity.ok || !new RegExp(`^\\d{${codeLength}}$`).test(code)) {
+    return json(request, env, 400, { ok: false, error: { code: "INVALID_CODE", message: `Provide a valid identity and ${codeLength}-digit code.` } });
+  }
+
+  const maxAttempts = toInt(env.AUTH_MAX_CODE_ATTEMPTS, 5);
+  const records = await airtableList(env, table(env, "AUTH_LOGIN_CODES"), {
+    filterByFormula: `AND({identity_key}=${formulaString(identity.identity_key)}, OR({consumed_at}=BLANK(), {consumed_at}=''))`,
+    sort: [{ field: "created_at", direction: "desc" }],
+    maxRecords: 10,
+  });
+
+  let matched = null;
+  const now = Date.now();
+
+  for (const record of records) {
+    const fields = record.fields || {};
+    const expiresAt = Date.parse(fields.expires_at || "");
+    const attempts = Number(fields.attempts || 0);
+    if (!expiresAt || expiresAt < now || attempts >= maxAttempts) continue;
+
+    const expected = await hashSecret(env, `${identity.identity_key}:${fields.nonce}:${code}`);
+    if (safeEqual(expected, String(fields.code_hash || ""))) {
+      matched = record;
+      break;
+    }
+
+    await airtableUpdate(env, table(env, "AUTH_LOGIN_CODES"), record.id, { attempts: attempts + 1 });
+  }
+
+  if (!matched) {
+    await audit(env, request, "", "auth.verify_code", "error", { identity_key: identity.identity_key, reason: "no_match" });
+    return json(request, env, 401, { ok: false, error: { code: "CODE_REJECTED", message: "Code is invalid, expired, or already used." } });
+  }
+
+  const matchedFields = matched.fields || {};
+  await airtableUpdate(env, table(env, "AUTH_LOGIN_CODES"), matched.id, { consumed_at: nowIso() });
+
+  const memberRecord = await findMemberById(env, matchedFields.member_id);
+  if (!memberRecord) {
+    return json(request, env, 404, { ok: false, error: { code: "MEMBER_NOT_FOUND", message: "Member record was not found." } });
+  }
+
+  const sessionToken = randomToken(32);
+  const sessionHash = await hashSecret(env, `session:${sessionToken}`);
+  const sessionId = randomId("sess");
+  const expiresAt = new Date(Date.now() + toInt(env.AUTH_SESSION_TTL_DAYS, 30) * 24 * 60 * 60 * 1000).toISOString();
+
+  await airtableCreate(env, table(env, "AUTH_SESSIONS"), compactFields({
+    session_id: sessionId,
+    member_id: matchedFields.member_id,
+    session_hash: sessionHash,
+    created_at: nowIso(),
+    expires_at: expiresAt,
+    revoked_at: "",
+    ip_hash: await hashClientValue(env, getClientIp(request)),
+    user_agent: request.headers.get("user-agent") || "",
+  }));
+
+  await updateMemberLastLogin(env, memberRecord);
+
+  const profile = await buildProfile(env, memberRecord.fields || {});
+  await audit(env, request, matchedFields.member_id, "auth.login", "success", { session_id: sessionId });
+
+  return json(request, env, 200, { ok: true, profile, expires_at: expiresAt }, {
+    "Set-Cookie": makeSessionCookie(env, sessionToken, expiresAt),
+  });
+}
+
+async function handleMe(request, env) {
+  const session = await readSession(request, env);
+  if (!session.ok) {
+    return json(request, env, 401, {
+      ok: false,
+      authenticated: false,
+      error: { code: session.code || "SESSION_REQUIRED", message: session.message || "Login required." },
+    });
+  }
+
+  return json(request, env, 200, {
+    ok: true,
+    authenticated: true,
+    profile: session.profile,
+    session: {
+      expires_at: session.session_fields.expires_at,
+    },
+  });
+}
+
+async function handleLogout(request, env) {
+  const cookie = getCookie(request, env.AUTH_COOKIE_NAME || "mmd_auth");
+  if (cookie) {
+    const sessionHash = await hashSecret(env, `session:${cookie}`);
+    const records = await airtableList(env, table(env, "AUTH_SESSIONS"), {
+      filterByFormula: `AND({session_hash}=${formulaString(sessionHash)}, OR({revoked_at}=BLANK(), {revoked_at}=''))`,
+      maxRecords: 1,
+    });
+    if (records[0]) await airtableUpdate(env, table(env, "AUTH_SESSIONS"), records[0].id, { revoked_at: nowIso() });
+  }
+
+  return json(request, env, 200, { ok: true }, {
+    "Set-Cookie": clearSessionCookie(env),
+  });
+}
+
+async function handleAdminGrant(request, env) {
+  const auth = request.headers.get("authorization") || "";
+  if (!env.ADMIN_BEARER || auth !== `Bearer ${env.ADMIN_BEARER}`) {
+    return json(request, env, 401, { ok: false, error: { code: "ADMIN_REQUIRED", message: "Admin bearer token required." } });
+  }
+
+  const body = await readJson(request);
+  const memberId = String(body.member_id || "").trim();
+  const resourceKey = String(body.resource_key || "").trim();
+  const minTier = String(body.min_tier || "").trim().toLowerCase();
+  const expiresAt = body.expires_at ? String(body.expires_at) : "";
+
+  if (!memberId || !resourceKey) {
+    return json(request, env, 400, { ok: false, error: { code: "GRANT_REQUIRED", message: "member_id and resource_key are required." } });
+  }
+
+  const entitlementId = randomId("ent");
+  await airtableCreate(env, table(env, "MEMBER_ENTITLEMENTS"), compactFields({
+    entitlement_id: entitlementId,
+    member_id: memberId,
+    resource_key: resourceKey,
+    min_tier: minTier,
+    status: "active",
+    starts_at: nowIso(),
+    expires_at: expiresAt,
+    note: String(body.note || ""),
+    created_at: nowIso(),
+  }));
+
+  await audit(env, request, memberId, "admin.access_grant", "success", { resource_key: resourceKey, min_tier: minTier });
+  return json(request, env, 200, { ok: true, entitlement_id: entitlementId });
+}
+
+async function readSession(request, env) {
+  const token = getCookie(request, env.AUTH_COOKIE_NAME || "mmd_auth");
+  if (!token) return { ok: false, code: "SESSION_REQUIRED", message: "Login required." };
+
+  const sessionHash = await hashSecret(env, `session:${token}`);
+  const records = await airtableList(env, table(env, "AUTH_SESSIONS"), {
+    filterByFormula: `AND({session_hash}=${formulaString(sessionHash)}, OR({revoked_at}=BLANK(), {revoked_at}=''))`,
+    maxRecords: 1,
+  });
+
+  const session = records[0];
+  if (!session) return { ok: false, code: "SESSION_NOT_FOUND", message: "Session not found." };
+
+  const fields = session.fields || {};
+  if (Date.parse(fields.expires_at || "") < Date.now()) {
+    return { ok: false, code: "SESSION_EXPIRED", message: "Session expired." };
+  }
+
+  const memberRecord = await findMemberById(env, fields.member_id);
+  if (!memberRecord) return { ok: false, code: "MEMBER_NOT_FOUND", message: "Member not found." };
+
+  const profile = await buildProfile(env, memberRecord.fields || {});
+  return { ok: true, profile, session_record: session, session_fields: fields };
+}
+
+async function buildProfile(env, memberFields) {
+  const memberId = String(memberFields.member_id || "");
+  const email = normalizeEmail(memberFields.email || "");
+  const entitlements = await deriveMemberEntitlements(env, memberId);
+  const packageAccess = await derivePackageAccess(env, memberFields);
+
+  return {
+    member_id: memberId,
+    name: memberFields.name || "",
+    email,
+    phone: memberFields.phone || "",
+    telegram_username: memberFields.telegram_username || "",
+    tier: packageAccess.tier,
+    status: packageAccess.status,
+    expire_at: packageAccess.expire_at,
+    package_code: packageAccess.package_code,
+    tier_rank: TIER_RANK[packageAccess.tier] || 0,
+    entitlements,
+    grants: entitlements,
+  };
+}
+
+async function derivePackageAccess(env, memberFields) {
+  const email = normalizeEmail(memberFields.email || "");
+  if (!email) return { tier: "guest", status: "guest", expire_at: "", package_code: "" };
+
+  const records = await airtableList(env, table(env, "MEMBER_PACKAGES"), {
+    filterByFormula: `LOWER({member_email})=${formulaString(email)}`,
+    sort: [{ field: "end_date", direction: "desc" }],
+    maxRecords: 20,
+  });
+
+  const now = Date.now();
+  let best = null;
+  for (const record of records) {
+    const f = record.fields || {};
+    if (String(f.status || "").toLowerCase() !== "active") continue;
+    const endAt = Date.parse(f.end_date || "");
+    if (!endAt || endAt < now) continue;
+    const tier = tierFromPackageCode(f.package_code || f.tier || "");
+    const rank = TIER_RANK[tier] || 0;
+    if (!best || rank > best.rank || endAt > best.endAt) {
+      best = { tier, rank, endAt, package_code: f.package_code || f.tier || "", expire_at: f.end_date || "" };
+    }
+  }
+
+  if (!best) return { tier: "guest", status: "no_active_membership", expire_at: "", package_code: "" };
+  return { tier: best.tier, status: "active", expire_at: best.expire_at, package_code: best.package_code };
+}
+
+async function deriveMemberEntitlements(env, memberId) {
+  if (!memberId) return [];
+  let records = [];
+  try {
+    records = await airtableList(env, table(env, "MEMBER_ENTITLEMENTS"), {
+      filterByFormula: `AND({member_id}=${formulaString(memberId)}, {status}='active')`,
+      maxRecords: 100,
+    });
+  } catch (error) {
+    console.warn("Member entitlement read skipped", safeAirtableReadDebug(table(env, "MEMBER_ENTITLEMENTS"), error));
+    return [];
+  }
+  const now = Date.now();
+  return records
+    .map((r) => r.fields || {})
+    .filter((f) => {
+      const starts = f.starts_at ? Date.parse(f.starts_at) : 0;
+      const expires = f.expires_at ? Date.parse(f.expires_at) : Number.MAX_SAFE_INTEGER;
+      return starts <= now && expires >= now;
+    })
+    .map((f) => ({ resource_key: f.resource_key || "", min_tier: f.min_tier || "", expires_at: f.expires_at || "" }))
+    .filter((g) => g.resource_key);
+}
+
+function tierFromPackageCode(value) {
+  const raw = String(value || "").toLowerCase();
+  if (raw.includes("black") || raw.includes("svip")) return raw.includes("black") ? "blackcard" : "svip";
+  if (raw.includes("vip")) return "vip";
+  if (raw.includes("premium")) return "premium";
+  if (raw.includes("standard") || raw.includes("lite")) return "standard";
+  if (raw.includes("7") || raw.includes("guest")) return "guest_pass";
+  return "guest";
+}
+
+async function findOrCreateMember(env, identity) {
+  const identityRecord = await findIdentity(env, identity.identity_key);
+  if (identityRecord?.fields?.member_id) {
+    const memberRecord = await findMemberById(env, identityRecord.fields.member_id);
+    if (memberRecord) return memberRecord.fields;
+  }
+
+  let memberRecord = null;
+  if (identity.type === "email") {
+    memberRecord = await airtableFirst(env, table(env, "MEMBERS"), `LOWER({Contact Email})=${formulaString(identity.value)}`);
+  } else if (identity.type === "phone") {
+    memberRecord = await airtableFirst(env, table(env, "MEMBERS"), `{Phone Number}=${formulaString(identity.value)}`);
+  } else if (identity.type === "telegram") {
+    memberRecord = await airtableFirst(env, table(env, "MEMBERS"), `{telegram_username}=${formulaString(identity.value)}`);
+  }
+
+  if (memberRecord) return normalizeMemberRecord(memberRecord);
+
+  const memberId = await memberIdFromIdentity(identity);
+  const fields = compactFields({
+    member_id: memberId,
+    "Full Name": "",
+    "Contact Email": identity.type === "email" ? identity.value : "",
+    "Phone Number": identity.type === "phone" ? identity.value : "",
+    telegram_username: identity.type === "telegram" ? identity.value : "",
+    "Date Joined": todayDate(),
+  });
+  await airtableCreate(env, table(env, "MEMBERS"), fields);
+  return {
+    ...fields,
+    member_id: memberId,
+    name: fields["Full Name"] || "",
+    email: normalizeEmail(fields["Contact Email"] || ""),
+    phone: fields["Phone Number"] || "",
+  };
+}
+
+async function upsertIdentity(env, memberId, identity) {
+  const existing = await findIdentity(env, identity.identity_key);
+  if (existing) {
+    await airtableUpdate(env, table(env, "AUTH_IDENTITIES"), existing.id, {
+      member_id: memberId,
+      last_seen_at: nowIso(),
+    });
+    return existing;
+  }
+
+  return airtableCreate(env, table(env, "AUTH_IDENTITIES"), {
+    identity_id: randomId("ident"),
+    member_id: memberId,
+    identity_type: identity.type,
+    identity_value: identity.value,
+    identity_key: identity.identity_key,
+    status: "active",
+    created_at: nowIso(),
+    last_seen_at: nowIso(),
+  });
+}
+
+async function findIdentity(env, identityKey) {
+  return airtableFirst(env, table(env, "AUTH_IDENTITIES"), `{identity_key}=${formulaString(identityKey)}`);
+}
+
+async function findMemberById(env, memberId) {
+  const id = String(memberId || "");
+  if (id.startsWith("mmd_rec_")) {
+    const recordId = id.slice("mmd_rec_".length);
+    const record = await airtableGet(env, table(env, "MEMBERS"), recordId);
+    return record ? { ...record, fields: normalizeMemberRecord(record) } : null;
+  }
+  const record = await airtableFirst(env, table(env, "MEMBERS"), `{member_id}=${formulaString(id)}`);
+  return record ? { ...record, fields: normalizeMemberRecord(record) } : null;
+}
+
+function normalizeMemberRecord(record) {
+  const fields = record.fields || {};
+  const memberId = String(fields.member_id || fields["Member ID"] || fields.auth_member_id || "");
+  return {
+    ...fields,
+    member_id: memberId || `mmd_rec_${String(record.id || "")}`,
+    name: fields.name || fields["Full Name"] || fields["Full Name (Display)"] || fields["Full Name (EN)"] || "",
+    email: normalizeEmail(fields.email || fields["Contact Email"] || ""),
+    phone: fields.phone || fields["Phone Number"] || "",
+    telegram_username: fields.telegram_username || "",
+  };
+}
+
+async function memberIdFromIdentity(identity) {
+  const digest = await sha256Hex(identity.identity_key);
+  return `mmd_${identity.type}_${digest.slice(0, 16)}`;
+}
+
+async function updateMemberLastLogin(env, memberRecord) {
+  const fields = memberRecord.fields || {};
+  const updates = {};
+  if (Object.prototype.hasOwnProperty.call(fields, "last_login_at")) updates.last_login_at = nowIso();
+  if (Object.prototype.hasOwnProperty.call(fields, "Last Login At")) updates["Last Login At"] = nowIso();
+  if (Object.keys(updates).length) await airtableUpdate(env, table(env, "MEMBERS"), memberRecord.id, updates);
+}
+
+function compactFields(fields) {
+  return Object.fromEntries(
+    Object.entries(fields).filter(([, value]) => value !== undefined && value !== null && value !== "")
+  );
+}
+
+async function audit(env, request, memberId, action, result, metadata = {}) {
+  try {
+    await airtableCreate(env, table(env, "ACCESS_LOG"), compactFields({
+      access_log_id: randomId("log"),
+      member_id: memberId || "",
+      action,
+      result,
+      metadata_json: JSON.stringify(metadata),
+      ip_hash: await hashClientValue(env, getClientIp(request)),
+      user_agent: request.headers.get("user-agent") || "",
+      created_at: nowIso(),
+    }));
+  } catch (error) {
+    console.warn("Access log write skipped", safeAirtableReadDebug(table(env, "ACCESS_LOG"), error));
+    // Audit failures must never block auth.
+  }
+}
+
+function normalizeIdentity(body) {
+  const email = normalizeEmail(body.email || body.identifier || "");
+  if (email && email.includes("@")) return { ok: true, type: "email", value: email, identity_key: `email:${email}` };
+
+  const phone = normalizePhone(body.phone || body.identifier || "");
+  if (phone && phone.length >= 7) return { ok: true, type: "phone", value: phone, identity_key: `phone:${phone}` };
+
+  const telegram = normalizeTelegram(body.telegram_username || body.telegram || body.identifier || "");
+  if (telegram) return { ok: true, type: "telegram", value: telegram, identity_key: `telegram:${telegram}` };
+
+  return { ok: false };
+}
+
+function normalizeEmail(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function normalizePhone(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+  return raw.replace(/[^0-9+]/g, "").replace(/^\+66/, "0");
+}
+
+function normalizeTelegram(value) {
+  return String(value || "").trim().replace(/^@/, "").toLowerCase();
+}
+
+async function airtableList(env, tableName, params = {}) {
+  requireAirtable(env);
+  const url = new URL(`https://api.airtable.com/v0/${encodeURIComponent(env.AIRTABLE_BASE_ID)}/${encodeURIComponent(tableName)}`);
+
+  if (params.filterByFormula) url.searchParams.set("filterByFormula", params.filterByFormula);
+  if (params.maxRecords) url.searchParams.set("maxRecords", String(params.maxRecords));
+  if (Array.isArray(params.sort)) {
+    params.sort.forEach((sort, index) => {
+      url.searchParams.set(`sort[${index}][field]`, sort.field);
+      url.searchParams.set(`sort[${index}][direction]`, sort.direction || "asc");
+    });
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${env.AIRTABLE_API_KEY}` },
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(`Airtable list failed: ${response.status} ${JSON.stringify(data)}`);
+  return data.records || [];
+}
+
+async function airtableFirst(env, tableName, formula) {
+  const records = await airtableList(env, tableName, { filterByFormula: formula, maxRecords: 1 });
+  return records[0] || null;
+}
+
+async function airtableGet(env, tableName, recordId) {
+  requireAirtable(env);
+  const response = await fetch(`https://api.airtable.com/v0/${encodeURIComponent(env.AIRTABLE_BASE_ID)}/${encodeURIComponent(tableName)}/${encodeURIComponent(recordId)}`, {
+    headers: { Authorization: `Bearer ${env.AIRTABLE_API_KEY}` },
+  });
+  const data = await response.json().catch(() => ({}));
+  if (response.status === 404) return null;
+  if (!response.ok) throw new Error(`Airtable get failed: ${response.status} ${JSON.stringify(data)}`);
+  return data;
+}
+
+async function airtableCreate(env, tableName, fields) {
+  requireAirtable(env);
+  const response = await fetch(`https://api.airtable.com/v0/${encodeURIComponent(env.AIRTABLE_BASE_ID)}/${encodeURIComponent(tableName)}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.AIRTABLE_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ fields }),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    console.warn("Airtable create failed", safeAirtableDebug(tableName, response.status, data));
+    throw new Error(`Airtable create failed: ${response.status} ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+async function airtableUpdate(env, tableName, recordId, fields) {
+  requireAirtable(env);
+  const response = await fetch(`https://api.airtable.com/v0/${encodeURIComponent(env.AIRTABLE_BASE_ID)}/${encodeURIComponent(tableName)}/${encodeURIComponent(recordId)}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${env.AIRTABLE_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ fields }),
+  });
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    console.warn("Airtable update failed", safeAirtableDebug(tableName, response.status, data));
+    throw new Error(`Airtable update failed: ${response.status} ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+function requireAirtable(env) {
+  if (!env.AIRTABLE_API_KEY || !env.AIRTABLE_BASE_ID) throw new Error("AIRTABLE_API_KEY and AIRTABLE_BASE_ID are required.");
+}
+
+function table(env, key) {
+  return env[`AIRTABLE_TABLE_${key}`] || key.toLowerCase();
+}
+
+function formulaString(value) {
+  return `'${String(value || "").replace(/'/g, "\\'")}'`;
+}
+
+function corsHeaders(request, env) {
+  const origin = request.headers.get("origin") || "";
+  const allowed = String(env.ALLOWED_ORIGINS || "").split(",").map((s) => s.trim()).filter(Boolean);
+  const allowList = allowed.length ? allowed : DEFAULT_ALLOWED_ORIGINS;
+  const allowOrigin = allowList.includes(origin) ? origin : allowList[0] || "*";
+  return {
+    "Access-Control-Allow-Origin": allowOrigin,
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type,Authorization,X-Requested-With",
+    "Vary": "Origin",
+  };
+}
+
+function json(request, env, status, body, extraHeaders = {}) {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: {
+      ...corsHeaders(request, env),
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "no-store",
+      ...extraHeaders,
+    },
+  });
+}
+
+function safeErrorMessage(error) {
+  const message = error instanceof Error ? error.message : String(error || "Unknown error");
+  return message.slice(0, 500) || "Unknown error";
+}
+
+async function readJson(request) {
+  const text = await request.text();
+  if (!text) return {};
+  try { return JSON.parse(text); } catch (_) { return {}; }
+}
+
+function makeSessionCookie(env, token, expiresAt) {
+  const name = env.AUTH_COOKIE_NAME || "mmd_auth";
+  const maxAge = Math.max(0, Math.floor((Date.parse(expiresAt) - Date.now()) / 1000));
+  return `${name}=${token}; Path=/; Max-Age=${maxAge}${cookieDomain(env)}; HttpOnly; Secure; SameSite=Lax`;
+}
+
+function clearSessionCookie(env) {
+  const name = env.AUTH_COOKIE_NAME || "mmd_auth";
+  return `${name}=; Path=/; Max-Age=0${cookieDomain(env)}; HttpOnly; Secure; SameSite=Lax`;
+}
+
+function cookieDomain(env) {
+  const domain = String(env.COOKIE_DOMAIN || "").trim();
+  return domain ? `; Domain=${domain}` : "";
+}
+
+function getCookie(request, name) {
+  const cookie = request.headers.get("cookie") || "";
+  const parts = cookie.split(/;\s*/);
+  for (const part of parts) {
+    const index = part.indexOf("=");
+    if (index < 0) continue;
+    if (part.slice(0, index) === name) return decodeURIComponent(part.slice(index + 1));
+  }
+  return "";
+}
+
+function getClientIp(request) {
+  return request.headers.get("cf-connecting-ip") || request.headers.get("x-forwarded-for") || "";
+}
+
+async function hashSecret(env, value) {
+  if (!env.AUTH_HMAC_SECRET) throw new Error("AUTH_HMAC_SECRET is required.");
+  return sha256Hex(`${env.AUTH_HMAC_SECRET}:${value}`);
+}
+
+async function hashClientValue(env, value) {
+  if (!value) return "";
+  const salt = env.AUTH_HMAC_SECRET || "mmd-auth";
+  return sha256Hex(`${salt}:client:${value}`);
+}
+
+async function sha256Hex(value) {
+  const bytes = new TextEncoder().encode(String(value));
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function safeEqual(a, b) {
+  const x = String(a || "");
+  const y = String(b || "");
+  if (x.length !== y.length) return false;
+  let result = 0;
+  for (let i = 0; i < x.length; i += 1) result |= x.charCodeAt(i) ^ y.charCodeAt(i);
+  return result === 0;
+}
+
+function randomDigits(length) {
+  let out = "";
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  for (const byte of bytes) out += String(byte % 10);
+  return out;
+}
+
+function randomToken(byteLength) {
+  const bytes = new Uint8Array(byteLength);
+  crypto.getRandomValues(bytes);
+  return btoa(String.fromCharCode(...bytes)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function randomId(prefix) {
+  return `${prefix}_${randomToken(16).toLowerCase()}`;
+}
+
+function toInt(value, fallback) {
+  const n = Number.parseInt(String(value || ""), 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function todayDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function safeAirtableDebug(tableName, status, data) {
+  return {
+    table: tableName,
+    status,
+    errorType: data?.error?.type || "",
+    errorMessage: data?.error?.message || "",
+  };
+}
+
+function safeAirtableReadDebug(tableName, error) {
+  const message = error instanceof Error ? error.message : String(error || "");
+  return {
+    table: tableName,
+    message: message.slice(0, 300),
+  };
+}

--- a/auth-worker/src/index.js
+++ b/auth-worker/src/index.js
@@ -288,7 +288,14 @@ async function readSession(request, env) {
 async function buildProfile(env, memberFields) {
   const memberId = String(memberFields.member_id || "");
   const email = normalizeEmail(memberFields.email || "");
-  const entitlements = await deriveMemberEntitlements(env, memberId);
+  const entitlements = await deriveMemberEntitlements(env, {
+    member_id: memberId,
+    email,
+    memberstack_id: memberFields.memberstack_id || "",
+    telegram_user_id: memberFields.telegram_user_id || "",
+    telegram_username: memberFields.telegram_username || "",
+    line_user_id: memberFields.line_user_id || memberFields.line_id || "",
+  });
   const packageAccess = await derivePackageAccess(env, memberFields);
 
   return {
@@ -335,12 +342,13 @@ async function derivePackageAccess(env, memberFields) {
   return { tier: best.tier, status: "active", expire_at: best.expire_at, package_code: best.package_code };
 }
 
-async function deriveMemberEntitlements(env, memberId) {
-  if (!memberId) return [];
+async function deriveMemberEntitlements(env, memberIdentity) {
+  const identityFormula = entitlementIdentityFormula(env, memberIdentity);
+  if (!identityFormula) return [];
   let records = [];
   try {
     records = await airtableList(env, table(env, "MEMBER_ENTITLEMENTS"), {
-      filterByFormula: `AND({member_id}=${formulaString(memberId)}, {status}='active')`,
+      filterByFormula: identityFormula,
       maxRecords: 100,
     });
   } catch (error) {
@@ -348,15 +356,53 @@ async function deriveMemberEntitlements(env, memberId) {
     return [];
   }
   const now = Date.now();
+  const accessStatusFields = envList(env.AIRTABLE_ENTITLEMENT_ACCESS_STATUS_FIELDS || "access_status");
+  const memberStatusFields = envList(env.AIRTABLE_ENTITLEMENT_MEMBER_STATUS_FIELDS || "member_status");
+  const activeValues = envList(env.AIRTABLE_ENTITLEMENT_ACTIVE_VALUES || "active,grace").map((v) => v.toLowerCase());
+  const blockedMemberValues = envList(env.AIRTABLE_ENTITLEMENT_BLOCKED_MEMBER_STATUS_VALUES || "inactive,blocked").map((v) => v.toLowerCase());
+  const resourceFields = envList(env.AIRTABLE_ENTITLEMENT_RESOURCE_FIELDS || "resource_key,access_key,package_code");
+  const minTierFields = envList(env.AIRTABLE_ENTITLEMENT_TIER_FIELDS || "min_tier,tier,package_code");
+  const expiresAtFields = envList(env.AIRTABLE_ENTITLEMENT_EXPIRES_AT_FIELDS || "expire_at");
+
   return records
     .map((r) => r.fields || {})
     .filter((f) => {
-      const starts = f.starts_at ? Date.parse(f.starts_at) : 0;
-      const expires = f.expires_at ? Date.parse(f.expires_at) : Number.MAX_SAFE_INTEGER;
-      return starts <= now && expires >= now;
+      const accessStatus = stringField(f, accessStatusFields).toLowerCase();
+      if (!accessStatus || !activeValues.includes(accessStatus)) return false;
+
+      const memberStatus = stringField(f, memberStatusFields).toLowerCase();
+      if (memberStatus && blockedMemberValues.includes(memberStatus)) return false;
+
+      const expiresAt = stringField(f, expiresAtFields);
+      const expires = expiresAt ? Date.parse(expiresAt) : Number.MAX_SAFE_INTEGER;
+      return expires >= now;
     })
-    .map((f) => ({ resource_key: f.resource_key || "", min_tier: f.min_tier || "", expires_at: f.expires_at || "" }))
+    .map((f) => ({
+      resource_key: stringField(f, resourceFields),
+      min_tier: normalizeTierValue(stringField(f, minTierFields)),
+      expires_at: stringField(f, expiresAtFields),
+    }))
     .filter((g) => g.resource_key);
+}
+
+function entitlementIdentityFormula(env, identity) {
+  const clauses = [];
+  addFormulaClause(clauses, env.AIRTABLE_ENTITLEMENT_MEMBERSTACK_ID_FIELD || "memberstack_id", identity?.memberstack_id);
+  addFormulaClause(clauses, env.AIRTABLE_ENTITLEMENT_MEMBER_EMAIL_FIELD || "member_email", identity?.email, true);
+  addFormulaClause(clauses, env.AIRTABLE_ENTITLEMENT_TELEGRAM_USER_ID_FIELD || "telegram_user_id", identity?.telegram_user_id);
+  addFormulaClause(clauses, env.AIRTABLE_ENTITLEMENT_TELEGRAM_USERNAME_FIELD || "telegram_username", identity?.telegram_username, true);
+  addFormulaClause(clauses, env.AIRTABLE_ENTITLEMENT_LINE_USER_ID_FIELD || "line_user_id", identity?.line_user_id);
+  if (!clauses.length) return "";
+  return clauses.length === 1 ? clauses[0] : `OR(${clauses.join(",")})`;
+}
+
+function addFormulaClause(clauses, field, value, lower = false) {
+  const fieldName = String(field || "").trim();
+  const fieldValue = String(value || "").trim();
+  if (!fieldName || !fieldValue) return;
+  const left = lower ? `LOWER({${fieldName}})` : `{${fieldName}}`;
+  const right = formulaString(lower ? fieldValue.toLowerCase() : fieldValue);
+  clauses.push(`${left}=${right}`);
 }
 
 function tierFromPackageCode(value) {
@@ -453,6 +499,9 @@ function normalizeMemberRecord(record) {
     email: normalizeEmail(fields.email || fields["Contact Email"] || ""),
     phone: fields.phone || fields["Phone Number"] || "",
     telegram_username: fields.telegram_username || "",
+    telegram_user_id: fields.telegram_user_id || "",
+    memberstack_id: fields.memberstack_id || "",
+    line_user_id: fields.line_user_id || fields.line_id || "",
   };
 }
 
@@ -477,20 +526,59 @@ function compactFields(fields) {
 
 async function audit(env, request, memberId, action, result, metadata = {}) {
   try {
-    await airtableCreate(env, table(env, "ACCESS_LOG"), compactFields({
-      access_log_id: randomId("log"),
-      member_id: memberId || "",
-      action,
-      result,
-      metadata_json: JSON.stringify(metadata),
-      ip_hash: await hashClientValue(env, getClientIp(request)),
-      user_agent: request.headers.get("user-agent") || "",
-      created_at: nowIso(),
-    }));
+    const fields = compactFields({
+      [env.AIRTABLE_ACCESS_LOG_EVENT_ID_FIELD || "Event ID"]: randomId("log"),
+      [env.AIRTABLE_ACCESS_LOG_ACTION_FIELD || "Action"]: action,
+      [env.AIRTABLE_ACCESS_LOG_RESULT_FIELD || "Result"]: normalizeAuditResult(result),
+      ...optionalField(env.AIRTABLE_ACCESS_LOG_MEMBER_FIELD, memberId || ""),
+      ...optionalField(env.AIRTABLE_ACCESS_LOG_METADATA_FIELD, JSON.stringify(metadata)),
+      ...optionalField(env.AIRTABLE_ACCESS_LOG_IP_HASH_FIELD, await hashClientValue(env, getClientIp(request))),
+      ...optionalField(env.AIRTABLE_ACCESS_LOG_USER_AGENT_FIELD, request.headers.get("user-agent") || ""),
+      ...optionalField(env.AIRTABLE_ACCESS_LOG_CREATED_AT_FIELD, nowIso()),
+    });
+    if (Object.keys(fields).length) await airtableCreate(env, table(env, "ACCESS_LOG"), fields);
   } catch (error) {
     console.warn("Access log write skipped", safeAirtableReadDebug(table(env, "ACCESS_LOG"), error));
     // Audit failures must never block auth.
   }
+}
+
+function normalizeAuditResult(result) {
+  return String(result || "").toLowerCase() === "success" ? "success" : "fail";
+}
+
+function optionalField(field, value) {
+  const key = String(field || "").trim();
+  return key ? { [key]: value } : {};
+}
+
+function envList(value) {
+  return String(value || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function stringField(fields, candidates) {
+  for (const field of candidates) {
+    const value = fields[field];
+    const normalized = normalizeFieldValue(value);
+    if (normalized) return normalized;
+  }
+  return "";
+}
+
+function normalizeFieldValue(value) {
+  if (value === undefined || value === null) return "";
+  if (Array.isArray(value)) return value.map(normalizeFieldValue).filter(Boolean).join(",");
+  if (typeof value === "object") return String(value.name || value.id || "").trim();
+  return String(value).trim();
+}
+
+function normalizeTierValue(value) {
+  const raw = String(value || "").trim().toLowerCase();
+  if (raw === "black_card") return "blackcard";
+  return raw;
 }
 
 function normalizeIdentity(body) {

--- a/auth-worker/wrangler.toml
+++ b/auth-worker/wrangler.toml
@@ -1,0 +1,43 @@
+name = "mmd-auth-worker"
+main = "src/index.js"
+compatibility_date = "2026-01-20"
+
+[vars]
+# Comma-separated origins that may call the auth API.
+ALLOWED_ORIGINS = "https://mmdbkk.com,https://mmdprive.webflow.io,https://mmdprive.com"
+WEB_BASE_URL = "https://mmdbkk.com"
+COOKIE_DOMAIN = ".mmdbkk.com"
+
+AUTH_COOKIE_NAME = "mmd_auth"
+AUTH_SESSION_TTL_DAYS = "30"
+AUTH_CODE_TTL_MINUTES = "10"
+AUTH_CODE_LENGTH = "6"
+AUTH_MAX_CODE_ATTEMPTS = "5"
+
+# Airtable table names in the existing MMD Commerce Operating System base.
+# You can replace these with Airtable table IDs later.
+AIRTABLE_TABLE_MEMBERS = "Members"
+AIRTABLE_TABLE_MEMBER_PACKAGES = "member_packages"
+AIRTABLE_TABLE_PACKAGES = "packages"
+AIRTABLE_TABLE_PAYMENTS = "Payments"
+AIRTABLE_TABLE_SESSIONS = "Sessions"
+AIRTABLE_TABLE_POINTS_LEDGER = "MMD — Points Ledger"
+AIRTABLE_TABLE_MEMBER_ENTITLEMENTS = "MMD — Member Entitlements"
+AIRTABLE_TABLE_ACCESS_LOG = "System — Access Log"
+AIRTABLE_TABLE_AUTH_IDENTITIES = "MMD — Auth Identities"
+AIRTABLE_TABLE_AUTH_LOGIN_CODES = "MMD — Auth Login Codes"
+AIRTABLE_TABLE_AUTH_SESSIONS = "MMD — Auth Sessions"
+
+# Default paths used by Webflow pages.
+LOGIN_PATH = "/login"
+DENIED_PATH = "/membership/upgrade-required"
+EXPIRED_PATH = "/membership/renewal"
+
+# DEV ONLY. Set to "true" only while testing so the API returns the login code.
+MMD_AUTH_DEV_MODE = "false"
+
+# Required secrets to set with wrangler secret put:
+# AIRTABLE_API_KEY
+# AIRTABLE_BASE_ID
+# AUTH_HMAC_SECRET
+# ADMIN_BEARER

--- a/auth-worker/wrangler.toml
+++ b/auth-worker/wrangler.toml
@@ -28,6 +28,35 @@ AIRTABLE_TABLE_AUTH_IDENTITIES = "MMD — Auth Identities"
 AIRTABLE_TABLE_AUTH_LOGIN_CODES = "MMD — Auth Login Codes"
 AIRTABLE_TABLE_AUTH_SESSIONS = "MMD — Auth Sessions"
 
+# MMD — Member Entitlements mapping.
+# The current table does not expose the old auth MVP member_id field.
+# Entitlement reads are fail-safe: if the identity/status fields are missing or unmapped,
+# /v1/auth/me returns an empty grants array instead of failing login/gate checks.
+AIRTABLE_ENTITLEMENT_MEMBERSTACK_ID_FIELD = "memberstack_id"
+AIRTABLE_ENTITLEMENT_MEMBER_EMAIL_FIELD = "member_email"
+AIRTABLE_ENTITLEMENT_TELEGRAM_USER_ID_FIELD = "telegram_user_id"
+AIRTABLE_ENTITLEMENT_TELEGRAM_USERNAME_FIELD = "telegram_username"
+AIRTABLE_ENTITLEMENT_LINE_USER_ID_FIELD = "line_user_id"
+AIRTABLE_ENTITLEMENT_ACCESS_STATUS_FIELDS = "access_status"
+AIRTABLE_ENTITLEMENT_MEMBER_STATUS_FIELDS = "member_status"
+AIRTABLE_ENTITLEMENT_ACTIVE_VALUES = "active,grace"
+AIRTABLE_ENTITLEMENT_BLOCKED_MEMBER_STATUS_VALUES = "inactive,blocked"
+AIRTABLE_ENTITLEMENT_RESOURCE_FIELDS = "resource_key,access_key,package_code"
+AIRTABLE_ENTITLEMENT_TIER_FIELDS = "min_tier,tier,package_code"
+AIRTABLE_ENTITLEMENT_EXPIRES_AT_FIELDS = "expire_at"
+
+# System — Access Log mapping.
+# Result is normalized to success/fail. Other log fields are optional and should be
+# mapped here only after the corresponding Airtable fields exist.
+AIRTABLE_ACCESS_LOG_EVENT_ID_FIELD = "Event ID"
+AIRTABLE_ACCESS_LOG_ACTION_FIELD = "Action"
+AIRTABLE_ACCESS_LOG_RESULT_FIELD = "Result"
+AIRTABLE_ACCESS_LOG_MEMBER_FIELD = ""
+AIRTABLE_ACCESS_LOG_METADATA_FIELD = ""
+AIRTABLE_ACCESS_LOG_IP_HASH_FIELD = ""
+AIRTABLE_ACCESS_LOG_USER_AGENT_FIELD = ""
+AIRTABLE_ACCESS_LOG_CREATED_AT_FIELD = ""
+
 # Default paths used by Webflow pages.
 LOGIN_PATH = "/login"
 DENIED_PATH = "/membership/upgrade-required"

--- a/docs/airtable-schema.md
+++ b/docs/airtable-schema.md
@@ -1,0 +1,198 @@
+# MMD / SIGIL Access Core Airtable Schema
+
+Use the existing Airtable base `MMD Commerce Operating System` as the source of truth. Do not create a new Airtable base unless explicitly approved.
+
+Reuse existing MMD tables:
+
+- `Members`
+- `member_packages`
+- `packages`
+- `Payments`
+- `Sessions`
+- `MMD — Points Ledger`
+- `MMD — Member Entitlements`
+- `System — Access Log`
+
+Create only missing auth-specific tables:
+
+- `MMD — Auth Identities`
+- `MMD — Auth Login Codes`
+- `MMD — Auth Sessions`
+
+Created auth tables in `MMD Commerce Operating System`:
+
+| Table | Airtable table ID | Purpose |
+|---|---|---|
+| `MMD — Auth Identities` | `tbl1AM0GE1tHzZXFD` | Public member identity keys for email, phone, and Telegram login |
+| `MMD — Auth Login Codes` | `tblbcWun1fUqXhzJZ` | Hash-only 6-digit login code challenges |
+| `MMD — Auth Sessions` | `tblgu2ZDdmu6bTJqc` | Public member auth sessions only |
+
+Do not create `access_grants`. Use `MMD — Member Entitlements` as the access/entitlement source.
+
+Do not create `audit_log`. Use `System — Access Log`.
+
+Do not reuse `Admin Sessions` for public member login. `Admin Sessions` belongs to admin auth only. `auth-worker` must write public login sessions only to `MMD — Auth Sessions`.
+
+Map table names in `auth-worker/wrangler.toml` to existing table IDs or exact existing table names before deployment.
+
+## Existing: Members
+
+| Field | Type | Notes |
+|---|---|---|
+| member_id | single line text | Optional MMD-owned auth/member key. Do not assume Memberstack. If absent, auth derives `mmd_rec_<AirtableRecordId>` for existing rows. |
+| name | single line text | Optional display name |
+| email | email / text | Lowercase preferred |
+| phone | phone / text | Normalized preferred |
+| telegram_username | single line text | No `@`, lowercase preferred |
+| status | single select | `guest`, `active`, `blocked` |
+| created_at | date time | ISO timestamp |
+| last_login_at | date time | ISO timestamp |
+
+### member_id derivation
+
+`member_id` is an internal normalized SIGIL/MMD auth key, not a Memberstack ID.
+
+Derivation order:
+
+- Existing MMD-owned key from `member_id`, `Member ID`, or `auth_member_id`.
+- Existing Airtable `Members` row: `mmd_rec_<AirtableRecordId>`.
+- Auth-created row: `mmd_<identity_type>_<sha256(identity_key)[0..16]>`, where `identity_key` is normalized email, phone, or Telegram username with its type prefix.
+
+## New: MMD — Auth Identities
+
+Table ID: `tbl1AM0GE1tHzZXFD`
+
+| Field | Type | Notes |
+|---|---|---|
+| identity_id | single line text | Unique |
+| member_id | single line text | Internal normalized SIGIL/MMD key. Never Memberstack. |
+| identity_type | single select | `email`, `phone`, `telegram` |
+| identity_value | single line text | Normalized value |
+| identity_key | single line text | Unique. Example `email:per@example.com` |
+| status | single select | `active`, `blocked` |
+| created_at | date time | ISO timestamp |
+| last_seen_at | date time | ISO timestamp |
+
+## New: MMD — Auth Login Codes
+
+Table ID: `tblbcWun1fUqXhzJZ`
+
+| Field | Type | Notes |
+|---|---|---|
+| code_id | single line text | Unique |
+| member_id | single line text | Internal normalized SIGIL/MMD key. Never Memberstack. |
+| identity_type | single select | email / phone / telegram |
+| identity_value | single line text | The visible identity value |
+| identity_key | single line text | Search key |
+| code_hash | long text | Hashed code, never store raw code |
+| nonce | single line text | Per-code salt |
+| attempts | number | Default 0 |
+| expires_at | date time | Usually now + 10 min |
+| consumed_at | date time or blank | Set after successful login |
+| requester_ip_hash | single line text | Privacy-safe IP hash |
+| user_agent | long text | Browser/device hint |
+| created_at | date time | ISO timestamp |
+
+## New: MMD — Auth Sessions
+
+Table ID: `tblgu2ZDdmu6bTJqc`
+
+| Field | Type | Notes |
+|---|---|---|
+| session_id | single line text | Unique |
+| member_id | single line text | Internal normalized SIGIL/MMD key. Never Memberstack. |
+| session_hash | long text | Hashed cookie token |
+| created_at | date time | ISO timestamp |
+| expires_at | date time | Usually now + 30 days |
+| revoked_at | date time or blank | Set on logout/admin revoke |
+| ip_hash | single line text | Privacy-safe IP hash |
+| user_agent | long text | Browser/device hint |
+
+## Existing: member_packages
+
+The worker reads this table to derive real membership status.
+
+Required fields:
+
+| Field | Type | Notes |
+|---|---|---|
+| member_email | email/text | Lowercase preferred |
+| package_code | text/select | standard, premium, vip, svip, blackcard, guest pass |
+| status | select/text | Must be `active` for access |
+| end_date | date time | Must be in the future |
+
+This keeps Airtable ledger as source of truth and prevents front-end role spoofing.
+
+## Existing: MMD — Member Entitlements
+
+Use this table as the access/entitlement source for Webflow gate checks and member-specific grants. Do not create a parallel `access_grants` table.
+
+Auth-worker must not assume a `member_id` field exists on this table. Entitlement lookups use the full member/profile identity context and only these real identity fields:
+
+- `memberstack_id`
+- `member_email`
+- `telegram_user_id`
+- `telegram_username`
+- `line_user_id`
+
+Current known auth-facing field mappings:
+
+| Concept | Mapping |
+|---|---|
+| member reference | Matched through `memberstack_id`, `member_email`, `telegram_user_id`, `telegram_username`, or `line_user_id`; never `{member_id}` |
+| access status | `access_status`; active values are `active` and `grace` |
+| member status | `member_status`; `inactive` and `blocked` are rejected |
+| expiry | `expire_at`; blank or future passes |
+| package/tier | `package_code`, `tier`, or `min_tier` |
+| resource/scope | `resource_key`, `access_key`, or `package_code` |
+
+Entitlement reads are fail-safe. If identity/status fields are absent, unmapped, or rejected by Airtable, `/v1/auth/me` returns empty `entitlements`/`grants` instead of failing login or gate checks.
+
+Expected auth-facing concepts once mapping is completed:
+
+| Concept | Notes |
+|---|---|
+| member reference | Link or stable ID for the member |
+| resource key | Page/path/model/access key to unlock |
+| entitlement status | Active/revoked/expired equivalent |
+| start/end dates | Optional effective window |
+| minimum tier | Optional tier floor when the entitlement is tier-based |
+
+## Existing: System — Access Log
+
+Use this table for auth and access audit events. Do not create a parallel `audit_log` table.
+
+The current auth-worker mapping does not use `access_log_id`; do not add a parallel `audit_log` table.
+
+Current MVP write fields:
+
+| Field | Notes |
+|---|---|
+| `Event ID` | Auth-generated log ID |
+| `Action` | Example `auth.login`, `auth.request_code`, `admin.access_grant` |
+| `Result` | Normalized to `success` or `fail` only |
+
+Additional audit fields are optional and must be mapped through `AIRTABLE_ACCESS_LOG_*_FIELD` variables after those fields exist in Airtable. Access-log writes are non-blocking and must never block login/session flows.
+
+Expected auth-facing concepts once mapping is completed:
+
+| Concept | Notes |
+|---|---|
+| member reference | Optional member ID/link |
+| action | Example `auth.login`, `auth.request_code`, `admin.access_grant` |
+| result | `success` or `error` equivalent |
+| metadata | JSON or long text details |
+| IP hash | Privacy-safe IP hash |
+| user agent | Browser/device hint |
+| created time | Event timestamp |
+
+## Existing tables outside auth ownership
+
+The auth worker may read from membership state but does not own payment or package lifecycle tables:
+
+- `Payments`
+- `Sessions`
+- `packages`
+- `MMD — Points Ledger`
+
+Those remain under `payments-worker` ownership.

--- a/docs/deploy-checklist.md
+++ b/docs/deploy-checklist.md
@@ -1,0 +1,225 @@
+# Deploy Checklist: SIGIL Access Core
+
+## 1. Create Airtable tables
+
+Use the existing Airtable base: `MMD Commerce Operating System`. Do not create a new Airtable base unless explicitly approved.
+
+Reuse existing tables:
+
+- `Members`
+- `member_packages`
+- `packages`
+- `Payments`
+- `Sessions`
+- `MMD — Points Ledger`
+- `MMD — Member Entitlements`
+- `System — Access Log`
+
+Create only missing auth-specific tables from `docs/airtable-schema.md`:
+
+- `MMD — Auth Identities` (`tbl1AM0GE1tHzZXFD`)
+- `MMD — Auth Login Codes` (`tblbcWun1fUqXhzJZ`)
+- `MMD — Auth Sessions` (`tblgu2ZDdmu6bTJqc`)
+
+Do not create `access_grants`; use `MMD — Member Entitlements` as the access/entitlement source.
+
+Do not create `audit_log`; use `System — Access Log`.
+
+Do not reuse `Admin Sessions` for public member login. `Admin Sessions` belongs to admin auth only. `auth-worker` must write public login sessions only to `MMD — Auth Sessions`.
+
+Confirm `member_id` semantics before production:
+
+- `member_id` is an internal normalized SIGIL/MMD auth key.
+- It must not assume or reuse Memberstack.
+- Existing `Members` rows without a member key derive `member_id` as `mmd_rec_<AirtableRecordId>`.
+- Auth-created rows derive `member_id` from normalized email, phone, or Telegram identity as `mmd_<identity_type>_<sha256(identity_key)[0..16]>`.
+
+For the MVP, keep field names exactly as documented. If the existing base uses Airtable table IDs or nonstandard table names, map them in `auth-worker/wrangler.toml`.
+
+## 2. Confirm worker ownership
+
+Keep `auth-worker` as a separate Cloudflare Worker in the existing `mmd-workers` repo. Do not merge it into `admin-worker`, `payments-worker`, `chat-worker`, `events-worker`, `telegram-worker`, or `realtime-worker`.
+
+- `auth-worker` owns login, 6-digit code flow, auth session cookie, `/v1/auth/me`, logout, and Webflow gate checks.
+- `admin-worker` owns internal admin approval and member/access operations.
+- `payments-worker` owns payments, `payment_ref`, `member_packages`, `points_ledger`, and package lifecycle.
+- `telegram-worker` may later deliver login codes, but must not own auth sessions.
+- `auth-worker` reads entitlement/access status from `MMD — Member Entitlements`.
+- `member_packages` remains the membership ledger source of truth.
+- `POST /v1/admin/access/grant` stays in `auth-worker` only for the MVP, guarded by `ADMIN_BEARER`; long-term admin ownership should move behind `admin-worker` or be proxied by `admin-worker`.
+
+## 3. Set Cloudflare Worker secrets
+
+```bash
+wrangler secret put AIRTABLE_API_KEY
+wrangler secret put AIRTABLE_BASE_ID
+wrangler secret put AUTH_HMAC_SECRET
+wrangler secret put ADMIN_BEARER
+```
+
+Use a long random value for `AUTH_HMAC_SECRET`.
+
+Confirm these non-secret vars in `auth-worker/wrangler.toml`:
+
+```toml
+ALLOWED_ORIGINS = "https://mmdbkk.com,https://mmdprive.webflow.io,https://mmdprive.com"
+WEB_BASE_URL = "https://mmdbkk.com"
+COOKIE_DOMAIN = ".mmdbkk.com"
+MMD_AUTH_DEV_MODE = "false"
+```
+
+Before deployment, map auth table vars to the existing base/table names or table IDs:
+
+```toml
+AIRTABLE_TABLE_MEMBERS = "Members"
+AIRTABLE_TABLE_MEMBER_PACKAGES = "member_packages"
+AIRTABLE_TABLE_PACKAGES = "packages"
+AIRTABLE_TABLE_PAYMENTS = "Payments"
+AIRTABLE_TABLE_SESSIONS = "Sessions"
+AIRTABLE_TABLE_POINTS_LEDGER = "MMD — Points Ledger"
+AIRTABLE_TABLE_MEMBER_ENTITLEMENTS = "MMD — Member Entitlements"
+AIRTABLE_TABLE_ACCESS_LOG = "System — Access Log"
+AIRTABLE_TABLE_AUTH_IDENTITIES = "MMD — Auth Identities"
+AIRTABLE_TABLE_AUTH_LOGIN_CODES = "MMD — Auth Login Codes"
+AIRTABLE_TABLE_AUTH_SESSIONS = "MMD — Auth Sessions"
+
+AIRTABLE_ENTITLEMENT_MEMBERSTACK_ID_FIELD = "memberstack_id"
+AIRTABLE_ENTITLEMENT_MEMBER_EMAIL_FIELD = "member_email"
+AIRTABLE_ENTITLEMENT_TELEGRAM_USER_ID_FIELD = "telegram_user_id"
+AIRTABLE_ENTITLEMENT_TELEGRAM_USERNAME_FIELD = "telegram_username"
+AIRTABLE_ENTITLEMENT_LINE_USER_ID_FIELD = "line_user_id"
+AIRTABLE_ENTITLEMENT_ACCESS_STATUS_FIELDS = "access_status"
+AIRTABLE_ENTITLEMENT_MEMBER_STATUS_FIELDS = "member_status"
+AIRTABLE_ENTITLEMENT_ACTIVE_VALUES = "active,grace"
+AIRTABLE_ENTITLEMENT_BLOCKED_MEMBER_STATUS_VALUES = "inactive,blocked"
+AIRTABLE_ENTITLEMENT_RESOURCE_FIELDS = "resource_key,access_key,package_code"
+AIRTABLE_ENTITLEMENT_TIER_FIELDS = "min_tier,tier,package_code"
+AIRTABLE_ENTITLEMENT_EXPIRES_AT_FIELDS = "expire_at"
+
+AIRTABLE_ACCESS_LOG_EVENT_ID_FIELD = "Event ID"
+AIRTABLE_ACCESS_LOG_ACTION_FIELD = "Action"
+AIRTABLE_ACCESS_LOG_RESULT_FIELD = "Result"
+AIRTABLE_ACCESS_LOG_MEMBER_FIELD = ""
+AIRTABLE_ACCESS_LOG_METADATA_FIELD = ""
+AIRTABLE_ACCESS_LOG_IP_HASH_FIELD = ""
+AIRTABLE_ACCESS_LOG_USER_AGENT_FIELD = ""
+AIRTABLE_ACCESS_LOG_CREATED_AT_FIELD = ""
+```
+
+Created auth table IDs may be used instead of names:
+
+```toml
+AIRTABLE_TABLE_AUTH_IDENTITIES = "tbl1AM0GE1tHzZXFD"
+AIRTABLE_TABLE_AUTH_LOGIN_CODES = "tblbcWun1fUqXhzJZ"
+AIRTABLE_TABLE_AUTH_SESSIONS = "tblgu2ZDdmu6bTJqc"
+```
+
+`AIRTABLE_TABLE_MEMBER_ENTITLEMENTS` must point to `MMD — Member Entitlements`, not a new `access_grants` table.
+
+`auth-worker` must not query `{member_id}` on `MMD — Member Entitlements`. It should build identity lookup formulas from `memberstack_id`, `member_email`, `telegram_user_id`, `telegram_username`, and `line_user_id` only.
+
+`AIRTABLE_TABLE_ACCESS_LOG` must point to `System — Access Log`, not a new `audit_log` table.
+
+`System — Access Log` does not use `access_log_id`. The MVP write uses `Event ID`, `Action`, and `Result`; `Result` must be normalized to `success` or `fail`. Map additional fields only after they exist in Airtable.
+
+## 4. Test locally
+
+```bash
+node --check auth-worker/src/index.js
+wrangler dev --config auth-worker/wrangler.toml
+```
+
+Temporarily set this in `wrangler.toml` while testing:
+
+```toml
+MMD_AUTH_DEV_MODE = "true"
+```
+
+Then call:
+
+```bash
+curl -i -X POST http://localhost:8787/v1/auth/request-code \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"test@example.com"}'
+```
+
+Use the returned `dev_code` to verify:
+
+```bash
+curl -i -X POST http://localhost:8787/v1/auth/verify-code \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"test@example.com","code":"123456"}'
+```
+
+## 5. Deploy
+
+```bash
+wrangler deploy --config auth-worker/wrangler.toml
+```
+
+Set a route or custom domain such as:
+
+```text
+auth.mmdbkk.com/*
+```
+
+## 6. Add login page to Webflow
+
+Create `/login` in Webflow and paste `webflow/login.html` into an Embed block.
+
+Change this line to the real worker domain:
+
+```html
+<section class="sigil-login" data-auth-base="https://auth.mmdbkk.com">
+```
+
+## 7. Add gate script to protected pages
+
+In Webflow page settings, before `</body>`:
+
+```html
+<style>
+  .mmd-auth-locking body { opacity: 0; pointer-events: none; }
+</style>
+<script
+  src="https://mmdbkk.com/assets/mmd-gate.js"
+  data-mmd-gate
+  data-auth-base="https://auth.mmdbkk.com"
+  data-allow="premium,vip,svip,blackcard"
+  data-login="/login"
+  data-denied="/membership/upgrade-required"
+  data-expired="/membership/renewal">
+</script>
+```
+
+For Standard pages:
+
+```html
+data-allow="standard,premium,vip,svip,blackcard"
+```
+
+For VIP pages:
+
+```html
+data-allow="vip,svip,blackcard"
+```
+
+For Black Card pages:
+
+```html
+data-allow="blackcard"
+```
+
+## 8. Production delivery provider
+
+The MVP creates codes but does not send email/SMS automatically unless you connect a provider.
+
+Recommended next step:
+
+- Telegram Worker delivery for users with Telegram username or ID.
+- Email delivery via Resend / Postmark / Cloudflare Email Routing worker.
+- SMS only later, because it adds cost and privacy concerns.
+
+Production warning: keep `MMD_AUTH_DEV_MODE=false` in production. `dev_code` must never be returned from the live auth API.
+
+Memberstack remains optional backup only. It is not the source of truth for tier, package status, access, or session state.


### PR DESCRIPTION
- Maps access log writes to real System Access Log fields
- Maps entitlement lookup to real MMD Member Entitlements identity fields
- Removes access_log_id and entitlement member_id assumptions
- Keeps access log and entitlement failures non-blocking
- Adds auth/me unauthenticated and grants shape smoke checks