### PR TITLE
chore: add partner assets binding

### DIFF
--- a/partners-worker/wrangler.toml
+++ b/partners-worker/wrangler.toml
@@ -15,6 +15,10 @@ routes = [
   { pattern = "mmdbkk.com/legal/terms*", zone_name = "mmdbkk.com" }
 ]
 
+[[r2_buckets]]
+binding = "PARTNER_ASSETS"
+bucket_name = "mmd-sigil-partner-assets"
+
 [observability]
 enabled = true
 head_sampling_rate = 1


### PR DESCRIPTION
Adds the missing PARTNER_ASSETS R2 binding to partners-worker/wrangler.toml after PR #143 merged.

Confirmations:

* PARTNER_ASSETS binding added only if missing.
* Four public model API routes from PR #143 remain.
* No broad catch-all routes added.
* No mmd-redirect-worker changes.
* No secret changes.
* No deploy performed.
* No merge performed.
* AIRTABLE_API_KEY rotation remains a separate explicit step.
* partners-worker live deploy remains a separate explicit approval step.
* Existing terms* route ownership shift is acknowledged as a deploy-time consideration.