### PR TITLE
chore: route public model API paths to partners-worker

### DIFF
--- a/partners-worker/wrangler.toml
+++ b/partners-worker/wrangler.toml
@@ -5,6 +5,10 @@ compatibility_flags = [ "nodejs_compat" ]
 workers_dev = true
 
 routes = [
+  { pattern = "mmdbkk.com/v1/apply/public-model*", zone_name = "mmdbkk.com" },
+  { pattern = "www.mmdbkk.com/v1/apply/public-model*", zone_name = "mmdbkk.com" },
+  { pattern = "mmdbkk.com/v1/partner/upload*", zone_name = "mmdbkk.com" },
+  { pattern = "www.mmdbkk.com/v1/partner/upload*", zone_name = "mmdbkk.com" },
   { pattern = "www.mmdbkk.com/terms*", zone_name = "mmdbkk.com" },
   { pattern = "www.mmdbkk.com/legal/terms*", zone_name = "mmdbkk.com" },
   { pattern = "mmdbkk.com/terms*", zone_name = "mmdbkk.com" },


### PR DESCRIPTION
## What

Adds exactly four zone route declarations to `partners-worker/wrangler.toml` so the deployed `POST /v1/apply/public-model` endpoint and the `POST /v1/partner/upload` flow used by the public model application form are reachable on the production domain:

- `mmdbkk.com/v1/apply/public-model*`
- `www.mmdbkk.com/v1/apply/public-model*`
- `mmdbkk.com/v1/partner/upload*`
- `www.mmdbkk.com/v1/partner/upload*`

All with `zone_name = "mmdbkk.com"`.

## Why

Live verification shows POST to both paths on mmdbkk.com returns HTTP 405 (`text/html`, `x-mmd-front-gate: mmd-redirect-worker`, `x-wf-region: us-east-1`) — requests fall through the front gate to Webflow and never reach partners-worker. Cloudflare routes more-specific patterns first, so these exact patterns carve out only the two API paths without modifying mmd-redirect-worker.

## Confirmations

- Exact routes only — no broad catch-alls (`/v1/*`, `/*`)
- No mmd-redirect-worker changes (source or config)
- No secret changes
- No deploy performed — routes activate only on the next `wrangler deploy` of partners-worker
- `npx wrangler deploy --dry-run` passed cleanly on this branch

## Deploy hazards to resolve before deploying from this branch

1. **Missing R2 binding:** this toml (from main) has no `[[r2_buckets]] PARTNER_ASSETS` binding, but the live partners-worker has one — deploying as-is would break `/v1/partner/upload` (503). The binding fix exists on `codex/public-model-application-endpoint` (commit 1d3e685).
2. **Pre-existing `terms*` route declarations** (already on main, untouched here) would be claimed from mmd-redirect-worker's catch-all on deploy — `www.mmdbkk.com/terms` currently serves 200 via the front gate.
3. **Stale `AIRTABLE_API_KEY`** on partners-worker still returns 401 — applications cannot be written to Airtable until it is rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)