### PR TITLE
chore: add partner assets binding

### DIFF
--- a/partners-worker/wrangler.toml
+++ b/partners-worker/wrangler.toml
@@ -15,6 +15,10 @@ routes = [
   { pattern = "mmdbkk.com/legal/terms*", zone_name = "mmdbkk.com" }
 ]
 
+[[r2_buckets]]
+binding = "PARTNER_ASSETS"
+bucket_name = "mmd-sigil-partner-assets"
+
 [observability]
 enabled = true
 head_sampling_rate = 1


### PR DESCRIPTION
Adds PARTNER_ASSETS binding only.

Keeps PR #143 public model API routes.

No deploy performed.

No secret changes.

AIRTABLE_API_KEY rotation remains separate.

partners-worker deploy remains separate explicit approval.