### PR TITLE
MMD route governance connector lock

### DIFF
--- a/docs/checklists/MMD_ROUTE_LOCK_SMOKE_CHECKLIST_20260701.md
+++ b/docs/checklists/MMD_ROUTE_LOCK_SMOKE_CHECKLIST_20260701.md
@@ -1,0 +1,72 @@
+# MMD Route Lock Smoke Checklist - 2026-07-01
+
+Use these checks without secrets. Run with redirects disabled first.
+
+## Route Smoke
+
+```bash
+curl -I -sS https://mmdbkk.com/sigil/pay/membership
+curl -I -sS 'https://mmdbkk.com/sigil/pay/membership?code=TEST'
+curl -I -sS 'https://mmdbkk.com/sigil/pay/membership?package=premium'
+curl -I -sS 'https://mmdbkk.com/sigil/pay/membership?plan=standard'
+curl -I -sS https://www.mmdbkk.com/sigil/pay/membership
+curl -I -sS 'https://www.mmdbkk.com/sigil/pay/membership?code=TEST'
+curl -I -sS https://mmdbkk.com/pay/membership
+curl -I -sS 'https://mmdbkk.com/pay/membership?plan=standard'
+curl -I -sS https://mmdbkk.com/sigil/pay/renewal
+curl -I -sS https://www.mmdbkk.com/sigil/pay/renewal
+curl -I -sS https://mmdbkk.com/pay/renewal
+curl -I -sS https://www.mmdbkk.com/pay/renewal
+curl -I -sS https://mmdbkk.com/unknown-test-route-mmd
+```
+
+Expected:
+
+- `/sigil/pay/membership` is not `301`, `302`, `307`, or `308` to `/sigil/pay/renewal`.
+- `Location` must not contain `/sigil/pay/renewal` on membership payment routes.
+- Membership routes must not include `x-mmd-route-source: member-dashboard-chat-worker:sigil-pay-renewal`.
+- `/pay/membership` is served safely through the front gate/member pages path.
+- `/sigil/pay/renewal` and `/pay/renewal` remain manual legacy renewal evidence routes.
+- Unknown routes do not redirect to `/default`, `/autodirect`, or `/sigil/pay/renewal`.
+
+## LIFF Smoke
+
+```bash
+curl -sS -X POST https://mmdbkk.com/member/api/liff/identify \
+  -H 'content-type: application/json' \
+  --data '{"line_user_id":"Ucodexmin_route_lock_check","entry_route":"renewal","t":"tok"}'
+
+curl -sS -X POST https://mmdbkk.com/member/api/liff/identify \
+  -H 'content-type: application/json' \
+  --data '{"line_user_id":"Ucodexmin_route_lock_check","entry_route":"pay_membership","t":"tok"}'
+```
+
+Expected renewal response:
+
+- `ok: true`
+- `intent: membership_review`
+- `next_route: /member/membership?t=tok`
+- `safe_next.renewal: null`
+- `safe_next.sigil_payment: /sigil/pay/membership?t=tok`
+- response does not include `/sigil/pay/renewal`
+
+Expected pay_membership response:
+
+- `ok: true`
+- `next_route: /pay/membership?t=tok`
+- `safe_next.renewal: null`
+- `safe_next.sigil_payment: /sigil/pay/membership?t=tok`
+
+## Worker Route Ownership
+
+Expected Worker route ownership:
+
+- no `mmdbkk.com/sigil/pay/membership*` route assigned to `member-dashboard-chat-worker`;
+- no `www.mmdbkk.com/sigil/pay/membership*` route assigned to `member-dashboard-chat-worker`;
+- `member-dashboard-chat-worker` may own only explicit manual renewal routes:
+  - `mmdbkk.com/pay/renewal*`
+  - `www.mmdbkk.com/pay/renewal*`
+  - `mmdbkk.com/sigil/pay/renewal*`
+  - `www.mmdbkk.com/sigil/pay/renewal*`
+
+Do not recreate the deleted membership route bindings.

