### PR TITLE
chore: restore partner assets R2 binding

### DIFF
--- a/partners-worker/wrangler.toml
+++ b/partners-worker/wrangler.toml
@@ -15,6 +15,10 @@ routes = [
   { pattern = "mmdbkk.com/legal/terms*", zone_name = "mmdbkk.com" }
 ]
 
+[[r2_buckets]]
+binding = "PARTNER_ASSETS"
+bucket_name = "mmd-sigil-partner-assets"
+
 [observability]
 enabled = true
 head_sampling_rate = 1


### PR DESCRIPTION
Restores `PARTNER_ASSETS` R2 binding for partners-worker.

Keeps exact public model API routes already merged.

No mmd-redirect-worker changes.

No source-code changes.

No secrets changed.

No deploy performed.

Dry-run passed.