### PR TITLE
fix: add member dashboard LINE webhook route

### DIFF
--- a/member-dashboard-chat-worker/src/index.js
+++ b/member-dashboard-chat-worker/src/index.js
@@ -1,5 +1,13 @@
 const LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push";
+const LINE_REPLY_URL = "https://api.line.me/v2/bot/message/reply";
 const WORKER_NAME = "member-dashboard-chat-worker";
+
+const LINE_WEBHOOK_PATHS = new Set([
+  "/webhooks/line",
+  "/webhooks/line/",
+  "/webhook/line",
+  "/webhook/line/",
+]);
 
 const PUBLIC_MENU_TEXT = [
   "MMD Member Help",
@@ -37,6 +45,10 @@ function asString(value) {
   return String(value || "").trim();
 }
 
+function isEnabled(value) {
+  return /^(1|true|yes|on)$/i.test(asString(value));
+}
+
 function hasTrustedEvent(input = {}, request = null) {
   const header = asString(request?.headers?.get("X-MMD-Trusted-Event")).toLowerCase();
   return input.trusted_event === true || header === "true" || header === "1";
@@ -69,6 +81,53 @@ function sanitizeLineText(value) {
   return text.slice(0, 1600);
 }
 
+function base64Encode(bytes) {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  if (typeof btoa === "function") return btoa(binary);
+  return Buffer.from(binary, "binary").toString("base64");
+}
+
+function timingSafeEqual(a, b) {
+  const left = asString(a);
+  const right = asString(b);
+  if (left.length !== right.length) return false;
+
+  let mismatch = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    mismatch |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return mismatch === 0;
+}
+
+async function signLineBody(secret, rawBody) {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(rawBody));
+  return base64Encode(new Uint8Array(signature));
+}
+
+async function verifyLineSignature(request, env, rawBody) {
+  const secret = asString(env.LINE_CHANNEL_SECRET);
+  if (!secret) return { ok: false, status: 500, error: "line_channel_secret_missing" };
+
+  const provided = asString(request.headers.get("x-line-signature"));
+  if (!provided) return { ok: false, status: 401, error: "line_signature_missing" };
+
+  const expected = await signLineBody(secret, rawBody);
+  if (!timingSafeEqual(expected, provided)) {
+    return { ok: false, status: 401, error: "invalid_line_signature" };
+  }
+
+  return { ok: true };
+}
+
 export function getLineUserId(input = {}) {
   const candidates = [
     input.line_user_id,
@@ -85,6 +144,86 @@ export function getLineUserId(input = {}) {
   }
 
   return "";
+}
+
+function getLineText(event = {}) {
+  if (event.type === "message" && event.message?.type === "text") {
+    return asString(event.message.text);
+  }
+  if (event.type === "postback") return asString(event.postback?.data);
+  return "";
+}
+
+function inferLineIntent(event = {}) {
+  const text = getLineText(event).toLowerCase();
+  if (!text && event.type === "follow") return "new_follow";
+  if (/สลิป|slip|paid|payment|จ่าย|โอน/.test(text)) return "payment_slip";
+  if (/black\s*card|svip|vip/.test(text)) return "vip_blackcard";
+  if (/จอง|booking|book|นัด|schedule/.test(text)) return "booking_intake";
+  if (/ต่ออายุ|renew|membership|member|สมาชิก/.test(text)) return "membership_question";
+  if (/เคนจิ|kenji|hi|hello|สวัสดี|คุยกับ/.test(text)) return "greeting";
+  return event.type || "line_event";
+}
+
+function buildAirtableUrl(env = {}) {
+  const baseId = asString(env.AIRTABLE_BASE_ID);
+  const tableName = asString(env.AIRTABLE_SYNC_TABLE) || "MMD — Console Inbox";
+  if (!baseId || !tableName) return "";
+  return `https://api.airtable.com/v0/${encodeURIComponent(baseId)}/${encodeURIComponent(tableName)}`;
+}
+
+function buildInboxId(event = {}) {
+  const messageId = asString(event.message?.id);
+  const webhookEventId = asString(event.webhookEventId);
+  const suffix = messageId || webhookEventId || crypto.randomUUID?.() || `${Date.now()}-${Math.random()}`;
+  return `line_${suffix}`.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 96);
+}
+
+async function writeLineEventToAirtable(env = {}, event = {}, profile = {}) {
+  const apiKey = asString(env.AIRTABLE_API_KEY);
+  const url = buildAirtableUrl(env);
+  if (!apiKey || !url) return { ok: false, skipped: "airtable_not_configured" };
+
+  const text = sanitizeLineText(getLineText(event));
+  const intent = inferLineIntent(event);
+  const lineUserId = getLineUserId(event);
+  const payload = {
+    route: "/webhooks/line",
+    worker: WORKER_NAME,
+    event_type: event.type || "unknown",
+    message_type: event.message?.type || "",
+    reply_token_present: Boolean(event.replyToken),
+    text_preview: text.slice(0, 200),
+    profile,
+  };
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      fields: {
+        inbox_id: buildInboxId(event),
+        source: "line",
+        intent,
+        line_user_id: lineUserId,
+        line_id: lineUserId,
+        admin_note: text || `LINE ${event.type || "event"}`,
+        payload_json: JSON.stringify(payload),
+        status: "received",
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    return { ok: false, error: "airtable_write_failed", status: response.status, detail: errorText.slice(0, 300) };
+  }
+
+  const result = await response.json().catch(() => ({}));
+  return { ok: true, id: result.id || "" };
 }
 
 export async function deliverLineText(env = {}, lineUserId, text, options = {}) {
@@ -116,6 +255,39 @@ export async function deliverLineText(env = {}, lineUserId, text, options = {}) 
   return { ok: true, status: response.status };
 }
 
+async function replyLineText(env = {}, replyToken, text) {
+  const token = asString(env.LINE_CHANNEL_ACCESS_TOKEN);
+  const safeReplyToken = asString(replyToken);
+  const safeText = sanitizeLineText(text);
+
+  if (!token || !safeReplyToken || !safeText) return { ok: false, skipped: "line_reply_not_configured" };
+
+  const response = await fetch(LINE_REPLY_URL, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      replyToken: safeReplyToken,
+      messages: [{ type: "text", text: safeText }],
+    }),
+  });
+
+  if (!response.ok) return { ok: false, error: "line_reply_failed", status: response.status };
+  return { ok: true, status: response.status };
+}
+
+function buildSafeAutoReply(intent) {
+  if (intent === "greeting" || intent === "new_follow") {
+    return "สวัสดีครับ ผม Kenji จาก MMD Privé รับเรื่องให้แล้วครับ หากเป็นการจอง งานสมาชิก หรือส่งหลักฐานชำระเงิน ทีมจะตรวจสอบก่อนยืนยันทุกครั้งครับ";
+  }
+  if (intent === "booking_intake") {
+    return "รับเรื่องจองแล้วครับ รบกวนแจ้งวัน เวลาโดยประมาณ ระยะเวลา และพื้นที่ที่สะดวก ทีมจะตรวจสอบสถานะสมาชิก เงื่อนไข และความพร้อมก่อนยืนยันครับ";
+  }
+  return "";
+}
+
 export async function deliverLinePublicMenu(env = {}, lineUserId, options = {}) {
   return deliverLineText(env, lineUserId, PUBLIC_MENU_TEXT, options);
 }
