### PR TITLE
ops: lock Kenji LINE to member-dashboard-chat-worker and ai-worker

### DIFF
--- a/docs/line/kenji-line-official.md
+++ b/docs/line/kenji-line-official.md
@@ -9,45 +9,67 @@ Kenji LINE OA is the member-facing concierge entry for MMD Privé. It is not the
 - `/sigil/board`: internal system/admin/rules/control layer
 - LINE OA Kenji: member-facing conversational entry
 
+## Two-worker lock
+
+Kenji LINE is locked to two workers:
+
+```text
+immigrate-worker = LINE intake and handoff bridge
+ai-worker = intelligence and answer support
+```
+
+`mmd-redirect-worker` may be used only as an optional public bridge/front gate when healthy. It is not the Kenji brain and must not be treated as the LINE answer owner.
+
 ## Production Webhook Route
 
-LINE Official should keep using the stable MMD domain route:
+Preferred stable route when the front gate is healthy:
 
 ```text
 https://mmdbkk.com/webhooks/line
 ```
 
-This route is owned at the `mmd-redirect-worker` front gate and can bridge to the configured LINE webhook implementation through:
+This route may bridge through `mmd-redirect-worker` to the configured LINE webhook implementation through:
 
 ```text
 LINE_WEBHOOK_UPSTREAM_URL=https://<your-site>.netlify.app/.netlify/functions/webhook
+```
+
+If `mmd-redirect-worker` is unstable, LINE Official may temporarily bypass it and point directly to the existing `immigrate-worker` / Netlify-compatible webhook:
+
+```text
+https://<your-site>.netlify.app/.netlify/functions/webhook
 ```
 
 Do not ask LINE Official to point directly to Netlify as the long-term production URL unless there is an intentional migration decision. The public LINE OA URL should remain stable on `mmdbkk.com`; the upstream can be changed behind the gate.
 
 ## Required Env
 
-For the active LINE webhook implementation:
+For the active `immigrate-worker` LINE webhook implementation:
 
 ```text
-LINE_AUTO_REPLY_ENABLED=true
+LINE_AUTO_REPLY_ENABLED=false
 LINE_KENJI_AI_ENABLED=true
+LINE_KENJI_AI_DEBUG=true
 LINE_CHANNEL_SECRET=...
 LINE_CHANNEL_ACCESS_TOKEN=...
 AIRTABLE_API_KEY=...
-AIRTABLE_BASE_ID=...
+AIRTABLE_BASE_ID=appsV1ILPRfIjkaYg
+AIRTABLE_SYNC_TABLE=MMD — Console Inbox
 ```
 
-For the `mmdbkk.com/webhooks/line` bridge in `mmd-redirect-worker`:
+For the optional `mmdbkk.com/webhooks/line` bridge in `mmd-redirect-worker`:
 
 ```text
 LINE_WEBHOOK_UPSTREAM_URL=https://<your-site>.netlify.app/.netlify/functions/webhook
 ```
 
-Optional:
+For `ai-worker`, keep it as intelligence support only. It should not hold public LINE webhook ownership:
 
 ```text
-LINE_KENJI_AI_DEBUG=true
+FEATURE_RETRIEVAL=true
+FEATURE_SUMMARIZATION=true
+AI_MAX_RESULTS=...
+AI_TIMEOUT_MS=...
 ```
 
 ## Test Phrases
@@ -77,6 +99,7 @@ Expected behavior:
 - Black Card reply says private review, not automatic approval.
 - Pricing messages keep the existing pricing review acknowledgement path.
 - Model availability messages keep the existing model lookup / Per confirmation path.
+- If `LINE_AUTO_REPLY_ENABLED=false`, inbound events should still log/draft/handoff without public auto reply.
 
 ## Safety Notes
 
@@ -89,3 +112,6 @@ Expected behavior:
 - LINE OA Kenji does not enable real Worker Control POST actions.
 - Deduped LINE events must not reply twice.
 - Netlify / immigrate-worker can be an upstream compatibility target, but should not become the canonical long-term LINE route owner.
+- `admin-worker` must not be the public LINE webhook owner.
+- `telegram-worker` must not be the public chatbot owner.
+- `himai-chat-worker` is pattern reference only and must not be used as MMD production LINE.

--- a/docs/line/kenji-line-official.md
+++ b/docs/line/kenji-line-official.md
@@ -9,42 +9,38 @@ Kenji LINE OA is the member-facing concierge entry for MMD Privé. It is not the
 - `/sigil/board`: internal system/admin/rules/control layer
 - LINE OA Kenji: member-facing conversational entry
 
