### PR TITLE
MMD route governance lock

### DIFF
--- a/docs/checklists/MMD_ROUTE_LOCK_SMOKE_CHECKLIST_20260701.md
+++ b/docs/checklists/MMD_ROUTE_LOCK_SMOKE_CHECKLIST_20260701.md
@@ -1,0 +1,72 @@
+# MMD Route Lock Smoke Checklist - 2026-07-01
+
+Use these checks without secrets. Run with redirects disabled first.
+
+## Route Smoke
+
+```bash
+curl -I -sS https://mmdbkk.com/sigil/pay/membership
+curl -I -sS 'https://mmdbkk.com/sigil/pay/membership?code=TEST'
+curl -I -sS 'https://mmdbkk.com/sigil/pay/membership?package=premium'
+curl -I -sS 'https://mmdbkk.com/sigil/pay/membership?plan=standard'
+curl -I -sS https://www.mmdbkk.com/sigil/pay/membership
+curl -I -sS 'https://www.mmdbkk.com/sigil/pay/membership?code=TEST'
+curl -I -sS https://mmdbkk.com/pay/membership
+curl -I -sS 'https://mmdbkk.com/pay/membership?plan=standard'
+curl -I -sS https://mmdbkk.com/sigil/pay/renewal
+curl -I -sS https://www.mmdbkk.com/sigil/pay/renewal
+curl -I -sS https://mmdbkk.com/pay/renewal
+curl -I -sS https://www.mmdbkk.com/pay/renewal
+curl -I -sS https://mmdbkk.com/unknown-test-route-mmd
+```
+
+Expected:
+
+- `/sigil/pay/membership` is not `301`, `302`, `307`, or `308` to `/sigil/pay/renewal`.
+- `Location` must not contain `/sigil/pay/renewal` on membership payment routes.
+- Membership routes must not include `x-mmd-route-source: member-dashboard-chat-worker:sigil-pay-renewal`.
+- `/pay/membership` is served safely through the front gate/member pages path.
+- `/sigil/pay/renewal` and `/pay/renewal` remain manual legacy renewal evidence routes.
+- Unknown routes do not redirect to `/default`, `/autodirect`, or `/sigil/pay/renewal`.
+
+## LIFF Smoke
+
+```bash
+curl -sS -X POST https://mmdbkk.com/member/api/liff/identify \
+  -H 'content-type: application/json' \
+  --data '{"line_user_id":"Ucodexmin_route_lock_check","entry_route":"renewal","t":"tok"}'
+
+curl -sS -X POST https://mmdbkk.com/member/api/liff/identify \
+  -H 'content-type: application/json' \
+  --data '{"line_user_id":"Ucodexmin_route_lock_check","entry_route":"pay_membership","t":"tok"}'
+```
+
+Expected renewal response:
+
+- `ok: true`
+- `intent: membership_review`
+- `next_route: /member/membership?t=tok`
+- `safe_next.renewal: null`
+- `safe_next.sigil_payment: /sigil/pay/membership?t=tok`
+- response does not include `/sigil/pay/renewal`
+
+Expected pay_membership response:
+
+- `ok: true`
+- `next_route: /pay/membership?t=tok`
+- `safe_next.renewal: null`
+- `safe_next.sigil_payment: /sigil/pay/membership?t=tok`
+
+## Worker Route Ownership
+
+Expected Worker route ownership:
+
+- no `mmdbkk.com/sigil/pay/membership*` route assigned to `member-dashboard-chat-worker`;
+- no `www.mmdbkk.com/sigil/pay/membership*` route assigned to `member-dashboard-chat-worker`;
+- `member-dashboard-chat-worker` may own only explicit manual renewal routes:
+  - `mmdbkk.com/pay/renewal*`
+  - `www.mmdbkk.com/pay/renewal*`
+  - `mmdbkk.com/sigil/pay/renewal*`
+  - `www.mmdbkk.com/sigil/pay/renewal*`
+
+Do not recreate the deleted membership route bindings.

