### PR TITLE
Document Webflow auth worker base snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Used to move data and workflows into the core production system without pollutin
 - token parameter must be `t`
 - Airtable is the back-office source of truth
 - Native MMD auth-worker is the frontend auth gate; protected frontend pages must call `/v1/auth/me`
+- Webflow protected pages must set `window.MMD_AUTH_WORKER_BASE_URL = "https://mmdbkk.com"` before loading `webflow/mmd-gate.js`, so `mmdprive.webflow.io` checks auth through the canonical `mmdbkk.com` route
 - Airtable entitlements and `member_packages` are the access truth
 - `memberstack_id` remains legacy compatibility only
 - worker boundaries are production contracts

--- a/webflow/sigil/access/sigil-access-webflow-snippet.html
+++ b/webflow/sigil/access/sigil-access-webflow-snippet.html
@@ -1,0 +1,11 @@
+<!--
+  MMD SIGIL Access Webflow snippet
+  Page: /sigil/access
+  Placement: Page Settings > Before </body>
+  Important: MMD_AUTH_WORKER_BASE_URL must be set before mmd-gate.js.
+-->
+<script>
+  window.MMD_AUTH_WORKER_BASE_URL = "https://mmdbkk.com";
+</script>
+<script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/mmd-gate.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/sigil/access/sigil-access-os.js"></script>

--- a/webflow/sigil/board/README.md
+++ b/webflow/sigil/board/README.md
@@ -18,6 +18,11 @@ Load `webflow/mmd-gate.js` first, then load this helper after the V7.0 board
 embed. It adds a delegated click handler for gate unlock controls and exposes
 `window.mmdBoardV70UnlockGate()` as a console fallback.
 
+Protected Webflow pages must set
+`window.MMD_AUTH_WORKER_BASE_URL = "https://mmdbkk.com"` before loading
+`webflow/mmd-gate.js`. This is required on `mmdprive.webflow.io` so auth checks
+call the canonical `mmdbkk.com` auth route.
+
 The gate checks the native MMD auth-worker session with `GET /v1/auth/me` and
 `credentials: "include"`. It must not compute access from Memberstack
 `customFields`, localStorage, DOM attributes, or browser-only passphrases.
@@ -29,12 +34,14 @@ Webflow.
 
 1. Add the HTML/root embed first on the `/sigil/board` Webflow page.
 2. Add the main V7 board inline JS after the HTML/root embed.
-3. Load `webflow/mmd-gate.js` before any protected page/gate script.
-4. Load `kenji-board-v70-gate.js` after the V7 board/root markup and board
+3. Set `window.MMD_AUTH_WORKER_BASE_URL = "https://mmdbkk.com"` before
+   `webflow/mmd-gate.js`.
+4. Load `webflow/mmd-gate.js` before any protected page/gate script.
+5. Load `kenji-board-v70-gate.js` after the V7 board/root markup and board
    inline JS.
-5. Load `kenji-board-v70-smoke-test.js` last, or in Webflow **Before
+6. Load `kenji-board-v70-smoke-test.js` last, or in Webflow **Before
    `</body>`**.
-6. The HTML/root embed must include the V7 root and gate elements shown in
+7. The HTML/root embed must include the V7 root and gate elements shown in
    `kenji-board-v70-webflow-snippet.html`:
    - `[data-mmd-board-v70]`
    - `[data-v70-auth-check]`
@@ -52,13 +59,18 @@ Recommended Webflow order:
   /* Paste the main Kenji Board V7.0 inline JS here. */
 </script>
 
-<!-- 3. Auth-worker gate helper before protected scripts -->
+<!-- 3. Set the canonical auth-worker base before the shared gate helper -->
+<script>
+  window.MMD_AUTH_WORKER_BASE_URL = "https://mmdbkk.com";
+</script>
+
+<!-- 4. Auth-worker gate helper before protected scripts -->
 <script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/mmd-gate.js"></script>
 
-<!-- 4. Gate helper after the V7 board/root markup -->
+<!-- 5. Gate helper after the V7 board/root markup -->
 <script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/sigil/board/kenji-board-v70-gate.js"></script>
 
-<!-- 5. Smoke helper last, or in Webflow Before </body> -->
+<!-- 6. Smoke helper last, or in Webflow Before </body> -->
 <script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/sigil/board/kenji-board-v70-smoke-test.js"></script>
 ```
 

--- a/webflow/sigil/board/kenji-board-v70-webflow-snippet.html
+++ b/webflow/sigil/board/kenji-board-v70-webflow-snippet.html
@@ -2,9 +2,10 @@
   MMD SIGIL Board V7.0 Webflow embed snippet
   Placement:
   1. Paste the V7 board embed/root markup first on /sigil/board.
-  2. Load webflow/mmd-gate.js after this embed.
-  3. Load kenji-board-v70-gate.js after the auth gate helper.
-  4. Load kenji-board-v70-smoke-test.js last, or in Before </body>.
+  2. Set MMD_AUTH_WORKER_BASE_URL before loading webflow/mmd-gate.js.
+  3. Load webflow/mmd-gate.js after this embed.
+  4. Load kenji-board-v70-gate.js after the auth gate helper.
+  5. Load kenji-board-v70-smoke-test.js last, or in Before </body>.
 -->
 <section data-mmd-board-v70 data-gate="locked" data-role="guest">
   <div class="mmd-board-v70__gate-panel" data-v70-gate-panel>
@@ -16,6 +17,11 @@
     </p>
   </div>
 </section>
+
+<!-- Set before loading the shared auth gate helper. -->
+<script>
+  window.MMD_AUTH_WORKER_BASE_URL = "https://mmdbkk.com";
+</script>
 
 <!-- Load before the board gate helper. -->
 <script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/mmd-gate.js"></script>

--- a/webflow/sigil/private-models/sigil-private-models-webflow-snippet.html
+++ b/webflow/sigil/private-models/sigil-private-models-webflow-snippet.html
@@ -1,0 +1,11 @@
+<!--
+  MMD SIGIL Private Models Webflow snippet
+  Page: /sigil/private-models
+  Placement: Page Settings > Before </body>
+  Important: MMD_AUTH_WORKER_BASE_URL must be set before mmd-gate.js.
+-->
+<script>
+  window.MMD_AUTH_WORKER_BASE_URL = "https://mmdbkk.com";
+</script>
+<script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/mmd-gate.js"></script>
+<script src="https://cdn.jsdelivr.net/gh/MMD-Prive/mmd-workers@main/webflow/sigil/private-models/sigil-private-models.js"></script>


### PR DESCRIPTION
## Summary
- Add explicit MMD_AUTH_WORKER_BASE_URL setup to Webflow snippets
- Add snippet files for SIGIL access and private models
- Document that protected Webflow pages must call auth through mmdbkk.com

## Validation
- node --check passed for Webflow scripts
- Board gate test passed
- Snippet grep confirmed auth base URL is present before mmd-gate.js

## Notes
- No Webflow publish performed
- No Cloudflare Worker deploy
- No secrets changed
- No Airtable data changes
- No stash changes