-## Two-worker lock
+## MMD memory owner lock
 
-Kenji LINE is locked to two workers:
+Kenji LINE is locked by current MMD memory to this runtime ownership:
 
 ```text
-immigrate-worker = LINE intake and handoff bridge
+member-dashboard-chat-worker = current production LINE webhook owner / Kenji member-facing entry
 ai-worker = intelligence and answer support
 ```
 
-`mmd-redirect-worker` may be used only as an optional public bridge/front gate when healthy. It is not the Kenji brain and must not be treated as the LINE answer owner.
+`mmd-redirect-worker` may be used only as a route bridge/front gate when healthy. It is not the Kenji brain and must not be treated as the LINE answer owner.
+
+`immigrate-worker` is legacy/migration compatibility. Do not revive or retarget LINE OFC to `immigrate-worker` unless there is a separate, explicit migration decision.
 
 ## Production Webhook Route
 
-Preferred stable route when the front gate is healthy:
+LINE Official should keep using the stable MMD domain route:
 
 ```text
 https://mmdbkk.com/webhooks/line
 ```
 
-This route may bridge through `mmd-redirect-worker` to the configured LINE webhook implementation through:
+This route is owned by the current LINE production owner in MMD memory:
 
 ```text
-LINE_WEBHOOK_UPSTREAM_URL=https://<your-site>.netlify.app/.netlify/functions/webhook
+member-dashboard-chat-worker
 ```
 
-If `mmd-redirect-worker` is unstable, LINE Official may temporarily bypass it and point directly to the existing `immigrate-worker` / Netlify-compatible webhook:
-
-```text
-https://<your-site>.netlify.app/.netlify/functions/webhook
-```
-
-Do not ask LINE Official to point directly to Netlify as the long-term production URL unless there is an intentional migration decision. The public LINE OA URL should remain stable on `mmdbkk.com`; the upstream can be changed behind the gate.
+Do not ask LINE Official to point directly to Netlify, Webflow, Memberstack, page scripts, admin-worker, or telegram-worker as the production LINE route.
 
 ## Required Env
 
-For the active `immigrate-worker` LINE webhook implementation:
+For the active `member-dashboard-chat-worker` LINE webhook implementation:
 
 ```text
 LINE_AUTO_REPLY_ENABLED=false
@@ -55,12 +51,6 @@ LINE_CHANNEL_ACCESS_TOKEN=...
 AIRTABLE_API_KEY=...
 AIRTABLE_BASE_ID=appsV1ILPRfIjkaYg
 AIRTABLE_SYNC_TABLE=MMD — Console Inbox
-```
-
-For the optional `mmdbkk.com/webhooks/line` bridge in `mmd-redirect-worker`:
-
-```text
-LINE_WEBHOOK_UPSTREAM_URL=https://<your-site>.netlify.app/.netlify/functions/webhook
 ```
 
 For `ai-worker`, keep it as intelligence support only. It should not hold public LINE webhook ownership:
@@ -111,7 +101,7 @@ Expected behavior:
 - Black Card is private review only.
 - LINE OA Kenji does not enable real Worker Control POST actions.
 - Deduped LINE events must not reply twice.
-- Netlify / immigrate-worker can be an upstream compatibility target, but should not become the canonical long-term LINE route owner.
+- `immigrate-worker` must stay legacy/migration unless explicitly reapproved for LINE production.
 - `admin-worker` must not be the public LINE webhook owner.
 - `telegram-worker` must not be the public chatbot owner.
 - `himai-chat-worker` is pattern reference only and must not be used as MMD production LINE.

--- a/docs/operations/line-connection-runbook.md
+++ b/docs/operations/line-connection-runbook.md
@@ -1,0 +1,50 @@
+# MMD LINE Connection Runbook
+
+Purpose: connect LINE Official Account traffic through the existing MMD front gate without creating a new Worker.
+
+## Ownership
+
+- Front gate: `mmd-redirect-worker`
+- Public domain: `mmdbkk.com`
+- Existing LINE upstream: existing LINE handler with Kenji member memory
+- Customer-facing route: `https://mmdbkk.com/webhooks/line`
+
+## Required routing rule
+
+LINE Developers should point to:
+
+```txt
+https://mmdbkk.com/webhooks/line
+```
+
+Do not point LINE directly to Webflow, Memberstack, or a page script.
+
+## Cloudflare setting
+
+Set the non-public upstream value on `mmd-redirect-worker`:
+
+```txt
+LINE_WEBHOOK_UPSTREAM_URL=<existing LINE handler URL>
+```
+
+The value must be configured in Cloudflare Worker settings. Do not expose it in Webflow.
+
+## Safe launch flags on the upstream
+
+Start with:
+
+```txt
+LINE_AUTO_REPLY_ENABLED=false
+LINE_KENJI_AI_ENABLED=true
+LINE_KENJI_AI_DEBUG=true
+```
+
+This keeps Kenji in receive, log, draft, and handoff mode before any broader auto reply is enabled.
+
+## Production rule
+
+Kenji may acknowledge safe low-risk requests only after review. Payment proof, final price, model availability, VIP or Black Card, refund, complaint, and private access must remain human or owner review.
+
+## Route lock
+
+Cloudflare Worker Router owns routing. Webflow displays pages only. Memberstack checks login and permission only. Page scripts must not perform global redirects. Unknown routes must not be sent to `/default` or `/autodirect`.