@@ -138,12 +310,59 @@ async function readJson(request) {
   }
 }
 
+async function handleLineWebhook(request, env) {
+  if (request.method !== "POST") return json({ ok: false, error: "method_not_allowed" }, 405);
+
+  const rawBody = await request.text();
+  const signature = await verifyLineSignature(request, env, rawBody);
+  if (!signature.ok) return json({ ok: false, error: signature.error }, signature.status);
+
+  let body;
+  try {
+    body = JSON.parse(rawBody || "{}");
+  } catch (_) {
+    return json({ ok: false, error: "invalid_json" }, 400);
+  }
+
+  const events = Array.isArray(body.events) ? body.events : [];
+  const processed = [];
+
+  for (const event of events) {
+    const intent = inferLineIntent(event);
+    const airtable = await writeLineEventToAirtable(env, event).catch((error) => ({
+      ok: false,
+      error: "airtable_exception",
+      detail: String(error?.message || error || "unknown").slice(0, 300),
+    }));
+
+    let reply = { ok: false, skipped: "auto_reply_disabled" };
+    if (isEnabled(env.LINE_AUTO_REPLY_ENABLED)) {
+      const text = buildSafeAutoReply(intent);
+      if (text) reply = await replyLineText(env, event.replyToken, text);
+    }
+
+    processed.push({
+      type: event.type || "unknown",
+      intent,
+      airtable_ok: Boolean(airtable.ok),
+      reply_ok: Boolean(reply.ok),
+      error: airtable.ok ? undefined : airtable.error || airtable.skipped,
+    });
+  }
+
+  return json({ ok: true, events: events.length, processed });
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
     if (request.method === "GET" && url.pathname === "/health") {
       return json({ ok: true, worker: WORKER_NAME });
+    }
+
+    if (LINE_WEBHOOK_PATHS.has(url.pathname)) {
+      return handleLineWebhook(request, env);
     }
 
     if (request.method === "POST" && url.pathname === "/v1/internal/line/public-menu-fallback") {

--- a/member-dashboard-chat-worker/test/line-webhook.test.mjs
+++ b/member-dashboard-chat-worker/test/line-webhook.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import test from "node:test";
+
+import worker from "../src/index.js";
+
+const SECRET = "line-secret";
+const LINE_USER_ID = "U1234567890abcdef1234567890abcdef";
+
+function sign(body) {
+  return createHmac("sha256", SECRET).update(body).digest("base64");
+}
+
+function lineWebhookRequest(body, headers = {}) {
+  const rawBody = JSON.stringify(body);
+  return new Request("https://mmdbkk.com/webhooks/line", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-line-signature": sign(rawBody),
+      ...headers,
+    },
+    body: rawBody,
+  });
+}
+
+test("LINE webhook route rejects missing signature instead of 404", async () => {
+  const response = await worker.fetch(new Request("https://mmdbkk.com/webhooks/line", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ events: [] }),
+  }), { LINE_CHANNEL_SECRET: SECRET });
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { ok: false, error: "line_signature_missing" });
+});
+
+test("LINE webhook route accepts valid empty LINE verify payload", async () => {
+  const response = await worker.fetch(lineWebhookRequest({ events: [] }), { LINE_CHANNEL_SECRET: SECRET });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { ok: true, events: 0, processed: [] });
+});
+
+test("LINE webhook route logs valid text event to Airtable without auto reply", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response(JSON.stringify({ id: "recLineInbox" }), { status: 200 });
+  };
+
+  try {
+    const response = await worker.fetch(lineWebhookRequest({
+      events: [{
+        type: "message",
+        replyToken: "reply-token",
+        source: { type: "user", userId: LINE_USER_ID },
+        message: { id: "msg-1", type: "text", text: "สวัสดีครับ" },
+      }],
+    }), {
+      LINE_CHANNEL_SECRET: SECRET,
+      AIRTABLE_API_KEY: "airtable-key",
+      AIRTABLE_BASE_ID: "appBase",
+      AIRTABLE_SYNC_TABLE: "MMD — Console Inbox",
+      LINE_AUTO_REPLY_ENABLED: "false",
+    });
+
+    assert.equal(response.status, 200);
+    const result = await response.json();
+    assert.equal(result.ok, true);
+    assert.equal(result.events, 1);
+    assert.equal(result.processed[0].intent, "greeting");
+    assert.equal(result.processed[0].airtable_ok, true);
+    assert.equal(result.processed[0].reply_ok, false);
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].url, /api\.airtable\.com\/v0\/appBase\//);
+    const payload = JSON.parse(calls[0].init.body);
+    assert.equal(payload.fields.source, "line");
+    assert.equal(payload.fields.intent, "greeting");
+    assert.equal(payload.fields.line_user_id, LINE_USER_ID);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("LINE webhook route returns method_not_allowed for GET", async () => {
+  const response = await worker.fetch(new Request("https://mmdbkk.com/webhooks/line"), { LINE_CHANNEL_SECRET: SECRET });
+
+  assert.equal(response.status, 405);
+  assert.deepEqual(await response.json(), { ok: false, error: "method_not_allowed" });
+});


### PR DESCRIPTION
## Summary
- Adds explicit `/webhooks/line` and `/webhook/line` handlers to `member-dashboard-chat-worker`.
- Verifies LINE signatures with `LINE_CHANNEL_SECRET` before processing.
- Accepts valid empty LINE verify payloads with `200`.
- Logs valid LINE events to Airtable / Console Inbox when Airtable env is configured.
- Keeps public auto-reply disabled by default and only allows safe low-risk replies when `LINE_AUTO_REPLY_ENABLED=true`.

## Why
Production route ownership now reaches `member-dashboard-chat-worker` correctly, but `POST /webhooks/line` currently returns `404 not_found` from that worker. This patch fixes the missing handler without changing payment, member access, dashboard, admin-worker, telegram-worker, or route ownership logic.

## Safety locks
- No payment confirmation.
- No VIP, SVIP, or Black Card approval.
- No model availability confirmation.
- No dashboard access granting.
- No route changes.
- No secrets committed.
- Airtable write failure is non-fatal for LINE acknowledgement to avoid retry storms.

## Validation
- Add `member-dashboard-chat-worker/test/line-webhook.test.mjs` for missing signature, valid empty LINE verify payload, Airtable logging, and GET method guard.
- Existing push fallback tests remain untouched.