### PR TITLE
[codex] Rebuild member dashboard chat push fallback

### DIFF
--- a/member-dashboard-chat-worker/README.md
+++ b/member-dashboard-chat-worker/README.md
@@ -7,8 +7,9 @@ Deploy preflight:
 - Do not deploy from a folder that only contains `.wrangler/`.
 - Do not use tmp `.wrangler` cache as source.
 - Confirm `src/index.js`, `test/push-fallback.test.mjs`, and `wrangler.toml` exist.
-- Confirm `wrangler.toml` has no route declarations.
-- Bind `LINE_CHANNEL_ACCESS_TOKEN` as a Cloudflare secret; never write it to `wrangler.toml`.
+- Confirm `wrangler.toml` has no route declarations and `workers_dev = false`.
+- Bind `LINE_CHANNEL_ACCESS_TOKEN`, `INTERNAL_TOKEN`, and `CONFIRM_KEY` as Cloudflare secrets; never write them to `wrangler.toml`.
+- Confirm `POST /v1/internal/line/public-menu-fallback` is not publicly reachable without internal auth.
 - Run `node --check src/index.js`, `node --test test/*.test.mjs`, and `git diff --check`.
 
 Safety contract:
@@ -17,4 +18,5 @@ Safety contract:
 - Payment proof is evidence only until official verification.
 - Public menu fallback must not activate membership, payments, points, packages, or dashboard access.
 - Dashboard and private actions stay gated by trusted worker state.
+- `trusted_event` is only a semantic guard, never the authentication boundary.
 - This worker does not mutate Airtable, Memberstack, payment state, member state, routes, or Rich Menu configuration.

--- a/member-dashboard-chat-worker/README.md
+++ b/member-dashboard-chat-worker/README.md
@@ -1,0 +1,20 @@
+# member-dashboard-chat-worker
+
+Safe push fallback worker for member dashboard chat events.
+
+Deploy preflight:
+
+- Do not deploy from a folder that only contains `.wrangler/`.
+- Do not use tmp `.wrangler` cache as source.
+- Confirm `src/index.js`, `test/push-fallback.test.mjs`, and `wrangler.toml` exist.
+- Confirm `wrangler.toml` has no route declarations.
+- Bind `LINE_CHANNEL_ACCESS_TOKEN` as a Cloudflare secret; never write it to `wrangler.toml`.
+- Run `node --check src/index.js`, `node --test test/*.test.mjs`, and `git diff --check`.
+
+Safety contract:
+
+- LINE/LIFF is an entry layer only.
+- Payment proof is evidence only until official verification.
+- Public menu fallback must not activate membership, payments, points, packages, or dashboard access.
+- Dashboard and private actions stay gated by trusted worker state.
+- This worker does not mutate Airtable, Memberstack, payment state, member state, routes, or Rich Menu configuration.