--- a/docs/operations/line-connection-runbook.md
+++ b/docs/operations/line-connection-runbook.md
@@ -1,45 +1,95 @@
 # MMD LINE Connection Runbook
 
-Purpose: connect LINE Official Account traffic through the existing MMD front gate without creating a new Worker.
+Purpose: connect LINE Official Account traffic through the MMD Kenji two-worker lock without creating another public LINE Worker.
 
-## Ownership
+## Two-worker lock
 
-- Front gate: `mmd-redirect-worker`
-- Public domain: `mmdbkk.com`
-- Existing LINE upstream: existing LINE handler with Kenji member memory
-- Customer-facing route: `https://mmdbkk.com/webhooks/line`
+The Kenji LINE route is locked to two workers:
 
-## Required routing rule
+1. `immigrate-worker`
+   - Owns LINE intake compatibility.
+   - Receives LINE webhook events or receives them behind a stable public bridge.
+   - Verifies LINE signature.
+   - Writes safe inbound records to Airtable / Console Inbox.
+   - Loads Kenji member memory where enabled.
+   - Creates draft, log, and handoff before any risky reply.
 
-LINE Developers should point to:
+2. `ai-worker`
+   - Owns AI search, retrieval, ranking, summarization, and intelligence support.
+   - Does not own LINE public webhook routing.
+   - Does not verify LINE signatures.
+   - Does not confirm payment, VIP, Black Card, final price, model availability, or private access.
+   - May be called by the LINE layer for approved knowledge and safe answer support.
+
+Do not use `mmd-redirect-worker` as Kenji brain. It may only act as front gate / bridge when healthy.
+
+Do not use `admin-worker` as public LINE webhook owner.
+
+Do not use `telegram-worker` as public chatbot owner.
+
+Do not use `himai-chat-worker` for MMD production LINE. It is a pattern reference only.
+
+## Preferred live flow
+
+```txt
+LINE Official Account
+→ stable public route
+→ immigrate-worker
+→ ai-worker when answer intelligence is needed
+→ Airtable / Console Inbox / Admin handoff
+```
+
+## Stable public route option
+
+LINE Developers may point to the stable MMD domain route when the front gate is healthy:
 
 ```txt
 https://mmdbkk.com/webhooks/line
 ```
 
-Do not point LINE directly to Webflow, Memberstack, or a page script.
-
-## Cloudflare setting
-
-Set the non-public upstream value on `mmd-redirect-worker`:
+This route may bridge through `mmd-redirect-worker` using:
 
 ```txt
-LINE_WEBHOOK_UPSTREAM_URL=<existing LINE handler URL>
+LINE_WEBHOOK_UPSTREAM_URL=<existing immigrate-worker LINE handler URL>
 ```
 
-The value must be configured in Cloudflare Worker settings. Do not expose it in Webflow.
+## Bypass route option
 
-## Safe launch flags on the upstream
-
-Start with:
+If `mmd-redirect-worker` is unstable, bypass it and point LINE Developers directly to the existing LINE upstream until the front gate is repaired:
 
 ```txt
-LINE_AUTO_REPLY_ENABLED=false
+https://<your-site>.netlify.app/.netlify/functions/webhook
+```
+
+This is allowed as a compatibility bypass, not as the long-term canonical owner.
+
+## Required env on immigrate-worker LINE upstream
+
+```txt
+LINE_CHANNEL_SECRET=...
+LINE_CHANNEL_ACCESS_TOKEN=...
+AIRTABLE_API_KEY=...
+AIRTABLE_BASE_ID=appsV1ILPRfIjkaYg
+AIRTABLE_SYNC_TABLE=MMD — Console Inbox
 LINE_KENJI_AI_ENABLED=true
 LINE_KENJI_AI_DEBUG=true
+LINE_AUTO_REPLY_ENABLED=false
 ```
 