--- a/docs/locks/MMD_ROUTE_OWNER_LOCK_20260701.md
+++ b/docs/locks/MMD_ROUTE_OWNER_LOCK_20260701.md
@@ -1,0 +1,96 @@
+# MMD Route Owner Lock - 2026-07-01
+
+Status: locked after production repair.
+
+## Incident Summary
+
+`/sigil/pay/membership` was returning a `308` redirect to `/sigil/pay/renewal`.
+The response identified `x-mmd-route-source: member-dashboard-chat-worker:sigil-pay-renewal`.
+
+This was not caused by `member-pages-worker` source logic and was not caused by
+`mmd-redirect-worker` source logic. The root cause was a wrong Cloudflare Worker
+route binding that sent the membership payment route to `member-dashboard-chat-worker`.
+
+## Deleted Route Bindings
+
+The following Cloudflare Worker routes were deleted:
+
+| Pattern | Route ID | Former owner |
+| --- | --- | --- |
+| `mmdbkk.com/sigil/pay/membership*` | `bc9521436bf74261a42d3bce97d25fa8` | `member-dashboard-chat-worker` |
+| `www.mmdbkk.com/sigil/pay/membership*` | `372a30bf70da4f64bcb5de6a62e64501` | `member-dashboard-chat-worker` |
+
+Do not recreate these bindings.
+
+## Permanent Ownership
+
+Membership payment routes:
+
+- `/sigil/pay/membership`
+- `/pay/membership`
+
+Manual legacy renewal evidence routes:
+
+- `/sigil/pay/renewal`
+- `/pay/renewal`
+
+`member-dashboard-chat-worker` may own only explicit manual renewal evidence
+routes such as:
+
+- `mmdbkk.com/pay/renewal*`
+- `www.mmdbkk.com/pay/renewal*`
+- `mmdbkk.com/sigil/pay/renewal*`
+- `www.mmdbkk.com/sigil/pay/renewal*`
+
+## Forbidden
+
+- `member-dashboard-chat-worker` must not own `/sigil/pay/membership`.
+- `/sigil/pay/membership` must never redirect to `/sigil/pay/renewal`.
+- `/pay/membership` must never redirect to `/sigil/pay/renewal`.
+- Unknown routes must never redirect to `/default`, `/autodirect`, or `/sigil/pay/renewal`.
+- Do not add `/sigil/pay/membership` to any renewal worker or renewal route family.
+
+## Live Verified Versions
+
+- `member-pages-worker`: `20260701-disable-auto-renewal-routing`
+- `mmd-redirect-worker`: `20260701-sigil-pay-membership-exact-safe`
+
+## Final Smoke Checklist
+
+- `/sigil/pay/membership`: safe, no redirect to renewal.
+- `/sigil/pay/membership?code=TEST`: safe, query preserved/passed through.
+- `/sigil/pay/membership?package=premium`: safe, query preserved/passed through.
+- `/sigil/pay/membership?plan=standard`: safe, query preserved/passed through.
+- `www.mmdbkk.com/sigil/pay/membership`: safe.
+- `/pay/membership`: safe, served through `member-pages-worker`.
+- `/sigil/pay/renewal`: manual legacy only, served by `member-dashboard-chat-worker`.
+- `/pay/renewal`: manual legacy only, served by `member-dashboard-chat-worker`.
+- `/unknown-test-route-mmd`: safe 404/recovery behavior, no renewal/default/autodirect redirect.
+- LIFF `entry_route=renewal`: safe, normalizes to `membership_review`.
+- LIFF `entry_route=pay_membership`: safe, routes to `/pay/membership`.
+
+## Evidence
+
+Redacted Worker route snapshot:
+
+`/Users/Hiright_1/.mmd-secrets/codexmin-backups/mmd-route-lock-worker-routes-after-fix-20260701.json`
+
+The snapshot asserts:
+
+- no `mmdbkk.com/sigil/pay/membership*` route is assigned to `member-dashboard-chat-worker`;
+- no `www.mmdbkk.com/sigil/pay/membership*` route is assigned to `member-dashboard-chat-worker`;
+- `member-dashboard-chat-worker` pay routes are explicit renewal routes only;
+- no global catch-all sends membership routes to `member-dashboard-chat-worker`.
+
+## Remaining Audit Gap
+
+Cloudflare Page Rules, Rulesets, and Bulk Redirect API checks returned `403` for
+the current local OAuth token. A complete external redirect audit requires
+read-only permissions equivalent to:
+
+- Zone Rulesets Read
+- Zone Page Rules Read
+- Account Bulk Redirects Read
+
+No Webflow, Memberstack, DNS, secrets, Airtable, or code changes were made for
+the route-binding repair.