--- a/member-dashboard-chat-worker/src/index.js
+++ b/member-dashboard-chat-worker/src/index.js
@@ -1,0 +1,141 @@
+const LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push";
+const WORKER_NAME = "member-dashboard-chat-worker";
+
+const PUBLIC_MENU_TEXT = [
+  "MMD Member Help",
+  "Open the member area from the official MMD link.",
+  "Payment proof is supporting evidence only until MMD completes official verification.",
+  "Dashboard and private actions stay locked until trusted worker state allows them.",
+].join("\n");
+
+const PRIVATE_MARKERS = [
+  /airtable/gi,
+  /record[_\s-]?id/gi,
+  /secret/gi,
+  /token/gi,
+  /authorization/gi,
+  /bearer/gi,
+  /payment[_\s-]?internal/gi,
+  /risk[_\s-]?flag/gi,
+  /vip|svip|black\s*card/gi,
+  /session[_\s-]?internal/gi,
+  /telegram|gmail|r2|kv/gi,
+];
+
+function json(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
+      "x-mmd-worker": WORKER_NAME,
+    },
+  });
+}
+
+function asString(value) {
+  return String(value || "").trim();
+}
+
+function hasTrustedEvent(input = {}, request = null) {
+  const header = asString(request?.headers?.get("X-MMD-Trusted-Event")).toLowerCase();
+  return input.trusted_event === true || header === "true" || header === "1";
+}
+
+function sanitizeLineText(value) {
+  let text = asString(value);
+  for (const marker of PRIVATE_MARKERS) text = text.replace(marker, "[redacted]");
+  text = text.replace(/rec[a-zA-Z0-9]{10,}/g, "[redacted]");
+  text = text.replace(/pat[a-zA-Z0-9._-]{10,}/g, "[redacted]");
+  text = text.replace(/sk-[a-zA-Z0-9_-]{10,}/g, "[redacted]");
+  return text.slice(0, 1600);
+}
+
+export function getLineUserId(input = {}) {
+  const candidates = [
+    input.line_user_id,
+    input.lineUserId,
+    input.user_id,
+    input.userId,
+    input.event?.source?.userId,
+    input.source?.userId,
+  ];
+
+  for (const candidate of candidates) {
+    const value = asString(candidate);
+    if (/^U[a-f0-9]{32}$/i.test(value)) return value;
+  }
+
+  return "";
+}
+
+export async function deliverLineText(env = {}, lineUserId, text, options = {}) {
+  const token = asString(env.LINE_CHANNEL_ACCESS_TOKEN);
+  const to = asString(lineUserId);
+  const safeText = sanitizeLineText(text);
+
+  if (!options.trusted_event) return { ok: false, error: "trusted_event_required" };
+  if (!token) return { ok: false, error: "line_token_missing" };
+  if (!to) return { ok: false, error: "line_user_id_missing" };
+  if (!safeText) return { ok: false, error: "line_text_missing" };
+
+  const response = await fetch(LINE_PUSH_URL, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      to,
+      messages: [{ type: "text", text: safeText }],
+    }),
+  });
+
+  if (!response.ok) {
+    return { ok: false, error: "line_push_failed", status: response.status };
+  }
+
+  return { ok: true, status: response.status };
+}
+
+export async function deliverLinePublicMenu(env = {}, lineUserId, options = {}) {
+  return deliverLineText(env, lineUserId, PUBLIC_MENU_TEXT, options);
+}
+
+export async function pushLinePublicMenu(input = {}, env = {}, request = null) {
+  const trusted = hasTrustedEvent(input, request);
+  if (!trusted) return { ok: false, error: "trusted_event_required" };
+
+  const lineUserId = getLineUserId(input);
+  if (!lineUserId) return { ok: false, error: "line_user_id_missing" };
+
+  return deliverLinePublicMenu(env, lineUserId, { trusted_event: true });
+}
+
+async function readJson(request) {
+  try {
+    return await request.json();
+  } catch (_) {
+    return null;
+  }
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (request.method === "GET" && url.pathname === "/health") {
+      return json({ ok: true, worker: WORKER_NAME });
+    }
+
+    if (request.method === "POST" && url.pathname === "/v1/internal/line/public-menu-fallback") {
+      const body = await readJson(request);
+      if (!body || typeof body !== "object") return json({ ok: false, error: "invalid_json" }, 400);
+
+      const result = await pushLinePublicMenu(body, env, request);
+      return json(result, result.ok ? 200 : 400);
+    }
+
+    return json({ ok: false, error: "not_found" }, 404);
+  },
+};

--- a/member-dashboard-chat-worker/src/index.js
+++ b/member-dashboard-chat-worker/src/index.js
@@ -42,6 +42,24 @@ function hasTrustedEvent(input = {}, request = null) {
   return input.trusted_event === true || header === "true" || header === "1";
 }
 