-This keeps Kenji in receive, log, draft, and handoff mode before any broader auto reply is enabled.
+`LINE_AUTO_REPLY_ENABLED=false` is the safe launch default. Keep it off until owner review confirms low-risk reply behavior.
+
+## Required env on ai-worker
+
+`ai-worker` should hold only intelligence-side settings. It must not hold public LINE webhook ownership.
+
+```txt
+AI_MAX_RESULTS=...
+AI_TIMEOUT_MS=...
+FEATURE_RETRIEVAL=true
+FEATURE_SUMMARIZATION=true
+```
+
+Add Airtable or knowledge-source bindings only when the AI layer is approved to retrieve from those sources.
 
 ## Production rule
 
@@ -48,3 +98,13 @@ Kenji may acknowledge safe low-risk requests only after review. Payment proof, f
 ## Route lock
 
 Cloudflare Worker Router owns routing. Webflow displays pages only. Memberstack checks login and permission only. Page scripts must not perform global redirects. Unknown routes must not be sent to `/default` or `/autodirect`.
+
+## Final lock statement
+
+For Kenji LINE, lock runtime responsibility as:
+
+```txt
+immigrate-worker = LINE intake and handoff bridge
+ai-worker = intelligence and answer support
+mmd-redirect-worker = optional bridge/front gate only
+```

--- a/docs/operations/line-connection-runbook.md
+++ b/docs/operations/line-connection-runbook.md
@@ -1,27 +1,29 @@
 # MMD LINE Connection Runbook
 
-Purpose: connect LINE Official Account traffic through the MMD Kenji two-worker lock without creating another public LINE Worker.
+Purpose: connect LINE Official Account traffic using the current MMD memory lock without creating another public LINE Worker and without reviving legacy migration ownership.
 
-## Two-worker lock
+## Current MMD memory lock
 
-The Kenji LINE route is locked to two workers:
+The production LINE OFC route remains:
 
-1. `immigrate-worker`
-   - Owns LINE intake compatibility.
-   - Receives LINE webhook events or receives them behind a stable public bridge.
-   - Verifies LINE signature.
-   - Writes safe inbound records to Airtable / Console Inbox.
-   - Loads Kenji member memory where enabled.
-   - Creates draft, log, and handoff before any risky reply.
+```txt
+https://mmdbkk.com/webhooks/line
+```
 
-2. `ai-worker`
-   - Owns AI search, retrieval, ranking, summarization, and intelligence support.
-   - Does not own LINE public webhook routing.
-   - Does not verify LINE signatures.
-   - Does not confirm payment, VIP, Black Card, final price, model availability, or private access.
-   - May be called by the LINE layer for approved knowledge and safe answer support.
+The runtime ownership lock is:
 
-Do not use `mmd-redirect-worker` as Kenji brain. It may only act as front gate / bridge when healthy.
+```txt
+member-dashboard-chat-worker = current production LINE webhook owner / Kenji member-facing entry
+ai-worker = intelligence and answer support
+```
+
+Long-term architecture may rename or consolidate the LINE surface into `chat-worker`, but the current deployed production owner from MMD memory is `member-dashboard-chat-worker`.
+
+## Explicit exclusions
+
+Do not revive or retarget LINE OFC to `immigrate-worker` unless there is a separate, explicit migration decision.
+
+Do not use `mmd-redirect-worker` as Kenji brain. It must not own `/webhooks/line`; it may only pass through or front-gate routes that are not owned by a more specific worker.
 
 Do not use `admin-worker` as public LINE webhook owner.
 
@@ -33,67 +35,58 @@ Do not use `himai-chat-worker` for MMD production LINE. It is a pattern referenc
 
 ```txt
 LINE Official Account
-→ stable public route
-→ immigrate-worker
+→ https://mmdbkk.com/webhooks/line
+→ member-dashboard-chat-worker
 → ai-worker when answer intelligence is needed
 → Airtable / Console Inbox / Admin handoff
 ```
 
-## Stable public route option
+## Route requirement
 
-LINE Developers may point to the stable MMD domain route when the front gate is healthy:
+LINE Developers should point to:
 
 ```txt
 https://mmdbkk.com/webhooks/line
 ```
 
