### PR TITLE
Ignore Next.js build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ dist
 *.dev.vars
 .env
 .env.*
+
+# Next.js build output
+.next/
+apps/**/.next/


### PR DESCRIPTION
## Summary
- Ignore Next.js build output and cache directories
- Prevent apps/**/.next artifacts from appearing in git status

## Validation
- Branch is based on origin/main
- Only .gitignore changed
- No PR #118 commits included