+function getBearerToken(request = null) {
+  const auth = asString(request?.headers?.get("Authorization"));
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  return asString(match?.[1]);
+}
+
+function hasInternalAuth(request = null, env = {}) {
+  const bearer = getBearerToken(request);
+  const confirmKey = asString(request?.headers?.get("X-Confirm-Key"));
+  const expectedInternalToken = asString(env.INTERNAL_TOKEN);
+  const expectedConfirmKey = asString(env.CONFIRM_KEY);
+
+  return Boolean(
+    (expectedInternalToken && bearer && bearer === expectedInternalToken) ||
+      (expectedConfirmKey && confirmKey && confirmKey === expectedConfirmKey),
+  );
+}
+
 function sanitizeLineText(value) {
   let text = asString(value);
   for (const marker of PRIVATE_MARKERS) text = text.replace(marker, "[redacted]");
@@ -129,6 +147,8 @@ export default {
     }
 
     if (request.method === "POST" && url.pathname === "/v1/internal/line/public-menu-fallback") {
+      if (!hasInternalAuth(request, env)) return json({ ok: false, error: "internal_auth_required" }, 401);
+
       const body = await readJson(request);
       if (!body || typeof body !== "object") return json({ ok: false, error: "invalid_json" }, 400);
 

--- a/member-dashboard-chat-worker/test/push-fallback.test.mjs
+++ b/member-dashboard-chat-worker/test/push-fallback.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker, {
+  deliverLinePublicMenu,
+  deliverLineText,
+  getLineUserId,
+  pushLinePublicMenu,
+} from "../src/index.js";
+
+const LINE_USER_ID = "U1234567890abcdef1234567890abcdef";
+
+test("getLineUserId accepts only LINE user ids", () => {
+  assert.equal(getLineUserId({ line_user_id: LINE_USER_ID }), LINE_USER_ID);
+  assert.equal(getLineUserId({ event: { source: { userId: LINE_USER_ID } } }), LINE_USER_ID);
+  assert.equal(getLineUserId({ line_user_id: "recXXXXXXXXXXXX" }), "");
+  assert.equal(getLineUserId({ line_user_id: "" }), "");
+});
+
+test("deliverLineText fails closed without trusted event, token, user id, or text", async () => {
+  assert.deepEqual(await deliverLineText({ LINE_CHANNEL_ACCESS_TOKEN: "x" }, LINE_USER_ID, "hi"), {
+    ok: false,
+    error: "trusted_event_required",
+  });
+  assert.deepEqual(await deliverLineText({}, LINE_USER_ID, "hi", { trusted_event: true }), {
+    ok: false,
+    error: "line_token_missing",
+  });
+  assert.deepEqual(await deliverLineText({ LINE_CHANNEL_ACCESS_TOKEN: "x" }, "", "hi", { trusted_event: true }), {
+    ok: false,
+    error: "line_user_id_missing",
+  });
+  assert.deepEqual(await deliverLineText({ LINE_CHANNEL_ACCESS_TOKEN: "x" }, LINE_USER_ID, "", { trusted_event: true }), {
+    ok: false,
+    error: "line_text_missing",
+  });
+});
+
+test("deliverLineText redacts internal markers before LINE push", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const result = await deliverLineText(
+      { LINE_CHANNEL_ACCESS_TOKEN: "line-token" },
+      LINE_USER_ID,
+      "Airtable recXXXXXXXXXXXX secret token VIP Black Card risk_flag",
+      { trusted_event: true },
+    );
+
+    assert.equal(result.ok, true);
+    const payload = JSON.parse(calls[0].init.body);
+    assert.equal(payload.to, LINE_USER_ID);
+    assert.doesNotMatch(payload.messages[0].text, /Airtable|recXXXXXXXXXXXX|secret|token|VIP|Black Card|risk_flag/i);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("deliverLinePublicMenu sends public-only help copy", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const result = await deliverLinePublicMenu(
+      { LINE_CHANNEL_ACCESS_TOKEN: "line-token" },
+      LINE_USER_ID,
+      { trusted_event: true },
+    );
+
+    assert.equal(result.ok, true);
+    const text = JSON.parse(calls[0].init.body).messages[0].text;
+    assert.match(text, /entry|official verification|trusted worker state/i);
+    assert.doesNotMatch(text, /activate|points|package unlocked|dashboard access granted/i);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("pushLinePublicMenu requires trusted server-side input", async () => {
+  assert.deepEqual(await pushLinePublicMenu({ line_user_id: LINE_USER_ID }, { LINE_CHANNEL_ACCESS_TOKEN: "x" }), {
+    ok: false,
+    error: "trusted_event_required",
+  });
+});
+
+test("worker route fails closed and pushes only trusted public menu fallback", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const untrusted = await worker.fetch(new Request("https://worker/v1/internal/line/public-menu-fallback", {
+      method: "POST",
+      body: JSON.stringify({ line_user_id: LINE_USER_ID }),
+    }), { LINE_CHANNEL_ACCESS_TOKEN: "line-token" });
+    assert.equal(untrusted.status, 400);
+    assert.equal(calls.length, 0);
+
+    const trusted = await worker.fetch(new Request("https://worker/v1/internal/line/public-menu-fallback", {
+      method: "POST",
+      headers: { "content-type": "application/json", "X-MMD-Trusted-Event": "true" },
+      body: JSON.stringify({ line_user_id: LINE_USER_ID }),
+    }), { LINE_CHANNEL_ACCESS_TOKEN: "line-token" });
+    assert.equal(trusted.status, 200);
+    assert.equal(calls.length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/member-dashboard-chat-worker/test/push-fallback.test.mjs
+++ b/member-dashboard-chat-worker/test/push-fallback.test.mjs
@@ -9,6 +9,19 @@ import worker, {
 } from "../src/index.js";
 
 const LINE_USER_ID = "U1234567890abcdef1234567890abcdef";
+const AUTH_ENV = {
+  INTERNAL_TOKEN: "internal-token",
+  CONFIRM_KEY: "confirm-key",
+  LINE_CHANNEL_ACCESS_TOKEN: "line-token",
+};
+
+function fallbackRequest({ headers = {}, body = { line_user_id: LINE_USER_ID } } = {}) {
+  return new Request("https://worker/v1/internal/line/public-menu-fallback", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
 
 test("getLineUserId accepts only LINE user ids", () => {
   assert.equal(getLineUserId({ line_user_id: LINE_USER_ID }), LINE_USER_ID);
@@ -78,7 +91,7 @@ test("deliverLinePublicMenu sends public-only help copy", async () => {
 
     assert.equal(result.ok, true);
     const text = JSON.parse(calls[0].init.body).messages[0].text;
-    assert.match(text, /entry|official verification|trusted worker state/i);
+    assert.match(text, /official verification|trusted worker state/i);
     assert.doesNotMatch(text, /activate|points|package unlocked|dashboard access granted/i);
   } finally {
     globalThis.fetch = originalFetch;
@@ -92,7 +105,7 @@ test("pushLinePublicMenu requires trusted server-side input", async () => {
   });
 });
 
-test("worker route fails closed and pushes only trusted public menu fallback", async () => {
+test("worker route rejects trusted_event without internal auth and does not call LINE", async () => {
   const calls = [];
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (url, init) => {
@@ -101,20 +114,101 @@ test("worker route fails closed and pushes only trusted public menu fallback", a
   };
 
   try {
-    const untrusted = await worker.fetch(new Request("https://worker/v1/internal/line/public-menu-fallback", {
-      method: "POST",
-      body: JSON.stringify({ line_user_id: LINE_USER_ID }),
-    }), { LINE_CHANNEL_ACCESS_TOKEN: "line-token" });
-    assert.equal(untrusted.status, 400);
-    assert.equal(calls.length, 0);
+    const response = await worker.fetch(fallbackRequest({
+      headers: { "X-MMD-Trusted-Event": "true" },
+    }), AUTH_ENV);
 
-    const trusted = await worker.fetch(new Request("https://worker/v1/internal/line/public-menu-fallback", {
-      method: "POST",
-      headers: { "content-type": "application/json", "X-MMD-Trusted-Event": "true" },
-      body: JSON.stringify({ line_user_id: LINE_USER_ID }),
-    }), { LINE_CHANNEL_ACCESS_TOKEN: "line-token" });
-    assert.equal(trusted.status, 200);
+    assert.equal(response.status, 401);
+    assert.equal(calls.length, 0);
+    assert.deepEqual(await response.json(), { ok: false, error: "internal_auth_required" });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker route rejects invalid internal auth and does not call LINE", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await worker.fetch(fallbackRequest({
+      headers: {
+        authorization: "Bearer wrong-token",
+        "X-MMD-Trusted-Event": "true",
+      },
+    }), AUTH_ENV);
+
+    assert.equal(response.status, 401);
+    assert.equal(calls.length, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker route accepts bearer internal auth plus trusted event", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await worker.fetch(fallbackRequest({
+      headers: {
+        authorization: "Bearer internal-token",
+        "X-MMD-Trusted-Event": "true",
+      },
+    }), AUTH_ENV);
+
+    assert.equal(response.status, 200);
     assert.equal(calls.length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker route accepts X-Confirm-Key internal auth plus trusted body", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await worker.fetch(fallbackRequest({
+      headers: { "X-Confirm-Key": "confirm-key" },
+      body: { line_user_id: LINE_USER_ID, trusted_event: true },
+    }), AUTH_ENV);
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("worker route still requires trusted event after valid internal auth", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await worker.fetch(fallbackRequest({
+      headers: { authorization: "Bearer internal-token" },
+    }), AUTH_ENV);
+
+    assert.equal(response.status, 400);
+    assert.equal(calls.length, 0);
+    assert.deepEqual(await response.json(), { ok: false, error: "trusted_event_required" });
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/member-dashboard-chat-worker/wrangler.toml
+++ b/member-dashboard-chat-worker/wrangler.toml
@@ -1,0 +1,9 @@
+name = "member-dashboard-chat-worker"
+main = "src/index.js"
+compatibility_date = "2026-07-02"
+workers_dev = true
+
+[observability]
+enabled = true
+
+# No routes in this PR. Bind LINE_CHANNEL_ACCESS_TOKEN as a Cloudflare secret only.

--- a/member-dashboard-chat-worker/wrangler.toml
+++ b/member-dashboard-chat-worker/wrangler.toml
@@ -1,9 +1,9 @@
 name = "member-dashboard-chat-worker"
 main = "src/index.js"
 compatibility_date = "2026-07-02"
-workers_dev = true
+workers_dev = false
 
 [observability]
 enabled = true
 
-# No routes in this PR. Bind LINE_CHANNEL_ACCESS_TOKEN as a Cloudflare secret only.
+# No routes in this PR. Bind LINE_CHANNEL_ACCESS_TOKEN, INTERNAL_TOKEN, and CONFIRM_KEY as Cloudflare secrets only.


### PR DESCRIPTION
## Summary
- Rebuilds member-dashboard-chat-worker push fallback source from main instead of using tmp .wrangler cache
- Adds required helpers: deliverLineText, deliverLinePublicMenu, pushLinePublicMenu, getLineUserId
- Adds fail-closed tests for trusted event, LINE token, LINE user id, sanitized LINE text, and public menu fallback
- Adds minimal wrangler.toml with no route declarations and a README deploy preflight note

## Safety locks
- No deploy, merge, tail, LINE Rich Menu publish, or Webflow publish
- No admin-worker or mmd-redirect-worker changes
- No routes, secrets, payment logic, member logic, or Airtable schema/data changes
- Public fallback does not activate membership, payments, points, packages, or dashboard access

## Validation
- node --check member-dashboard-chat-worker/src/index.js
- node --test member-dashboard-chat-worker/test/push-fallback.test.mjs
- node --test member-dashboard-chat-worker/test/*.test.mjs
- git diff --check

Closes #130