-This route may bridge through `mmd-redirect-worker` using:
+Do not point LINE directly to Webflow, Memberstack, page script, Telegram, admin-worker, or a generic redirect route.
+
+## Current safety mode
+
+Start or keep safe mode unless owner review confirms low-risk behavior:
 
 ```txt
-LINE_WEBHOOK_UPSTREAM_URL=<existing immigrate-worker LINE handler URL>
-```
-
-## Bypass route option
-
-If `mmd-redirect-worker` is unstable, bypass it and point LINE Developers directly to the existing LINE upstream until the front gate is repaired:
-
-```txt
-https://<your-site>.netlify.app/.netlify/functions/webhook
-```
-
-This is allowed as a compatibility bypass, not as the long-term canonical owner.
-
-## Required env on immigrate-worker LINE upstream
-
-```txt
-LINE_CHANNEL_SECRET=...
-LINE_CHANNEL_ACCESS_TOKEN=...
-AIRTABLE_API_KEY=...
-AIRTABLE_BASE_ID=appsV1ILPRfIjkaYg
-AIRTABLE_SYNC_TABLE=MMD — Console Inbox
+LINE_AUTO_REPLY_ENABLED=false
 LINE_KENJI_AI_ENABLED=true
 LINE_KENJI_AI_DEBUG=true
-LINE_AUTO_REPLY_ENABLED=false
 ```
 
-`LINE_AUTO_REPLY_ENABLED=false` is the safe launch default. Keep it off until owner review confirms low-risk reply behavior.
+If production has already enabled auto reply, only allow low-risk acknowledgement flows. Payment proof, final price, model availability, VIP, Black Card, refund, complaint, and private access remain human or owner review.
 
-## Required env on ai-worker
+## ai-worker role
 
-`ai-worker` should hold only intelligence-side settings. It must not hold public LINE webhook ownership.
+`ai-worker` should hold only intelligence-side responsibilities:
 
-```txt
-AI_MAX_RESULTS=...
-AI_TIMEOUT_MS=...
-FEATURE_RETRIEVAL=true
-FEATURE_SUMMARIZATION=true
-```
+- search
+- retrieval
+- ranking
+- summarization
+- answer support for approved knowledge/context
 
-Add Airtable or knowledge-source bindings only when the AI layer is approved to retrieve from those sources.
+It must not verify LINE signatures, own LINE public routing, grant access, confirm payment, or make owner-level decisions.
 
-## Production rule
+## member-dashboard-chat-worker role
 
-Kenji may acknowledge safe low-risk requests only after review. Payment proof, final price, model availability, VIP or Black Card, refund, complaint, and private access must remain human or owner review.
+`member-dashboard-chat-worker` owns the LINE entry while this MMD memory lock is active:
+
+- `POST /webhooks/line`
+- LINE signature verification
+- `Hi Per` / Kenji trigger handling
+- safe LINE reply behavior
+- Airtable Console Inbox logging
+- member-facing LINE continuity
+
+This worker may call `ai-worker` for answer intelligence, but public LINE webhook ownership stays here.
 
 ## Route lock
 
@@ -104,7 +97,8 @@ Cloudflare Worker Router owns routing. Webflow displays pages only. Memberstack 
 For Kenji LINE, lock runtime responsibility as:
 
 ```txt
-immigrate-worker = LINE intake and handoff bridge
+member-dashboard-chat-worker = LINE webhook owner and Kenji member-facing entry
 ai-worker = intelligence and answer support
-mmd-redirect-worker = optional bridge/front gate only
+mmd-redirect-worker = not LINE owner; no Kenji brain role
+immigrate-worker = legacy/migration only; do not revive for LINE OFC without explicit decision
 ```


### PR DESCRIPTION
This PR locks Kenji LINE runtime ownership to the current MMD memory model.

Final lock:
- `member-dashboard-chat-worker` = current production LINE webhook owner and Kenji member-facing entry.
- `ai-worker` = intelligence and answer support.
- `mmd-redirect-worker` = optional route bridge/front gate only, not Kenji brain and not LINE owner.
- `immigrate-worker` = legacy/migration compatibility only; do not revive for LINE OFC without a separate explicit decision.

Changes:
- Adds `docs/operations/line-connection-runbook.md` with the MMD memory owner lock, route requirement, safety boundaries, and exclusions.
- Updates `docs/line/kenji-line-official.md` so the main LINE documentation matches the current deployed owner lock.

Production rule:
- Payment proof, final price, model availability, VIP, Black Card, refund, complaint, and private access remain human/owner review.
- `admin-worker` must not be the public LINE webhook owner.
- `telegram-worker` must not be the public chatbot owner.
- `himai-chat-worker` is pattern reference only and must not be used as MMD production LINE.

Safe launch:
- Keep `LINE_AUTO_REPLY_ENABLED=false` unless owner review confirms low-risk reply behavior.