### PR TITLE
Fix events worker Wrangler config

### DIFF
--- a/events-worker/wrangler.toml
+++ b/events-worker/wrangler.toml
@@ -1,17 +1,15 @@
 name = "events-worker"
 main = "src/index.js"
 compatibility_date = "2026-02-27"
-type = "javascript"
-account_id = "REPLACE_WITH_CLOUDFLARE_ACCOUNT_ID"
 
 # cron triggers
 [triggers]
 crons = ["*/15 * * * *"] # run every 15 minutes
 
 # KV bindings (create namespace and replace id)
-kv_namespaces = [
-  { binding = "EVENTS_QUEUE_KV", id = "REPLACE_EVENTS_QUEUE_KV_ID" }
-]
+[[kv_namespaces]]
+binding = "EVENTS_QUEUE_KV"
+id = "REPLACE_EVENTS_QUEUE_KV_ID"
 
 [vars]
 # required runtime vars (set actual values in dashboard or use wrangler kv/vars)
@@ -21,4 +19,3 @@ ADMIN_WORKER_BASE = "https://admin-worker.malemodel-bkk.workers.dev"
 
 # Airtable/other env names should be set in dashboard or wrangler environment
 # e.g. AIRTABLE_API_KEY, AIRTABLE_BASE_ID, AIRTABLE_TABLE_SESSIONS, AIRTABLE_TABLE_MODELS, AIRTABLE_TABLE_CLIENTS, AIRTABLE_TABLE_ACTIVITY_LOGS
->>>>>>> main


### PR DESCRIPTION
## Summary
- Remove unresolved conflict marker from events-worker Wrangler config
- Remove placeholder account_id from committed config
- Remove legacy type field
- Move KV namespace binding outside triggers section

## Validation
- Conflict marker check passed
- Wrangler config parse succeeded with secret list
- Final diff only includes events-worker/wrangler.toml

## Notes
- No deploy performed
- No secrets changed
- No stash changes