--- a/docs/locks/MMD_ROUTE_OWNER_LOCK_20260701.md
+++ b/docs/locks/MMD_ROUTE_OWNER_LOCK_20260701.md
@@ -1,0 +1,96 @@
+# MMD Route Owner Lock - 2026-07-01
+
+Status: locked after production repair.
+
+## Incident Summary
+
+`/sigil/pay/membership` was returning a `308` redirect to `/sigil/pay/renewal`.
+The response identified `x-mmd-route-source: member-dashboard-chat-worker:sigil-pay-renewal`.
+
+This was not caused by `member-pages-worker` source logic and was not caused by
+`mmd-redirect-worker` source logic. The root cause was a wrong Cloudflare Worker
+route binding that sent the membership payment route to `member-dashboard-chat-worker`.
+
+## Deleted Route Bindings
+
+The following Cloudflare Worker routes were deleted:
+
+| Pattern | Route ID | Former owner |
+| --- | --- | --- |
+| `mmdbkk.com/sigil/pay/membership*` | `bc9521436bf74261a42d3bce97d25fa8` | `member-dashboard-chat-worker` |
+| `www.mmdbkk.com/sigil/pay/membership*` | `372a30bf70da4f64bcb5de6a62e64501` | `member-dashboard-chat-worker` |
+
+Do not recreate these bindings.
+
+## Permanent Ownership
+
+Membership payment routes:
+
+- `/sigil/pay/membership`
+- `/pay/membership`
+
+Manual legacy renewal evidence routes:
+
+- `/sigil/pay/renewal`
+- `/pay/renewal`
+
+`member-dashboard-chat-worker` may own only explicit manual renewal evidence
+routes such as:
+
+- `mmdbkk.com/pay/renewal*`
+- `www.mmdbkk.com/pay/renewal*`
+- `mmdbkk.com/sigil/pay/renewal*`
+- `www.mmdbkk.com/sigil/pay/renewal*`
+
+## Forbidden
+
+- `member-dashboard-chat-worker` must not own `/sigil/pay/membership`.
+- `/sigil/pay/membership` must never redirect to `/sigil/pay/renewal`.
+- `/pay/membership` must never redirect to `/sigil/pay/renewal`.
+- Unknown routes must never redirect to `/default`, `/autodirect`, or `/sigil/pay/renewal`.
+- Do not add `/sigil/pay/membership` to any renewal worker or renewal route family.
+
+## Live Verified Versions
+
+- `member-pages-worker`: `20260701-disable-auto-renewal-routing`
+- `mmd-redirect-worker`: `20260701-sigil-pay-membership-exact-safe`
+
+## Final Smoke Checklist
+
+- `/sigil/pay/membership`: safe, no redirect to renewal.
+- `/sigil/pay/membership?code=TEST`: safe, query preserved/passed through.
+- `/sigil/pay/membership?package=premium`: safe, query preserved/passed through.
+- `/sigil/pay/membership?plan=standard`: safe, query preserved/passed through.
+- `www.mmdbkk.com/sigil/pay/membership`: safe.
+- `/pay/membership`: safe, served through `member-pages-worker`.
+- `/sigil/pay/renewal`: manual legacy only, served by `member-dashboard-chat-worker`.
+- `/pay/renewal`: manual legacy only, served by `member-dashboard-chat-worker`.
+- `/unknown-test-route-mmd`: safe 404/recovery behavior, no renewal/default/autodirect redirect.
+- LIFF `entry_route=renewal`: safe, normalizes to `membership_review`.
+- LIFF `entry_route=pay_membership`: safe, routes to `/pay/membership`.
+
+## Evidence
+
+Redacted Worker route snapshot:
+
+`/Users/Hiright_1/.mmd-secrets/codexmin-backups/mmd-route-lock-worker-routes-after-fix-20260701.json`
+
+The snapshot asserts:
+
+- no `mmdbkk.com/sigil/pay/membership*` route is assigned to `member-dashboard-chat-worker`;
+- no `www.mmdbkk.com/sigil/pay/membership*` route is assigned to `member-dashboard-chat-worker`;
+- `member-dashboard-chat-worker` pay routes are explicit renewal routes only;
+- no global catch-all sends membership routes to `member-dashboard-chat-worker`.
+
+## Remaining Audit Gap
+
+Cloudflare Page Rules, Rulesets, and Bulk Redirect API checks returned `403` for
+the current local OAuth token. A complete external redirect audit requires
+read-only permissions equivalent to:
+
+- Zone Rulesets Read
+- Zone Page Rules Read
+- Account Bulk Redirects Read
+
+No Webflow, Memberstack, DNS, secrets, Airtable, or code changes were made for
+the route-binding repair.