--- a/member-pages-worker/test/liff-identity.test.mjs
+++ b/member-pages-worker/test/liff-identity.test.mjs
@@ -22,6 +22,13 @@ async function identify(payload, url = "https://mmdbkk.com/member/api/liff/ident
   return { response, body };
 }
 
+function assertNoAutoRenewalRoute(data, expectedSigilPayment = "/sigil/pay/membership?t=tok") {
+  assert.doesNotMatch(JSON.stringify(data), /\/sigil\/pay\/renewal/);
+  assert.equal(data.safe_next.renewal, null);
+  assert.equal(data.safe_next.sigil_payment, expectedSigilPayment);
+  assert.equal(data.auto_renewal_route_disabled, true);
+}
+
 describe("LIFF identity bridge", () => {
   it("keeps public membership LIFF flow out of SIGIL by default", async () => {
     const { response, body } = await identify({
@@ -205,11 +212,11 @@ describe("LIFF identity bridge", () => {
     assert.equal(body.data.rich_menu_target, "private_member");
     assert.equal(body.data.next_route, "/member/profile?t=tok&status=active");
     assert.equal(body.data.safe_next.booking, "/sigil/booking?t=tok");
-    assert.equal(body.data.safe_next.renewal, "/sigil/pay/renewal?t=tok");
     assert.equal(body.data.safe_next.dashboard, null);
+    assertNoAutoRenewalRoute(body.data);
   });
 
-  it("member_status expired and renewal expired route to /sigil/pay/renewal", async () => {
+  it("member_status expired and renewal route to membership review without auto-renewal", async () => {
     const env = {
       MEMBER_STATUS_RESOLVER: memberStatusResolver({
         membership_state: "expired",
@@ -221,14 +228,29 @@ describe("LIFF identity bridge", () => {
     const renewalResult = await identify({ line_user_id: "Uabc123", entry_route: "renewal", t: "tok" }, "https://mmdbkk.com/member/api/liff/identify", env);
 
     assert.equal(statusResult.body.data.membership_state, "expired");
-    assert.equal(statusResult.body.data.rich_menu_target, "renewal_required");
-    assert.equal(statusResult.body.data.next_route, "/sigil/pay/renewal?t=tok");
-    assert.equal(renewalResult.body.data.intent, "renewal");
-    assert.equal(renewalResult.body.data.next_route, "/sigil/pay/renewal?t=tok");
+    assert.equal(statusResult.body.data.rich_menu_target, "public_member");
+    assert.equal(statusResult.body.data.next_route, "/member/membership?t=tok");
+    assert.equal(statusResult.body.data.safe_next.booking, null);
+    assertNoAutoRenewalRoute(statusResult.body.data);
+    assert.equal(renewalResult.body.data.intent, "membership_review");
+    assert.equal(renewalResult.body.data.next_route, "/member/membership?t=tok");
     assert.equal(renewalResult.body.data.safe_next.dashboard, null);
+    assertNoAutoRenewalRoute(renewalResult.body.data);
   });
 
-  it("booking_request active/current routes to /sigil/booking and expired routes renewal", async () => {
+  it("renew entry route normalizes to membership review without auto-renewal", async () => {
+    const { body } = await identify(
+      { line_user_id: "Uabc123", entry_route: "renew", t: "tok" },
+      "https://mmdbkk.com/member/api/liff/identify",
+    );
+
+    assert.equal(body.ok, true);
+    assert.equal(body.data.intent, "membership_review");
+    assert.equal(body.data.next_route, "/member/membership?t=tok");
+    assertNoAutoRenewalRoute(body.data);
+  });
+
+  it("booking_request active/current routes to /sigil/booking and expired routes to membership", async () => {
     const active = await identify(
       { line_user_id: "Uabc123", entry_route: "booking_request", t: "tok" },
       "https://mmdbkk.com/member/api/liff/identify",
@@ -254,8 +276,25 @@ describe("LIFF identity bridge", () => {
     assert.equal(active.body.data.next_route, "/sigil/booking?t=tok");
     assert.equal(active.body.data.rich_menu_target, "private_member");
     assert.equal(active.body.data.safe_next.dashboard, null);
-    assert.equal(expired.body.data.next_route, "/sigil/pay/renewal?t=tok");
-    assert.equal(expired.body.data.rich_menu_target, "renewal_required");
+    assert.equal(expired.body.data.next_route, "/member/membership?t=tok");
+    assert.equal(expired.body.data.rich_menu_target, "public_member");
+    assert.equal(expired.body.data.safe_next.booking, null);
+    assertNoAutoRenewalRoute(expired.body.data);
+  });
+
+  it("payment entry routes go to membership payment without auto-renewal", async () => {
+    for (const entry_route of ["pay_membership", "payment"]) {
+      const { body } = await identify(
+        { line_user_id: "Uabc123", entry_route, t: "tok" },
+        "https://mmdbkk.com/member/api/liff/identify",
+      );
+
+      assert.equal(body.ok, true);
+      assert.equal(body.data.intent, "pay_membership");
+      assert.equal(body.data.next_route, "/pay/membership?t=tok");
+      assert.equal(body.data.safe_next.payment, "/pay/membership?t=tok");
+      assertNoAutoRenewalRoute(body.data);
+    }
   });
 
   it("no paid package keeps public member path and unknown never pretends active", async () => {
@@ -279,11 +318,13 @@ describe("LIFF identity bridge", () => {
     assert.equal(noPaid.body.data.rich_menu_target, "public_member");
     assert.equal(noPaid.body.data.next_route, "/member/membership?t=tok");
     assert.equal(noPaid.body.data.safe_next.booking, null);
+    assertNoAutoRenewalRoute(noPaid.body.data);
     assert.equal(unknown.body.data.membership_state, "unknown");
     assert.equal(unknown.body.data.package_state, "unknown");
     assert.equal(unknown.body.data.rich_menu_target, "public_member");
-    assert.equal(unknown.body.data.next_route, "/member/profile?t=tok&status=review_required");
+    assert.equal(unknown.body.data.next_route, "/member/membership?t=tok");
     assert.equal(unknown.body.data.safe_next.dashboard, null);
+    assertNoAutoRenewalRoute(unknown.body.data);
   });
 
   it("requires line_user_id", async () => {

--- a/tools/mmd-route-governance-connector.mjs
+++ b/tools/mmd-route-governance-connector.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, "..");
+const dirtyPatchPath = process.env.MMD_ROUTE_LOCK_DIRTY_PATCH
+  || "/Users/Hiright_1/.mmd-secrets/codexmin-backups/mmd-workers-dirty-before-clean-worktree-route-lock.patch";
+
+const testFiles = [
+  "member-pages-worker/test/liff-identity.test.mjs",
+  "mmd-redirect-worker/test/redirect.test.mjs",
+  "member-dashboard-chat-worker/test/renewal-route.test.mjs",
+];
+
+const routeChecks = [
+  { name: "sigil membership", url: "https://mmdbkk.com/sigil/pay/membership", kind: "membership" },
+  { name: "sigil membership code", url: "https://mmdbkk.com/sigil/pay/membership?code=TEST", kind: "membership-query" },
+  { name: "sigil membership package", url: "https://mmdbkk.com/sigil/pay/membership?package=premium", kind: "membership-query" },
+  { name: "sigil membership plan", url: "https://mmdbkk.com/sigil/pay/membership?plan=standard", kind: "membership-query" },
+  { name: "www sigil membership", url: "https://www.mmdbkk.com/sigil/pay/membership", kind: "membership" },
+  { name: "pay membership", url: "https://mmdbkk.com/pay/membership", kind: "pay-membership" },
+  { name: "sigil renewal", url: "https://mmdbkk.com/sigil/pay/renewal", kind: "manual-renewal" },
+  { name: "pay renewal", url: "https://mmdbkk.com/pay/renewal", kind: "manual-renewal" },
+  { name: "unknown route", url: "https://mmdbkk.com/unknown-test-route-mmd", kind: "unknown" },
+];
+
+const liffChecks = [
+  {
+    name: "renewal",
+    body: { line_user_id: "Ucodexmin_route_lock_check", entry_route: "renewal", t: "tok" },
+    expectedIntent: "membership_review",
+    expectedNextRoute: "/member/membership?t=tok",
+  },
+  {
+    name: "pay_membership",
+    body: { line_user_id: "Ucodexmin_route_lock_check", entry_route: "pay_membership", t: "tok" },
+    expectedIntent: "pay_membership",
+    expectedNextRoute: "/pay/membership?t=tok",
+  },
+];
+
+const dirtyPatchFiles = [
+  "events-worker/src/index.js",
+  "mmd-redirect-worker/src/index.js",
+  "mmd-redirect-worker/test/redirect.test.mjs",
+];
+
+const results = {
+  tests: [],
+  routes: [],
+  liff: [],
+  dirtyPatch: [],
+};
+
+let failed = false;
+
+function markFailed(message) {
+  failed = true;
+  console.error(`FAIL ${message}`);
+}
+
+function pass(message) {
+  console.log(`PASS ${message}`);
+}
+
+function runNodeTest(file) {
+  const result = spawnSync(process.execPath, ["--test", file], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const ok = result.status === 0;
+  results.tests.push({ file, ok });
+  if (ok) {
+    pass(`test ${file}`);
+    return;
+  }
+
+  markFailed(`test ${file}`);
+  const combinedOutput = `${result.stdout || ""}\n${result.stderr || ""}`.trim();
+  if (combinedOutput) console.error(redact(combinedOutput));
+}
+
+async function checkRoute(check) {
+  const response = await fetch(check.url, { method: "GET", redirect: "manual" });
+  const location = response.headers.get("location") || "";
+  const page = response.headers.get("x-mmd-page") || "";
+  const gate = response.headers.get("x-mmd-front-gate") || "";
+  const source = response.headers.get("x-mmd-route-source") || "";
+  const forbiddenLocation = containsForbiddenRoute(location);
+
+  let ok = !forbiddenLocation;
+  if (check.kind === "membership" || check.kind === "membership-query") {
+    ok = ok && !location.includes("/sigil/pay/renewal");
+  }
+  if (check.kind === "membership-query") {
+    ok = ok && response.url === check.url;
+  }
+  if (check.kind === "pay-membership") {
+    ok = ok && !location.includes("/sigil/pay/renewal") && response.status === 200;
+  }
+  if (check.kind === "manual-renewal") {
+    ok = ok && response.status === 200
+      && (source.includes("single-renewal-renderer") || page.includes("renewal"));
+  }
+  if (check.kind === "unknown") {
+    ok = ok && ![301, 302, 307, 308].includes(response.status);
+  }
+
+  const summary = {
+    name: check.name,
+    url: check.url,
+    status: response.status,
+    location: location || null,
+    page: page || null,
+    gate: gate || null,
+    source: source || null,
+    ok,
+  };
+  results.routes.push(summary);
+
+  if (ok) pass(`route ${check.name}`);
+  else markFailed(`route ${check.name}: ${JSON.stringify(summary)}`);
+}
+
+async function checkLiff(check) {
+  const response = await fetch("https://mmdbkk.com/member/api/liff/identify", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(check.body),
+  });
+  const json = await response.json();
+  const data = json.data || {};
+  const bodyText = JSON.stringify(json);
+  const sigilPayment = data.safe_next?.sigil_payment || "";
+  const ok = response.status === 200
+    && json.ok === true
+    && data.intent === check.expectedIntent
+    && data.next_route === check.expectedNextRoute
+    && data.safe_next?.renewal === null
+    && sigilPayment.startsWith("/sigil/pay/membership")
+    && data.auto_renewal_route_disabled === true
+    && !bodyText.includes("/sigil/pay/renewal");
+
+  const summary = {
+    name: check.name,
+    status: response.status,
+    ok,
+    intent: data.intent || null,
+    next_route: data.next_route || null,
+    safe_next_renewal: data.safe_next?.renewal ?? null,
+    safe_next_sigil_payment_path: sigilPayment.split("?")[0] || null,
+  };
+  results.liff.push(summary);
+
+  if (ok) pass(`liff ${check.name}`);
+  else markFailed(`liff ${check.name}: ${JSON.stringify(summary)}`);
+}
+
+function scanDirtyPatch() {
+  if (!existsSync(dirtyPatchPath)) {
+    results.dirtyPatch.push({
+      patch: dirtyPatchPath,
+      present: false,
+      route_lock_conflict: "unknown",
+      recommendation: "patch not found",
+    });
+    console.log(`INFO dirty patch not found: ${dirtyPatchPath}`);
+    return;
+  }
+
+  const patch = readFileSync(dirtyPatchPath, "utf8");
+  for (const file of dirtyPatchFiles) {
+    const body = extractPatchForFile(patch, file);
+    const mentions = {
+      sigil_pay_membership: body.includes("/sigil/pay/membership"),
+      sigil_pay_renewal: body.includes("/sigil/pay/renewal"),
+      default: body.includes("/default"),
+      autodirect: body.includes("/autodirect"),
+    };
+    const routeLockConflict = Boolean(
+      (mentions.sigil_pay_membership && mentions.sigil_pay_renewal)
+        || mentions.default
+        || mentions.autodirect,
+    );
+    const recommendation = routeLockConflict
+      ? "unsafe to reapply as-is"
+      : file.startsWith("events-worker/")
+        ? "unrelated"
+        : "safe for later review";
+
+    results.dirtyPatch.push({
+      file,
+      present: Boolean(body),
+      mentions,
+      route_lock_conflict: routeLockConflict,
+      recommendation,
+    });
+
+    const conflict = routeLockConflict ? "yes" : "no";
+    console.log(`INFO dirty patch ${file}: route-lock conflict ${conflict}; ${recommendation}`);
+  }
+}
+
+function extractPatchForFile(patch, file) {
+  const escaped = escapeRegExp(file);
+  const pattern = new RegExp(`diff --git a/${escaped} b/${escaped}([\\s\\S]*?)(?=\\ndiff --git |$)`);
+  return patch.match(pattern)?.[1] || "";
+}
+
+function containsForbiddenRoute(value) {
+  return value.includes("/sigil/pay/renewal")
+    || value.includes("/default")
+    || value.includes("/autodirect");
+}
+
+function redact(value) {
+  return value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
+    .replace(/pat[A-Za-z0-9._-]+/g, "[REDACTED_PAT]")
+    .replace(/gho_[A-Za-z0-9_]+/g, "[REDACTED_GITHUB_TOKEN]")
+    .replace(/sk-[A-Za-z0-9_-]+/g, "[REDACTED_SECRET]");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+console.log("MMD route governance connector");
+console.log("No deploy, route mutation, Cloudflare secret mutation, Airtable mutation, Webflow mutation, Memberstack mutation, or DNS mutation is performed.");
+
+for (const file of testFiles) runNodeTest(file);
+for (const check of routeChecks) await checkRoute(check);
+for (const check of liffChecks) await checkLiff(check);
+scanDirtyPatch();
+
+console.log(JSON.stringify(results, null, 2));
+
+if (failed) process.exit(1);


### PR DESCRIPTION
Production issue was caused by wrong Cloudflare Worker route bindings, not production source logic.

Deleted wrong Worker routes during the prior production fix:
- `mmdbkk.com/sigil/pay/membership*`
- `www.mmdbkk.com/sigil/pay/membership*`

This PR includes:
- route owner lock documentation
- route lock smoke checklist
- `member-pages-worker` LIFF test realignment
- local governance connector script: `tools/mmd-route-governance-connector.mjs`

The connector runs:
- targeted Node tests
- live no-deploy route smoke
- live LIFF smoke
- read-only dirty patch quarantine scan

No production source changes.
No deploy required.
No Cloudflare route changes.
No secrets.

Governance lock:
- `member-dashboard-chat-worker` must not own `/sigil/pay/membership`.
- `/sigil/pay/membership` must never redirect to `/sigil/pay/renewal`.
- `/pay/membership` must never redirect to `/sigil/pay/renewal`.
- `/sigil/pay/renewal` and `/pay/renewal` remain manual legacy renewal evidence routes only.
- Unknown routes must not redirect to `/default`, `/autodirect`, or `/sigil/pay/renewal`.

Validation passed:
- `node --check tools/mmd-route-governance-connector.mjs`
- `node tools/mmd-route-governance-connector.mjs`

The connector confirmed:
- all three targeted tests passed
- `/sigil/pay/membership` safe
- query variants safe
- `/pay/membership` safe
- renewal routes manual legacy only
- unknown route safe
- LIFF renewal safe
- LIFF pay_membership safe
- dirty patch redirect files are unsafe to reapply as-is

Cloudflare Page Rules / Rulesets / Bulk Redirect audit remains blocked by 403 until token has:
- Zone Rulesets Read
- Zone Page Rules Read
- Account Bulk Redirects Read