--- a/member-pages-worker/test/liff-identity.test.mjs
+++ b/member-pages-worker/test/liff-identity.test.mjs
@@ -22,6 +22,13 @@ async function identify(payload, url = "https://mmdbkk.com/member/api/liff/ident
   return { response, body };
 }
 
+function assertNoAutoRenewalRoute(data, expectedSigilPayment = "/sigil/pay/membership?t=tok") {
+  assert.doesNotMatch(JSON.stringify(data), /\/sigil\/pay\/renewal/);
+  assert.equal(data.safe_next.renewal, null);
+  assert.equal(data.safe_next.sigil_payment, expectedSigilPayment);
+  assert.equal(data.auto_renewal_route_disabled, true);
+}
+
 describe("LIFF identity bridge", () => {
   it("keeps public membership LIFF flow out of SIGIL by default", async () => {
     const { response, body } = await identify({
@@ -205,11 +212,11 @@ describe("LIFF identity bridge", () => {
     assert.equal(body.data.rich_menu_target, "private_member");
     assert.equal(body.data.next_route, "/member/profile?t=tok&status=active");
     assert.equal(body.data.safe_next.booking, "/sigil/booking?t=tok");
-    assert.equal(body.data.safe_next.renewal, "/sigil/pay/renewal?t=tok");
     assert.equal(body.data.safe_next.dashboard, null);
+    assertNoAutoRenewalRoute(body.data);
   });
 
-  it("member_status expired and renewal expired route to /sigil/pay/renewal", async () => {
+  it("member_status expired and renewal route to membership review without auto-renewal", async () => {
     const env = {
       MEMBER_STATUS_RESOLVER: memberStatusResolver({
         membership_state: "expired",
@@ -221,14 +228,29 @@ describe("LIFF identity bridge", () => {
     const renewalResult = await identify({ line_user_id: "Uabc123", entry_route: "renewal", t: "tok" }, "https://mmdbkk.com/member/api/liff/identify", env);
 
     assert.equal(statusResult.body.data.membership_state, "expired");
-    assert.equal(statusResult.body.data.rich_menu_target, "renewal_required");
-    assert.equal(statusResult.body.data.next_route, "/sigil/pay/renewal?t=tok");
-    assert.equal(renewalResult.body.data.intent, "renewal");
-    assert.equal(renewalResult.body.data.next_route, "/sigil/pay/renewal?t=tok");
+    assert.equal(statusResult.body.data.rich_menu_target, "public_member");
+    assert.equal(statusResult.body.data.next_route, "/member/membership?t=tok");
+    assert.equal(statusResult.body.data.safe_next.booking, null);
+    assertNoAutoRenewalRoute(statusResult.body.data);
+    assert.equal(renewalResult.body.data.intent, "membership_review");
+    assert.equal(renewalResult.body.data.next_route, "/member/membership?t=tok");
     assert.equal(renewalResult.body.data.safe_next.dashboard, null);
+    assertNoAutoRenewalRoute(renewalResult.body.data);
   });
 
-  it("booking_request active/current routes to /sigil/booking and expired routes renewal", async () => {
+  it("renew entry route normalizes to membership review without auto-renewal", async () => {
+    const { body } = await identify(
+      { line_user_id: "Uabc123", entry_route: "renew", t: "tok" },
+      "https://mmdbkk.com/member/api/liff/identify",
+    );
+
+    assert.equal(body.ok, true);
+    assert.equal(body.data.intent, "membership_review");
+    assert.equal(body.data.next_route, "/member/membership?t=tok");
+    assertNoAutoRenewalRoute(body.data);
+  });
+
+  it("booking_request active/current routes to /sigil/booking and expired routes to membership", async () => {
     const active = await identify(
       { line_user_id: "Uabc123", entry_route: "booking_request", t: "tok" },
       "https://mmdbkk.com/member/api/liff/identify",
@@ -254,8 +276,25 @@ describe("LIFF identity bridge", () => {
     assert.equal(active.body.data.next_route, "/sigil/booking?t=tok");
     assert.equal(active.body.data.rich_menu_target, "private_member");
     assert.equal(active.body.data.safe_next.dashboard, null);
-    assert.equal(expired.body.data.next_route, "/sigil/pay/renewal?t=tok");
-    assert.equal(expired.body.data.rich_menu_target, "renewal_required");
+    assert.equal(expired.body.data.next_route, "/member/membership?t=tok");
+    assert.equal(expired.body.data.rich_menu_target, "public_member");
+    assert.equal(expired.body.data.safe_next.booking, null);
+    assertNoAutoRenewalRoute(expired.body.data);
+  });
+
+  it("payment entry routes go to membership payment without auto-renewal", async () => {
+    for (const entry_route of ["pay_membership", "payment"]) {
+      const { body } = await identify(
+        { line_user_id: "Uabc123", entry_route, t: "tok" },
+        "https://mmdbkk.com/member/api/liff/identify",
+      );
+
+      assert.equal(body.ok, true);
+      assert.equal(body.data.intent, "pay_membership");
+      assert.equal(body.data.next_route, "/pay/membership?t=tok");
+      assert.equal(body.data.safe_next.payment, "/pay/membership?t=tok");
+      assertNoAutoRenewalRoute(body.data);
+    }
   });
 
   it("no paid package keeps public member path and unknown never pretends active", async () => {
@@ -279,11 +318,13 @@ describe("LIFF identity bridge", () => {
     assert.equal(noPaid.body.data.rich_menu_target, "public_member");
     assert.equal(noPaid.body.data.next_route, "/member/membership?t=tok");
     assert.equal(noPaid.body.data.safe_next.booking, null);
+    assertNoAutoRenewalRoute(noPaid.body.data);
     assert.equal(unknown.body.data.membership_state, "unknown");
     assert.equal(unknown.body.data.package_state, "unknown");
     assert.equal(unknown.body.data.rich_menu_target, "public_member");
-    assert.equal(unknown.body.data.next_route, "/member/profile?t=tok&status=review_required");
+    assert.equal(unknown.body.data.next_route, "/member/membership?t=tok");
     assert.equal(unknown.body.data.safe_next.dashboard, null);
+    assertNoAutoRenewalRoute(unknown.body.data);
   });
 
   it("requires line_user_id", async () => {


### PR DESCRIPTION
Production issue was caused by wrong Cloudflare Worker route bindings.

Deleted wrong Worker routes:
- `mmdbkk.com/sigil/pay/membership*`
- `www.mmdbkk.com/sigil/pay/membership*`

This PR includes route lock docs, smoke checklist, and LIFF test realignment.

No production source changes.
No deploy required.

Governance lock:
- `member-dashboard-chat-worker` must not own `/sigil/pay/membership`.
- `/sigil/pay/membership` must never redirect to `/sigil/pay/renewal`.
- `/sigil/pay/renewal` remains manual legacy only.

Tests passed:
- `node --test member-pages-worker/test/liff-identity.test.mjs`
- `node --test mmd-redirect-worker/test/redirect.test.mjs`
- `node --test member-dashboard-chat-worker/test/renewal-route.test.mjs`

Final live smoke passed.

Cloudflare Page Rules / Rulesets / Bulk Redirect audit remains blocked by 403 until token has:
- Zone Rulesets Read
- Zone Page Rules Read
- Account Bulk Redirects Read
