### PR TITLE
Restore Rich Menu Internal Publisher

### DIFF
--- a/admin-worker/rich-menu-admin-publisher.test.mjs
+++ b/admin-worker/rich-menu-admin-publisher.test.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "./src/index.js";
+
+const ADMIN_BEARER = "test_admin_bearer_rich_menu";
+const CONFIRM_KEY = "test_confirm_key_rich_menu";
+
+function canonicalPublicRichMenu() {
+  return {
+    areas: [
+      { action: { type: "message", text: "Hi Per" } },
+      { action: { type: "uri", uri: "https://mmdbkk.com/member/membership?source=line&entry_route=public_membership" } },
+      { action: { type: "uri", uri: "https://mmdbkk.com/member/membership?source=line&entry_route=member_status" } },
+      { action: { type: "uri", uri: "https://mmdbkk.com/member/membership?source=line&entry_route=booking_request&service=dinner_travel" } },
+      { action: { type: "uri", uri: "https://mmdbkk.com/pay/membership?source=line&entry_route=payment_proof" } },
+      { action: { type: "message", text: "Hi MMD" } },
+    ],
+  };
+}
+
+function canonicalPrivateRichMenu() {
+  return {
+    areas: [
+      { action: { type: "uri", uri: "https://mmdbkk.com/member/membership?source=line&entry_route=member_status" } },
+      { action: { type: "uri", uri: "https://mmdbkk.com/member/membership?source=line&entry_route=points" } },
+      { action: { type: "uri", uri: "https://mmdbkk.com/member/membership?source=line&entry_route=renewal" } },
+      { action: { type: "postback", data: "mmd_action=private_support&source=private_rich_menu", displayText: "Private Support" } },
+      { action: { type: "uri", uri: "https://mmdbkk.com/pay/membership?source=line&entry_route=payment_proof" } },
+      { action: { type: "message", text: "Hi MMD" } },
+    ],
+  };
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function makeEnv({ binding = true, upstreamBody = { ok: true, rich_menu_type: "public_world" }, upstreamStatus = 200 } = {}) {
+  const calls = [];
+  const env = {
+    ADMIN_BEARER,
+    CONFIRM_KEY,
+  };
+
+  if (binding) {
+    env.MEMBER_DASHBOARD_CHAT_WORKER = {
+      async fetch(request) {
+        calls.push({
+          url: request.url,
+          method: request.method,
+          headers: Object.fromEntries(request.headers.entries()),
+          body: request.method === "GET" ? "" : await request.text(),
+        });
+        return jsonResponse(upstreamBody, upstreamStatus);
+      },
+    };
+  }
+
+  return { env, calls };
+}
+
+async function adminFetch(path, { method = "POST", body = {}, headers = {} } = {}, env) {
+  const init = {
+    method,
+    headers: {
+      "content-type": "application/json",
+      ...headers,
+    },
+  };
+  if (method !== "GET") init.body = JSON.stringify(body);
+  const response = await worker.fetch(new Request(`https://admin-worker.test${path}`, init), env);
+  return { response, body: await response.json() };
+}
+
+test("admin rich menu endpoints require existing admin auth", async () => {
+  const { env, calls } = makeEnv();
+  const { response, body } = await adminFetch("/v1/admin/line/rich-menu/public-world/draft", {}, env);
+
+  assert.equal(response.status, 401);
+  assert.equal(body.error, "unauthorized");
+  assert.equal(calls.length, 0);
+});
+
+test("admin draft calls member-dashboard service binding without forwarding operator auth", async () => {
+  const { env, calls } = makeEnv({ upstreamBody: { ok: true, rich_menu_type: "public_world", rich_menu: canonicalPublicRichMenu() } });
+  const { response, body } = await adminFetch("/v1/admin/line/rich-menu/public-world/draft", {
+    headers: { authorization: `Bearer ${ADMIN_BEARER}` },
+  }, env);
+
+  assert.equal(response.status, 200);
+  assert.equal(body.ok, true);
+  assert.equal(body.rich_menu.areas.length, 6);
+  assert.deepEqual(body.rich_menu.areas[0].action, { type: "message", text: "Hi Per" });
+  assert.equal(body.rich_menu.areas[1].action.uri, "https://mmdbkk.com/member/membership?source=line&entry_route=public_membership");
+  assert.equal(body.rich_menu.areas[2].action.uri, "https://mmdbkk.com/member/membership?source=line&entry_route=member_status");
+  assert.equal(body.rich_menu.areas[3].action.uri, "https://mmdbkk.com/member/membership?source=line&entry_route=booking_request&service=dinner_travel");
+  assert.equal(body.rich_menu.areas[4].action.uri, "https://mmdbkk.com/pay/membership?source=line&entry_route=payment_proof");
+  assert.deepEqual(body.rich_menu.areas[5].action, { type: "message", text: "Hi MMD" });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/public-world/draft");
+  assert.equal(calls[0].method, "POST");
+  assert.equal(calls[0].headers["x-mmd-service-binding"], "admin-worker");
+  assert.equal(calls[0].headers["x-mmd-internal-call"], "true");
+  assert.equal(calls[0].headers.authorization, undefined);
+});
+
+test("admin draft route works with duplicate and trailing slashes", async () => {
+  const { env, calls } = makeEnv({ upstreamBody: { ok: true, rich_menu_type: "public_world", rich_menu: canonicalPublicRichMenu() } });
+
+  const duplicate = await adminFetch("/v1/admin//line/rich-menu/public-world/draft", {
+    headers: { authorization: `Bearer ${ADMIN_BEARER}` },
+  }, env);
+  const trailing = await adminFetch("/v1/admin/line/rich-menu/public-world/draft/", {
+    headers: { authorization: `Bearer ${ADMIN_BEARER}` },
+  }, env);
+
+  assert.equal(duplicate.response.status, 200);
+  assert.equal(trailing.response.status, 200);
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].url, "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/public-world/draft");
+  assert.equal(calls[1].url, "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/public-world/draft");
+});
+
+test("admin publish uses service binding with ADMIN_BEARER only and passes image_url", async () => {
+  const { env, calls } = makeEnv({ upstreamBody: { ok: true, default_set: true } });
+  const { response, body } = await adminFetch("/v1/admin/line/rich-menu/public-world/publish", {
+    headers: { authorization: `Bearer ${ADMIN_BEARER}` },
+    body: { image_url: "https://cdn.example/rich-menu.png" },
+  }, env);
+
+  assert.equal(response.status, 200);
+  assert.equal(body.default_set, true);
+  assert.equal(calls[0].url, "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/public-world/publish");
+  assert.deepEqual(JSON.parse(calls[0].body), { image_url: "https://cdn.example/rich-menu.png" });
+  assert.equal("INTERNAL_TOKEN" in env, false);
+});
+
+test("admin validate-minimal calls service binding with debug query, not public URL", async () => {
+  const { env, calls } = makeEnv({ upstreamBody: { ok: true, validated: true, variant: "minimal" } });
+  const { response, body } = await adminFetch("/v1/admin/line/rich-menu/public-world/validate-minimal?debug=1", {
+    headers: { authorization: `Bearer ${ADMIN_BEARER}` },
+  }, env);
+
+  assert.equal(response.status, 200);
+  assert.equal(body.variant, "minimal");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/public-world/validate-minimal?debug=1");
+  assert.equal(calls[0].headers["x-mmd-service-binding"], "admin-worker");
+  assert.equal(calls[0].headers["x-mmd-internal-call"], "true");
+  assert.equal(calls[0].headers.authorization, undefined);
+});
+
+test("admin validate variants use service binding aliases", async () => {
+  const { env, calls } = makeEnv({ upstreamBody: { ok: true, validated: true } });
+  const endpoints = [
+    "validate-no-postback",
+    "validate-message-only",
+    "validate-uri-only",
+  ];
+
+  for (const endpoint of endpoints) {
+    const { response } = await adminFetch(`/v1/admin/line/rich-menu/public-world/${endpoint}`, {
+      headers: { authorization: `Bearer ${ADMIN_BEARER}` },
+    }, env);
+    assert.equal(response.status, 200);
+  }
+
+  assert.deepEqual(calls.map((call) => call.url), [
+    "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/public-world/validate-no-postback",
+    "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/public-world/validate-message-only",
+    "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/public-world/validate-uri-only",
+  ]);
+});
+
+test("admin default and list use GET service aliases", async () => {
+  const { env, calls } = makeEnv({ upstreamBody: { ok: true, richmenus: [] } });
+
+  await adminFetch("/v1/admin/line/rich-menu/default", {
+    method: "GET",
+    headers: { "x-confirm-key": CONFIRM_KEY },
+  }, env);
+  await adminFetch("/v1/admin/line/rich-menu/list", {
+    method: "GET",
+    headers: { "x-confirm-key": CONFIRM_KEY },
+  }, env);
+
+  assert.equal(calls[0].url, "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/default");
+  assert.equal(calls[0].method, "GET");
+  assert.equal(calls[1].url, "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/list");
+  assert.equal(calls[1].method, "GET");
+});
+
+test("missing member-dashboard binding returns safe error", async () => {
+  const { env } = makeEnv({ binding: false });
+  const { response, body } = await adminFetch("/v1/admin/line/rich-menu/public-world/draft", {
+    headers: { authorization: `Bearer ${ADMIN_BEARER}` },
+  }, env);
+
+  assert.equal(response.status, 502);
+  assert.deepEqual(body, { ok: false, error: "service_binding_unavailable" });
+});
+
+test("admin private-member draft and validate use service binding", async () => {
+  const { env, calls } = makeEnv({ upstreamBody: { ok: true, rich_menu_type: "private_member", rich_menu: canonicalPrivateRichMenu() } });
+
+  const draft = await adminFetch("/v1/admin/line/rich-menu/private-member/draft", {
+    headers: { authorization: `Bearer ${ADMIN_BEARER}` },
+  }, env);
+  const validate = await adminFetch("/v1/admin/line/rich-menu/private-member/validate", {
+    headers: { authorization: `Bearer ${ADMIN_BEARER}` },
+  }, env);
+
+  assert.equal(draft.response.status, 200);
+  assert.equal(draft.body.rich_menu.areas.length, 6);
+  assert.equal(draft.body.rich_menu.areas[3].action.data, "mmd_action=private_support&source=private_rich_menu");
+  assert.equal(validate.response.status, 200);
+  assert.deepEqual(calls.map((call) => call.url), [
+    "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/private-member/draft",
+    "https://member-dashboard-chat-worker.local/__internal/line/rich-menu/private-member/validate",
+  ]);
+});
+
+test("admin rich menu response is sanitized", async () => {
+  const { env } = makeEnv({
+    upstreamBody: {
+      ok: false,
+      error: "line_failed",
+      authorization: "Bearer should-not-leak",
+      secret: "hidden",
+      nested: { token: "hidden", rich_menu_id: "richmenu-public" },
+    },
+    upstreamStatus: 502,
+  });
+  const { response, body } = await adminFetch("/v1/admin/line/rich-menu/public-world/validate", {
+    headers: { authorization: `Bearer ${ADMIN_BEARER}` },
+  }, env);
+  const rendered = JSON.stringify(body);
+
+  assert.equal(response.status, 502);
+  assert.equal(body.nested.rich_menu_id, "richmenu-public");
+  assert.doesNotMatch(rendered, /should-not-leak|hidden|authorization|secret|token/i);
+});

--- a/docs/line/rich-menu-membership-mapping.md
+++ b/docs/line/rich-menu-membership-mapping.md
@@ -1,9 +1,8 @@
 # LINE Rich Menu Membership Mapping
 
-Status: audit/prep only. No deploy, no LINE Rich Menu publish, no Webflow publish, and no merge.
+Status: backend-owned Rich Menu publisher is available for Public World. No Webflow publish and no merge.
 
-This repo does not own or publish the LINE Official Account Rich Menu layout/config.
-Configure these actions manually in LINE OA Manager. Do not publish from Codex.
+`member-dashboard-chat-worker` owns the Public World Rich Menu publisher through internal API endpoints. Do not use browser/frontend JavaScript for Rich Menu API calls, and do not print LINE tokens or returned Rich Menu IDs in public chat/logs.
 
 ## Safety Rules
 
@@ -18,11 +17,43 @@ Configure these actions manually in LINE OA Manager. Do not publish from Codex.
 
 Use `https://mmdbkk.com` as the production origin unless LINE OA Manager requires a LIFF URL wrapper.
 
+Public wakeup button requirement:
+
+- The Public World draft created by API sets area 1 as Message action text `Hi Per`.
+- Do not configure `Hi Per` as a URI action, clipboard action, dashboard URL, or secret-bearing link.
+- The draft also includes a postback fallback with data `mmd_action=hi_per&source=public_rich_menu` and display text `Hi Per`.
+- This wakeup only triggers Kenji's safe public acknowledgement; it must not activate membership, points, payment, VIP, Black Card, or dashboard access.
+
+Internal publisher endpoints:
+
+- `POST /v1/internal/line/rich-menu/public-world/draft`
+- `POST /v1/internal/line/rich-menu/public-world/validate`
+- `POST /v1/internal/line/rich-menu/public-world/create`
+- `POST /v1/internal/line/rich-menu/public-world/upload-image`
+- `POST /v1/internal/line/rich-menu/public-world/set-default`
+- `POST /v1/internal/line/rich-menu/public-world/publish`
+- `GET /v1/internal/line/rich-menu/default`
+- `GET /v1/internal/line/rich-menu/list`
+
+All publisher endpoints require `Authorization: Bearer INTERNAL_TOKEN`. Rich Menu image upload accepts only PNG/JPEG.
+
+Operator publishing should go through `admin-worker`, which calls `member-dashboard-chat-worker` by Cloudflare Service Binding. Operators authenticate to `admin-worker` with `ADMIN_BEARER` or `CONFIRM_KEY`; they should not pass `INTERNAL_TOKEN` manually.
+
+Admin publisher endpoints:
+
+- `POST /v1/admin/line/rich-menu/public-world/draft`
+- `POST /v1/admin/line/rich-menu/public-world/validate`
+- `POST /v1/admin/line/rich-menu/public-world/publish`
+- `GET /v1/admin/line/rich-menu/default`
+- `GET /v1/admin/line/rich-menu/list`
+
+The service-bound aliases under `/__internal/line/rich-menu/*` are only for `admin-worker` service binding calls with `x-mmd-service-binding: admin-worker` and `x-mmd-internal-call: true`; public `/v1/internal/...` routes still require Bearer auth.
+
 | Button | URL | Status |
 | --- | --- | --- |
 | สมัครสมาชิก | `https://mmdbkk.com/member/membership?source=line&entry_route=public_membership` | Worker-backed page, LIFF identity remains public membership intent. |
 | ตรวจสอบสถานะสมาชิก | `https://mmdbkk.com/member/membership?source=line&entry_route=member_status` | State-lookup-backed LIFF intent; does not collapse into generic public membership after identify. |
-| ต่ออายุสมาชิก | `https://mmdbkk.com/member/membership?source=line&entry_route=renewal` | State-lookup-backed LIFF intent; expired state routes to worker-backed `/sigil/pay/renewal`. |
+| ต่ออายุสมาชิก | `https://mmdbkk.com/member/membership?source=line&entry_route=renewal` | LINE LIFF renewal mode; identity/evidence only until payment is officially verified. |
 | ขอจอง/เลือกโมเดล | `https://mmdbkk.com/member/membership?source=line&entry_route=booking_request` | State-lookup-backed LIFF intent; active/current routes to `/sigil/booking`, expired routes renewal, no paid package stays public. |
 
 ## Private Rich Menu Button URLs
@@ -32,7 +63,7 @@ Private Rich Menu eligibility is a response state, not a dashboard unlock. The w
 | Button | URL | Status |
 | --- | --- | --- |
 | ตรวจสอบสถานะสมาชิก | `https://mmdbkk.com/member/membership?source=line&entry_route=member_status` | State-lookup-backed. Active/current returns private member eligibility. |
-| ต่ออายุสมาชิก | `https://mmdbkk.com/member/membership?source=line&entry_route=renewal` | State-lookup-backed. Expired routes `/sigil/pay/renewal`; active/current remains private eligible. |
+| ต่ออายุสมาชิก | `https://mmdbkk.com/member/membership?source=line&entry_route=renewal` | Opens renewal mode inside LINE. Private menu is still navigation only and never sets membership truth. |
 | ขอจอง/เลือกโมเดล | `https://mmdbkk.com/member/membership?source=line&entry_route=booking_request` | State-lookup-backed. Active/current routes `/sigil/booking`. |
 | Member dashboard | Not allowed as a Rich Menu action | Blocked until first real job/session unlock. |
 
@@ -60,8 +91,11 @@ Only these query values may be preserved into safe next routes:
 - `t`
 - `code`
 - `promo`
+- `source`
+- `entry_route`
+- `liff_state`
 
-Do not preserve `source`, `entry_route`, `payment_ref`, `session_id`, admin flags, raw LINE ids, raw Telegram ids, Airtable ids, internal notes, risk flags, proposed points, legacy points, SVIP, Black Card internals, or raw session internals in returned customer routes.
+Do not preserve `payment_ref`, `session_id`, admin flags, raw LINE ids, raw Telegram ids, Airtable ids, internal notes, risk flags, proposed points, legacy points, SVIP, Black Card internals, or raw session internals in returned customer routes.
 
 ## Dashboard Lock
 
@@ -130,15 +164,15 @@ Allowed states:
 
 - `membership_state`: `active`, `expired`, `no_paid_package`, `unknown`, `review_required`
 - `package_state`: `current`, `expired`, `none`, `unknown`
-- `rich_menu_target`: `public_member`, `private_member`, `renewal_required`
+- `rich_menu_target`: `public_member`, `private_member`, `renewal`, `blackcard`
 
 Routing:
 
 - `member_status` active/current: `rich_menu_target: private_member`, next route `/member/profile?status=active`, dashboard remains locked unless first job/session unlock exists.
-- `member_status` expired: next route `/sigil/pay/renewal`.
-- `renewal` expired: next route `/sigil/pay/renewal`.
+- `member_status` expired: `rich_menu_target: renewal`; renewal navigation remains evidence/review only.
+- `renewal` expired: `rich_menu_target: renewal`; renewal navigation remains evidence/review only.
 - `booking_request` active/current: next route `/sigil/booking`.
-- `booking_request` expired: next route `/sigil/pay/renewal`.
+- `booking_request` expired: `rich_menu_target: renewal`; booking remains unavailable until trusted current membership.
 - `no_paid_package`: next route `/member/membership`; no new pricing invented here.
 - `unknown` or `review_required`: next route `/member/profile?status=review_required`; never active.
 

--- a/member-dashboard-chat-worker/src/index.js
+++ b/member-dashboard-chat-worker/src/index.js
@@ -1,8 +1,20 @@
 const LINE_PUSH_URL = "https://api.line.me/v2/bot/message/push";
 const LINE_REPLY_URL = "https://api.line.me/v2/bot/message/reply";
 const LINE_PROFILE_BASE_URL = "https://api.line.me/v2/bot/profile";
+const LINE_RICH_MENU_LINK_URL = "https://api.line.me/v2/bot/user";
+const LINE_RICH_MENU_API_URL = "https://api.line.me/v2/bot/richmenu";
+const LINE_RICH_MENU_DATA_URL = "https://api-data.line.me/v2/bot/richmenu";
+const LINE_DEFAULT_RICH_MENU_URL = "https://api.line.me/v2/bot/user/all/richmenu";
 const WORKER_NAME = "member-dashboard-chat-worker";
 const LINE_WEBHOOK_PATHS = new Set(["/webhooks/line", "/webhooks/line/", "/webhook/line", "/webhook/line/"]);
+const LINE_RICH_MENU_SYNC_PATH = "/v1/internal/line/rich-menu/sync";
+const LINE_RICH_MENU_PUBLIC_WORLD_BASE_PATH = "/v1/internal/line/rich-menu/public-world";
+const LINE_RICH_MENU_DEFAULT_PATH = "/v1/internal/line/rich-menu/default";
+const LINE_RICH_MENU_LIST_PATH = "/v1/internal/line/rich-menu/list";
+const SERVICE_LINE_RICH_MENU_PUBLIC_WORLD_BASE_PATH = "/__internal/line/rich-menu/public-world";
+const SERVICE_LINE_RICH_MENU_PRIVATE_MEMBER_BASE_PATH = "/__internal/line/rich-menu/private-member";
+const SERVICE_LINE_RICH_MENU_DEFAULT_PATH = "/__internal/line/rich-menu/default";
+const SERVICE_LINE_RICH_MENU_LIST_PATH = "/__internal/line/rich-menu/list";
 const DEFAULT_SYNC_TABLE = "MMD — Console Inbox";
 
 const PUBLIC_MENU_TEXT = [
@@ -70,6 +82,24 @@ function hasInternalAuth(request = null, env = {}) {
     (expectedInternalToken && bearer && bearer === expectedInternalToken) ||
       (expectedConfirmKey && confirmKey && confirmKey === expectedConfirmKey),
   );
+}
+
+function hasBearerInternalAuth(request = null, env = {}) {
+  const bearer = getBearerToken(request);
+  const expectedInternalToken = asString(env.INTERNAL_TOKEN);
+  return Boolean(expectedInternalToken && bearer && bearer === expectedInternalToken);
+}
+
+function hasServiceBindingAuth(request = null, allowedCallers = []) {
+  const service = asString(request?.headers?.get("x-mmd-service-binding"));
+  const internal = asString(request?.headers?.get("x-mmd-internal-call")).toLowerCase();
+  let serviceHost = "";
+  try {
+    serviceHost = new URL(request.url).hostname;
+  } catch (_) {
+    serviceHost = "";
+  }
+  return serviceHost === "member-dashboard-chat-worker.local" && internal === "true" && allowedCallers.includes(service);
 }
 
 function sanitizeLineText(value) {
@@ -432,12 +462,505 @@ export async function pushLinePublicMenu(input = {}, env = {}, request = null) {
   return deliverLinePublicMenu(env, lineUserId, { trusted_event: true });
 }
 
+export async function linkRichMenuToUser(env = {}, lineUserId, richMenuId) {
+  const token = asString(env.LINE_CHANNEL_ACCESS_TOKEN);
+  const userId = asString(lineUserId);
+  const menuId = asString(richMenuId);
+
+  if (!token) return { ok: false, error: "line_token_missing" };
+  if (!userId) return { ok: false, error: "line_user_id_missing" };
+  if (!menuId) return { ok: false, error: "rich_menu_id_missing" };
+
+  const response = await fetch(`${LINE_RICH_MENU_LINK_URL}/${encodeURIComponent(userId)}/richmenu/${encodeURIComponent(menuId)}`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+  });
+
+  if (!response.ok) return { ok: false, error: "line_rich_menu_link_failed", status: response.status };
+  return { ok: true, status: response.status };
+}
+
+export function getRichMenuIdForTarget(env = {}, target) {
+  const normalized = asString(target).toLowerCase();
+  if (normalized === "public_member") return asString(env.LINE_RICH_MENU_PUBLIC_ID);
+  if (normalized === "private_member") return asString(env.LINE_RICH_MENU_PRIVATE_ID || env.LINE_RICH_MENU_MEMBER_ID);
+  if (normalized === "renewal") return asString(env.LINE_RICH_MENU_RENEWAL_ID);
+  if (normalized === "blackcard") return asString(env.LINE_RICH_MENU_BLACKCARD_ID);
+  return "";
+}
+
+function normalizeRichMenuState(value) {
+  return asString(value)
+    .toLowerCase()
+    .replace(/[_\s-]+/g, "_");
+}
+
+export function resolveRichMenuTarget(input = {}) {
+  const membershipState = normalizeRichMenuState(input.membership_state || input.membershipState || input.member_status);
+  const packageState = normalizeRichMenuState(input.package_state || input.packageState || input.package_status);
+  const tier = normalizeRichMenuState(input.tier || input.member_tier || input.package_tier);
+
+  if (tier === "blackcard" || tier === "black_card") return "blackcard";
+  if (membershipState === "expired" || packageState === "expired" || membershipState === "renewal_due") return "renewal";
+  if (membershipState === "active" || packageState === "current" || packageState === "active") return "private_member";
+  return "public_member";
+}
+
+function richMenuBounds(x, y, width, height) {
+  return { x, y, width, height };
+}
+
+function mmdbkkMembershipUrl(entryRoute, extra = "") {
+  return `https://mmdbkk.com/member/membership?source=line&entry_route=${entryRoute}${extra}`;
+}
+
+export function createPublicWorldRichMenuDraft() {
+  return {
+    size: { width: 2500, height: 1686 },
+    selected: true,
+    name: "MMD Public World",
+    chatBarText: "MMD",
+    areas: [
+      { bounds: richMenuBounds(0, 0, 833, 843), action: { type: "message", text: "Hi Per" } },
+      { bounds: richMenuBounds(834, 0, 833, 843), action: { type: "uri", uri: mmdbkkMembershipUrl("public_membership") } },
+      { bounds: richMenuBounds(1667, 0, 833, 843), action: { type: "uri", uri: mmdbkkMembershipUrl("member_status") } },
+      { bounds: richMenuBounds(0, 843, 833, 843), action: { type: "uri", uri: mmdbkkMembershipUrl("booking_request", "&service=dinner_travel") } },
+      { bounds: richMenuBounds(834, 843, 833, 843), action: { type: "uri", uri: "https://mmdbkk.com/pay/membership?source=line&entry_route=payment_proof" } },
+      { bounds: richMenuBounds(1667, 843, 833, 843), action: { type: "message", text: "Hi MMD" } },
+    ],
+  };
+}
+
+export const buildPublicWorldRichMenu = createPublicWorldRichMenuDraft;
+
+export function createPrivateMemberRichMenuDraft() {
+  return {
+    size: { width: 2500, height: 1686 },
+    selected: true,
+    name: "MMD Private Member",
+    chatBarText: "MMD",
+    areas: [
+      { bounds: richMenuBounds(0, 0, 833, 843), action: { type: "uri", uri: mmdbkkMembershipUrl("member_status") } },
+      { bounds: richMenuBounds(834, 0, 833, 843), action: { type: "uri", uri: mmdbkkMembershipUrl("points") } },
+      { bounds: richMenuBounds(1667, 0, 833, 843), action: { type: "uri", uri: mmdbkkMembershipUrl("renewal") } },
+      {
+        bounds: richMenuBounds(0, 843, 833, 843),
+        action: {
+          type: "postback",
+          data: "mmd_action=private_support&source=private_rich_menu",
+          displayText: "Private Support",
+        },
+      },
+      { bounds: richMenuBounds(834, 843, 833, 843), action: { type: "uri", uri: "https://mmdbkk.com/pay/membership?source=line&entry_route=payment_proof" } },
+      { bounds: richMenuBounds(1667, 843, 833, 843), action: { type: "message", text: "Hi MMD" } },
+    ],
+  };
+}
+
+function buildMinimalPublicWorldRichMenu() {
+  return {
+    size: { width: 2500, height: 1686 },
+    selected: true,
+    name: "MMD Public World Minimal",
+    chatBarText: "MMD",
+    areas: [{ bounds: richMenuBounds(0, 0, 2500, 1686), action: { type: "message", text: "Hi Per" } }],
+  };
+}
+
+function buildPublicWorldRichMenuVariant(kind = "full") {
+  if (kind === "minimal") return buildMinimalPublicWorldRichMenu();
+  const draft = buildPublicWorldRichMenu();
+  if (kind === "no-postback") {
+    return {
+      ...draft,
+      areas: draft.areas.map((area, index) => (
+        area.action.type === "postback" || index === 5 ? { ...area, action: { type: "message", text: "Hi Per" } } : area
+      )),
+    };
+  }
+  if (kind === "message-only") {
+    return {
+      ...draft,
+      areas: draft.areas.map((area) => ({ ...area, action: { type: "message", text: "Hi Per" } })),
+    };
+  }
+  if (kind === "uri-only") {
+    return {
+      ...draft,
+      areas: draft.areas.map((area, index) => ({
+        ...area,
+        action: { type: "uri", uri: mmdbkkMembershipUrl(index === 0 ? "public_membership" : "member_status") },
+      })),
+    };
+  }
+  return draft;
+}
+
+function requireLineToken(env = {}) {
+  const token = asString(env.LINE_CHANNEL_ACCESS_TOKEN);
+  if (!token) return { ok: false, error: "line_token_missing" };
+  return { ok: true, token };
+}
+
+function safeJsonParse(rawBody) {
+  try {
+    return JSON.parse(rawBody);
+  } catch (_) {
+    return null;
+  }
+}
+
+function lineSafeReason(status = 0) {
+  if (status === 400) return "payload_invalid";
+  if (status === 401 || status === 403) return "line_auth_failed";
+  if (status === 404) return "line_resource_missing";
+  if ([429, 500, 502, 503, 504].includes(Number(status))) return "line_upstream_unavailable";
+  return "line_api_unknown_error";
+}
+
+function sanitizeLineErrorExcerpt(rawText = "") {
+  let value = asString(rawText);
+  value = value.replace(/authorization\s*[:=]\s*bearer\s+[^\s",}]+/gi, "[auth-redacted]");
+  value = value.replace(/bearer\s+[A-Za-z0-9._~+/=-]+/gi, "[auth-redacted]");
+  value = value.replace(/(channel[_\s-]?access[_\s-]?token|secret|token|api[_\s-]?key)\s*[:=]\s*["']?[^"',}\s]+/gi, "[secret-redacted]");
+  value = value.replace(/richmenu-[A-Za-z0-9_-]+/gi, "[richmenu-id-redacted]");
+  value = value.replace(/U[a-f0-9]{32}/gi, "[line-user-redacted]");
+  return value.slice(0, 300);
+}
+
+function safeLineApiError(operation, response, rawText = "", options = {}) {
+  const status = Number(response?.status || 0);
+  const excerpt = options.debug ? sanitizeLineErrorExcerpt(rawText) : "";
+  return {
+    ok: false,
+    error: "line_api_failed",
+    operation,
+    line_status: status,
+    safe_reason: lineSafeReason(status),
+    ...(excerpt ? { line_error_excerpt: excerpt } : {}),
+  };
+}
+
+async function lineApiJson(env = {}, url, init = {}, options = {}) {
+  const token = requireLineToken(env);
+  if (!token.ok) return token;
+  try {
+    const response = await fetch(url, {
+      ...init,
+      headers: {
+        authorization: `Bearer ${token.token}`,
+        "content-type": "application/json",
+        ...(init.headers || {}),
+      },
+    });
+    const rawText = await response.text().catch(() => "");
+    const data = rawText ? safeJsonParse(rawText) || {} : {};
+    if (!response.ok) return safeLineApiError(options.operation || "line_api_json", response, rawText, options);
+    return { ok: true, status: response.status, data };
+  } catch (_) {
+    return { ok: false, error: "line_api_fetch_failed" };
+  }
+}
+
+async function lineApiRaw(env = {}, url, init = {}, options = {}) {
+  const token = requireLineToken(env);
+  if (!token.ok) return token;
+  try {
+    const response = await fetch(url, {
+      ...init,
+      headers: {
+        authorization: `Bearer ${token.token}`,
+        ...(init.headers || {}),
+      },
+    });
+    const rawText = await response.text().catch(() => "");
+    if (!response.ok) return safeLineApiError(options.operation || "line_api_raw", response, rawText, options);
+    return { ok: true, status: response.status };
+  } catch (_) {
+    return { ok: false, error: "line_api_fetch_failed" };
+  }
+}
+
+function sanitizeRichMenuList(payload = {}) {
+  const richmenus = Array.isArray(payload.richmenus) ? payload.richmenus : [];
+  return richmenus.map((menu) => ({
+    richMenuId: asString(menu.richMenuId),
+    name: asString(menu.name),
+    chatBarText: asString(menu.chatBarText),
+    selected: menu.selected === true,
+    areas_count: Array.isArray(menu.areas) ? menu.areas.length : 0,
+  }));
+}
+
 async function readJson(request) {
   try {
     return await request.json();
   } catch (_) {
     return null;
   }
+}
+
+async function handleRichMenuSync(request, env) {
+  if (!hasInternalAuth(request, env)) return json({ ok: false, error: "internal_auth_required" }, 401);
+  const body = await readJson(request);
+  if (!body || typeof body !== "object") return json({ ok: false, error: "invalid_json" }, 400);
+
+  const lineUserId = getLineUserId(body);
+  if (!lineUserId) return json({ ok: false, error: "line_user_id_missing" }, 400);
+
+  const richMenuTarget = resolveRichMenuTarget(body);
+  const richMenuId = getRichMenuIdForTarget(env, richMenuTarget);
+  if (!richMenuId) return json({ ok: false, error: "rich_menu_id_missing", rich_menu_target: richMenuTarget }, 400);
+
+  const linked = await linkRichMenuToUser(env, lineUserId, richMenuId);
+  if (!linked.ok) {
+    return json({ ok: false, ...linked, rich_menu_target: richMenuTarget, line_user_id: lineUserId }, linked.error === "line_token_missing" ? 500 : 502);
+  }
+
+  return json({ ok: true, linked: true, rich_menu_target: richMenuTarget, line_user_id: lineUserId });
+}
+
+function publicWorldDraftResponse() {
+  const draft = createPublicWorldRichMenuDraft();
+  return json({ ok: true, rich_menu_type: "public_world", draft, rich_menu: draft });
+}
+
+function privateMemberDraftResponse() {
+  const draft = createPrivateMemberRichMenuDraft();
+  return json({ ok: true, rich_menu_type: "private_member", draft, rich_menu: draft });
+}
+
+async function validatePublicWorldRichMenu(env, options = {}) {
+  const draft = buildPublicWorldRichMenuVariant(options.variant || "full");
+  const result = await lineApiJson(env, `${LINE_RICH_MENU_API_URL}/validate`, {
+    method: "POST",
+    body: JSON.stringify(draft),
+  }, {
+    operation: "rich_menu_validate",
+    debug: options.debug === true,
+  });
+  if (!result.ok) return result;
+  return { ok: true, validated: true, variant: options.variant || "full" };
+}
+
+async function validatePrivateMemberRichMenu(env, options = {}) {
+  const draft = createPrivateMemberRichMenuDraft();
+  const result = await lineApiJson(env, `${LINE_RICH_MENU_API_URL}/validate`, {
+    method: "POST",
+    body: JSON.stringify(draft),
+  }, {
+    operation: "rich_menu_validate",
+    debug: options.debug === true,
+  });
+  if (!result.ok) return result;
+  return { ok: true, validated: true, rich_menu_type: "private_member" };
+}
+
+async function createPublicWorldRichMenu(env) {
+  const draft = buildPublicWorldRichMenu();
+  const result = await lineApiJson(env, LINE_RICH_MENU_API_URL, {
+    method: "POST",
+    body: JSON.stringify(draft),
+  }, { operation: "rich_menu_create" });
+  if (!result.ok) return result;
+  return {
+    ok: true,
+    created: true,
+    rich_menu_type: "public_world",
+    rich_menu_id: asString(result.data?.richMenuId || result.data?.rich_menu_id),
+  };
+}
+
+function isAllowedRichMenuImageUrl(rawUrl = "") {
+  try {
+    const url = new URL(asString(rawUrl));
+    return url.protocol === "https:";
+  } catch (_) {
+    return false;
+  }
+}
+
+async function uploadPublicWorldRichMenuImage(env, input = {}) {
+  const richMenuId = asString(input.rich_menu_id || input.richMenuId);
+  const imageUrl = asString(input.image_url || input.imageUrl);
+  if (!richMenuId) return { ok: false, error: "rich_menu_id_missing" };
+  if (!imageUrl) return { ok: false, error: "image_url_missing" };
+  if (!isAllowedRichMenuImageUrl(imageUrl)) return { ok: false, error: "image_url_invalid" };
+  const imagePath = new URL(imageUrl).pathname.toLowerCase();
+  if (!/\.(?:jpe?g|png)$/.test(imagePath)) return { ok: false, error: "rich_menu_image_type_invalid" };
+
+  let imageResponse;
+  try {
+    imageResponse = await fetch(imageUrl);
+  } catch (_) {
+    return { ok: false, error: "rich_menu_image_fetch_failed" };
+  }
+  if (!imageResponse.ok) return { ok: false, error: "rich_menu_image_fetch_failed", status: imageResponse.status };
+
+  const contentType = asString(imageResponse.headers.get("content-type")).toLowerCase();
+  if (!["image/png", "image/jpeg"].includes(contentType)) {
+    return { ok: false, error: "rich_menu_image_content_type_invalid", content_type: contentType || "unknown" };
+  }
+  const body = await imageResponse.arrayBuffer();
+  const result = await lineApiRaw(env, `${LINE_RICH_MENU_DATA_URL}/${encodeURIComponent(richMenuId)}/content`, {
+    method: "POST",
+    headers: { "content-type": contentType },
+    body,
+  }, { operation: "rich_menu_image_upload" });
+  if (!result.ok) return { ...result, error: "rich_menu_image_upload_failed" };
+  return { ok: true, image_uploaded: true, rich_menu_type: "public_world", rich_menu_id: richMenuId };
+}
+
+async function setPublicWorldDefault(env, input = {}) {
+  const richMenuId = asString(input.rich_menu_id || input.richMenuId);
+  if (!richMenuId) return { ok: false, error: "rich_menu_id_missing" };
+  const result = await lineApiRaw(env, `${LINE_DEFAULT_RICH_MENU_URL}/${encodeURIComponent(richMenuId)}`, {
+    method: "POST",
+  }, { operation: "rich_menu_set_default" });
+  if (!result.ok) return result;
+  return { ok: true, default_set: true, rich_menu_type: "public_world", rich_menu_id: richMenuId };
+}
+
+async function publishPublicWorldRichMenu(env, input = {}) {
+  const imageUrl = asString(input.image_url || input.imageUrl);
+  if (!imageUrl) return { ok: false, error: "rich_menu_image_required" };
+
+  const validated = await validatePublicWorldRichMenu(env);
+  if (!validated.ok) return validated;
+
+  const created = await createPublicWorldRichMenu(env);
+  if (!created.ok) return created;
+
+  const uploaded = await uploadPublicWorldRichMenuImage(env, { ...input, rich_menu_id: created.rich_menu_id });
+  if (!uploaded.ok) {
+    return {
+      ok: false,
+      created: true,
+      image_uploaded: false,
+      default_set: false,
+      error: uploaded.error || "rich_menu_image_upload_failed",
+      rich_menu_type: "public_world",
+      rich_menu_id: created.rich_menu_id,
+    };
+  }
+
+  const defaultSet = await setPublicWorldDefault(env, { rich_menu_id: created.rich_menu_id });
+  if (!defaultSet.ok) {
+    return { ok: false, created: true, image_uploaded: true, default_set: false, error: defaultSet.error, rich_menu_type: "public_world", rich_menu_id: created.rich_menu_id };
+  }
+
+  return {
+    ok: true,
+    validated: true,
+    created: true,
+    image_uploaded: true,
+    default_set: true,
+    rich_menu_type: "public_world",
+    rich_menu_id: created.rich_menu_id,
+  };
+}
+
+async function handleRichMenuDefault(request, env) {
+  if (!hasInternalAuth(request, env)) return json({ ok: false, error: "internal_auth_required" }, 401);
+  const result = await lineApiJson(env, LINE_DEFAULT_RICH_MENU_URL, { method: "GET" }, { operation: "rich_menu_default" });
+  if (!result.ok) return json(result, result.error === "line_token_missing" ? 500 : 502);
+  return json({ ok: true, rich_menu_id: asString(result.data?.richMenuId || result.data?.rich_menu_id) });
+}
+
+async function handleRichMenuList(request, env) {
+  if (!hasInternalAuth(request, env)) return json({ ok: false, error: "internal_auth_required" }, 401);
+  const result = await lineApiJson(env, `${LINE_RICH_MENU_API_URL}/list`, { method: "GET" }, { operation: "rich_menu_list" });
+  if (!result.ok) return json(result, result.error === "line_token_missing" ? 500 : 502);
+  return json({ ok: true, richmenus: sanitizeRichMenuList(result.data) });
+}
+
+function richMenuStatus(result, fallback = 200) {
+  if (result.ok) return fallback;
+  if (result.error === "line_token_missing") return 500;
+  if ([
+    "rich_menu_id_missing",
+    "rich_menu_image_required",
+    "image_url_missing",
+    "image_url_invalid",
+    "rich_menu_image_type_invalid",
+    "rich_menu_image_content_type_invalid",
+  ].includes(result.error)) {
+    return 400;
+  }
+  return result.status || 502;
+}
+
+async function handlePublicWorldRichMenuRoute(request, env, path, serviceBound = false) {
+  if (!serviceBound && !hasInternalAuth(request, env)) return json({ ok: false, error: "internal_auth_required" }, 401);
+  const base = serviceBound ? SERVICE_LINE_RICH_MENU_PUBLIC_WORLD_BASE_PATH : LINE_RICH_MENU_PUBLIC_WORLD_BASE_PATH;
+  const debug = new URL(request.url).searchParams.get("debug") === "1" && (serviceBound || hasBearerInternalAuth(request, env));
+
+  if (request.method === "POST" && path === `${base}/draft`) return publicWorldDraftResponse();
+  if (request.method === "POST" && path === `${base}/validate`) {
+    const result = await validatePublicWorldRichMenu(env, { debug });
+    return json(result, result.ok ? 200 : richMenuStatus(result));
+  }
+  if (request.method === "POST" && path === `${base}/validate-minimal`) {
+    const result = await validatePublicWorldRichMenu(env, { variant: "minimal", debug });
+    return json(result, result.ok ? 200 : richMenuStatus(result));
+  }
+  if (request.method === "POST" && path === `${base}/validate-no-postback`) {
+    const result = await validatePublicWorldRichMenu(env, { variant: "no-postback", debug });
+    return json(result, result.ok ? 200 : richMenuStatus(result));
+  }
+  if (request.method === "POST" && path === `${base}/validate-message-only`) {
+    const result = await validatePublicWorldRichMenu(env, { variant: "message-only", debug });
+    return json(result, result.ok ? 200 : richMenuStatus(result));
+  }
+  if (request.method === "POST" && path === `${base}/validate-uri-only`) {
+    const result = await validatePublicWorldRichMenu(env, { variant: "uri-only", debug });
+    return json(result, result.ok ? 200 : richMenuStatus(result));
+  }
+  if (request.method === "POST" && path === `${base}/create`) {
+    const result = await createPublicWorldRichMenu(env);
+    return json(result, result.ok ? 200 : richMenuStatus(result));
+  }
+  if (request.method === "POST" && path === `${base}/upload-image`) {
+    const result = await uploadPublicWorldRichMenuImage(env, await readJson(request));
+    return json(result, result.ok ? 200 : richMenuStatus(result));
+  }
+  if (request.method === "POST" && path === `${base}/set-default`) {
+    const result = await setPublicWorldDefault(env, await readJson(request));
+    return json(result, result.ok ? 200 : richMenuStatus(result));
+  }
+  if (request.method === "POST" && path === `${base}/publish`) {
+    if (serviceBound && !hasServiceBindingAuth(request, ["admin-worker"])) return json({ ok: false, error: "internal_auth_required" }, 401);
+    const result = await publishPublicWorldRichMenu(env, await readJson(request));
+    return json(result, result.ok ? 200 : richMenuStatus(result));
+  }
+  return json({ ok: false, error: "not_found" }, 404);
+}
+
+async function handlePrivateMemberRichMenuRoute(request, env, path) {
+  if (request.method === "POST" && path === `${SERVICE_LINE_RICH_MENU_PRIVATE_MEMBER_BASE_PATH}/draft`) return privateMemberDraftResponse();
+  if (request.method === "POST" && path === `${SERVICE_LINE_RICH_MENU_PRIVATE_MEMBER_BASE_PATH}/validate`) {
+    const debug = new URL(request.url).searchParams.get("debug") === "1";
+    const result = await validatePrivateMemberRichMenu(env, { debug });
+    return json(result, result.ok ? 200 : richMenuStatus(result));
+  }
+  return json({ ok: false, error: "not_found" }, 404);
+}
+
+async function handleServiceBoundRichMenuRoute(request, env, path) {
+  if (!hasServiceBindingAuth(request, ["admin-worker"])) return json({ ok: false, error: "internal_auth_required" }, 401);
+  if (path.startsWith(`${SERVICE_LINE_RICH_MENU_PUBLIC_WORLD_BASE_PATH}/`)) return handlePublicWorldRichMenuRoute(request, env, path, true);
+  if (path.startsWith(`${SERVICE_LINE_RICH_MENU_PRIVATE_MEMBER_BASE_PATH}/`)) return handlePrivateMemberRichMenuRoute(request, env, path);
+  if (request.method === "GET" && path === SERVICE_LINE_RICH_MENU_DEFAULT_PATH) {
+    const result = await lineApiJson(env, LINE_DEFAULT_RICH_MENU_URL, { method: "GET" }, { operation: "rich_menu_default" });
+    if (!result.ok) return json(result, richMenuStatus(result));
+    return json({ ok: true, rich_menu_id: asString(result.data?.richMenuId || result.data?.rich_menu_id) });
+  }
+  if (request.method === "GET" && path === SERVICE_LINE_RICH_MENU_LIST_PATH) {
+    const result = await lineApiJson(env, `${LINE_RICH_MENU_API_URL}/list`, { method: "GET" }, { operation: "rich_menu_list" });
+    if (!result.ok) return json(result, richMenuStatus(result));
+    return json({ ok: true, richmenus: sanitizeRichMenuList(result.data) });
+  }
+  return json({ ok: false, error: "not_found" }, 404);
 }
 
 async function handleLineWebhook(request, env) {
@@ -500,6 +1023,31 @@ export default {
 
     if (request.method === "POST" && LINE_WEBHOOK_PATHS.has(url.pathname)) {
       return handleLineWebhook(request, env);
+    }
+
+    if (
+      url.pathname.startsWith(`${SERVICE_LINE_RICH_MENU_PUBLIC_WORLD_BASE_PATH}/`) ||
+      url.pathname.startsWith(`${SERVICE_LINE_RICH_MENU_PRIVATE_MEMBER_BASE_PATH}/`) ||
+      url.pathname === SERVICE_LINE_RICH_MENU_DEFAULT_PATH ||
+      url.pathname === SERVICE_LINE_RICH_MENU_LIST_PATH
+    ) {
+      return handleServiceBoundRichMenuRoute(request, env, url.pathname);
+    }
+
+    if (request.method === "POST" && url.pathname === LINE_RICH_MENU_SYNC_PATH) {
+      return handleRichMenuSync(request, env);
+    }
+
+    if (url.pathname.startsWith(`${LINE_RICH_MENU_PUBLIC_WORLD_BASE_PATH}/`)) {
+      return handlePublicWorldRichMenuRoute(request, env, url.pathname, false);
+    }
+
+    if (request.method === "GET" && url.pathname === LINE_RICH_MENU_DEFAULT_PATH) {
+      return handleRichMenuDefault(request, env);
+    }
+
+    if (request.method === "GET" && url.pathname === LINE_RICH_MENU_LIST_PATH) {
+      return handleRichMenuList(request, env);
     }
 
     if (request.method === "POST" && url.pathname === "/v1/internal/line/public-menu-fallback") {

--- a/member-dashboard-chat-worker/test/rich-menu-publisher.test.mjs
+++ b/member-dashboard-chat-worker/test/rich-menu-publisher.test.mjs
@@ -1,0 +1,545 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "../src/index.js";
+
+const AUTH_ENV = {
+  INTERNAL_TOKEN: "internal-token",
+  LINE_CHANNEL_ACCESS_TOKEN: "line-token",
+};
+
+function request(path, { method = "POST", body = {}, headers = {}, host = "worker" } = {}) {
+  const init = { method, headers: { ...headers } };
+  if (method !== "GET") {
+    init.headers["content-type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+  return new Request(`https://${host}${path}`, init);
+}
+
+function authHeaders() {
+  return { authorization: "Bearer internal-token" };
+}
+
+function serviceHeaders(service = "admin-worker") {
+  return {
+    "x-mmd-service-binding": service,
+    "x-mmd-internal-call": "true",
+  };
+}
+
+async function call(path, options = {}, env = AUTH_ENV) {
+  return worker.fetch(request(path, { headers: authHeaders(), ...options }), env);
+}
+
+test("draft endpoint rejects without auth", async () => {
+  const response = await worker.fetch(request("/v1/internal/line/rich-menu/public-world/draft"), AUTH_ENV);
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { ok: false, error: "internal_auth_required" });
+});
+
+test("public internal endpoint rejects spoofed service headers without bearer", async () => {
+  const response = await worker.fetch(request("/v1/internal/line/rich-menu/public-world/draft", {
+    headers: serviceHeaders(),
+  }), AUTH_ENV);
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { ok: false, error: "internal_auth_required" });
+});
+
+test("service-bound draft alias accepts admin-worker headers without bearer", async () => {
+  const response = await worker.fetch(request("/__internal/line/rich-menu/public-world/draft", {
+    headers: serviceHeaders(),
+    host: "member-dashboard-chat-worker.local",
+  }), AUTH_ENV);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.rich_menu_type, "public_world");
+  assert.equal(payload.rich_menu.areas[0].action.text, "Hi Per");
+});
+
+test("public external service-bound spoof is rejected", async () => {
+  const response = await worker.fetch(request("/__internal/line/rich-menu/public-world/draft", {
+    headers: serviceHeaders(),
+    host: "mmdbkk.com",
+  }), AUTH_ENV);
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { ok: false, error: "internal_auth_required" });
+});
+
+test("service-bound private-member draft returns canonical mapping", async () => {
+  const response = await worker.fetch(request("/__internal/line/rich-menu/private-member/draft", {
+    headers: serviceHeaders(),
+    host: "member-dashboard-chat-worker.local",
+  }), AUTH_ENV);
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.rich_menu_type, "private_member");
+  assert.equal(payload.rich_menu.name, "MMD Private Member");
+  assert.equal(payload.rich_menu.areas.length, 6);
+  assert.equal(payload.rich_menu.areas[0].action.uri, "https://mmdbkk.com/member/membership?source=line&entry_route=member_status");
+  assert.equal(payload.rich_menu.areas[1].action.uri, "https://mmdbkk.com/member/membership?source=line&entry_route=points");
+  assert.equal(payload.rich_menu.areas[2].action.uri, "https://mmdbkk.com/member/membership?source=line&entry_route=renewal");
+  assert.deepEqual(payload.rich_menu.areas[3].action, {
+    type: "postback",
+    data: "mmd_action=private_support&source=private_rich_menu",
+    displayText: "Private Support",
+  });
+  assert.equal(payload.rich_menu.areas[4].action.uri, "https://mmdbkk.com/pay/membership?source=line&entry_route=payment_proof");
+  assert.deepEqual(payload.rich_menu.areas[5].action, { type: "message", text: "Hi MMD" });
+});
+
+test("service-bound private-member validate sends raw rich menu and does not set default", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  };
+
+  try {
+    const response = await worker.fetch(request("/__internal/line/rich-menu/private-member/validate", {
+      headers: serviceHeaders(),
+      host: "member-dashboard-chat-worker.local",
+    }), AUTH_ENV);
+    const payload = await response.json();
+    const sent = JSON.parse(calls[0].init.body);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.rich_menu_type, "private_member");
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "https://api.line.me/v2/bot/richmenu/validate");
+    assert.equal(sent.name, "MMD Private Member");
+    assert.equal(sent.rich_menu, undefined);
+    assert.equal(calls.some((call) => call.url.includes("/user/all/richmenu")), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("service-bound publish alias rejects non-admin callers", async () => {
+  const response = await worker.fetch(request("/__internal/line/rich-menu/public-world/publish", {
+    headers: serviceHeaders("member-pages-worker"),
+    body: { image_url: "https://cdn.example/rich-menu.png" },
+    host: "member-dashboard-chat-worker.local",
+  }), AUTH_ENV);
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { ok: false, error: "internal_auth_required" });
+});
+
+test("service-bound publish alias returns safe missing-image error", async () => {
+  const response = await worker.fetch(request("/__internal/line/rich-menu/public-world/publish", {
+    headers: serviceHeaders(),
+    body: {},
+    host: "member-dashboard-chat-worker.local",
+  }), AUTH_ENV);
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { ok: false, error: "rich_menu_image_required" });
+});
+
+test("draft endpoint returns Public World with Message action Hi Per and safe routes", async () => {
+  const response = await call("/v1/internal/line/rich-menu/public-world/draft");
+  const payload = await response.json();
+  const rendered = JSON.stringify(payload);
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.rich_menu_type, "public_world");
+  assert.equal(payload.draft.name, "MMD Public World");
+  assert.equal(payload.draft.chatBarText, "MMD");
+  assert.equal(payload.draft.areas[0].action.type, "message");
+  assert.equal(payload.draft.areas[0].action.text, "Hi Per");
+  assert.equal(payload.rich_menu.areas.length, 6);
+  assert.equal(payload.draft.areas[3].action.uri, "https://mmdbkk.com/member/membership?source=line&entry_route=booking_request&service=dinner_travel");
+  assert.equal(payload.draft.areas[4].action.uri, "https://mmdbkk.com/pay/membership?source=line&entry_route=payment_proof");
+  assert.deepEqual(payload.draft.areas[5].action, { type: "message", text: "Hi MMD" });
+  assert.doesNotMatch(rendered, /\/member\/dashboard/);
+  assert.doesNotMatch(rendered, /\/internal|\/admin/);
+  assert.match(rendered, /https:\/\/mmdbkk\.com\/member\/membership/);
+});
+
+test("validate endpoint calls LINE rich menu validate", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  };
+
+  try {
+    const response = await call("/v1/internal/line/rich-menu/public-world/validate");
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.deepEqual(payload, { ok: true, validated: true, variant: "full" });
+    assert.equal(calls[0].url, "https://api.line.me/v2/bot/richmenu/validate");
+    assert.equal(calls[0].init.method, "POST");
+    const sent = JSON.parse(calls[0].init.body);
+    assert.equal(sent.areas[0].action.text, "Hi Per");
+    assert.equal(sent.richMenu, undefined);
+    assert.equal(sent.draft, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("validate failure returns safe LINE diagnostics without debug excerpt by default", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    message: "invalid richmenu richmenu-secret Authorization: Bearer should-not-leak",
+  }), { status: 400, headers: { "content-type": "application/json" } });
+
+  try {
+    const response = await call("/v1/internal/line/rich-menu/public-world/validate");
+    const payload = await response.json();
+    const rendered = JSON.stringify(payload);
+
+    assert.equal(response.status, 502);
+    assert.equal(payload.error, "line_api_failed");
+    assert.equal(payload.operation, "rich_menu_validate");
+    assert.equal(payload.line_status, 400);
+    assert.equal(payload.safe_reason, "payload_invalid");
+    assert.equal(payload.line_error_excerpt, undefined);
+    assert.doesNotMatch(rendered, /should-not-leak|authorization|secret|line-token|internal-token/i);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("validate debug with authenticated internal caller includes sanitized LINE excerpt", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({
+    message: "invalid richmenu richmenu-abc123 Authorization: Bearer should-not-leak",
+  }), { status: 400, headers: { "content-type": "application/json" } });
+
+  try {
+    const response = await call("/v1/internal/line/rich-menu/public-world/validate?debug=1");
+    const payload = await response.json();
+    const rendered = JSON.stringify(payload);
+
+    assert.equal(response.status, 502);
+    assert.equal(payload.error, "line_api_failed");
+    assert.equal(payload.safe_reason, "payload_invalid");
+    assert.match(payload.line_error_excerpt, /invalid richmenu/);
+    assert.doesNotMatch(rendered, /should-not-leak|richmenu-abc123|authorization|secret|line-token|internal-token/i);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("debug without auth does not include LINE excerpt", async () => {
+  const response = await worker.fetch(request("/v1/internal/line/rich-menu/public-world/validate?debug=1"), AUTH_ENV);
+  const payload = await response.json();
+
+  assert.equal(response.status, 401);
+  assert.equal(payload.line_error_excerpt, undefined);
+});
+
+test("validate-minimal exists, requires auth, and sends one Hi Per message action", async () => {
+  const unauthenticated = await worker.fetch(request("/v1/internal/line/rich-menu/public-world/validate-minimal"), AUTH_ENV);
+  assert.equal(unauthenticated.status, 401);
+
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  };
+
+  try {
+    const response = await call("/v1/internal/line/rich-menu/public-world/validate-minimal");
+    const payload = await response.json();
+    const sent = JSON.parse(calls[0].init.body);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.variant, "minimal");
+    assert.equal(sent.areas.length, 1);
+    assert.deepEqual(sent.areas[0].action, { type: "message", text: "Hi Per" });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("service-bound validate-minimal accepts admin-worker auth", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+
+  try {
+    const response = await worker.fetch(request("/__internal/line/rich-menu/public-world/validate-minimal", {
+      headers: serviceHeaders(),
+      host: "member-dashboard-chat-worker.local",
+    }), AUTH_ENV);
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.variant, "minimal");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("validate variants isolate postback message and URI actions", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  };
+
+  try {
+    const variants = [
+      ["validate-no-postback", "no-postback"],
+      ["validate-message-only", "message-only"],
+      ["validate-uri-only", "uri-only"],
+    ];
+    for (const [pathSuffix, variant] of variants) {
+      const response = await call(`/v1/internal/line/rich-menu/public-world/${pathSuffix}`);
+      const payload = await response.json();
+      assert.equal(response.status, 200);
+      assert.equal(payload.variant, variant);
+    }
+
+    const noPostback = JSON.parse(calls[0].init.body);
+    const messageOnly = JSON.parse(calls[1].init.body);
+    const uriOnly = JSON.parse(calls[2].init.body);
+
+    assert.equal(noPostback.areas[5].action.type, "message");
+    assert.equal(noPostback.areas[5].action.text, "Hi Per");
+    assert.equal(messageOnly.areas.every((area) => area.action.type === "message"), true);
+    assert.equal(uriOnly.areas.every((area) => area.action.type === "uri" && area.action.uri.startsWith("https://mmdbkk.com/member/membership")), true);
+    assert.equal(JSON.stringify({ noPostback, messageOnly, uriOnly }).includes("/member/dashboard"), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("create endpoint calls LINE rich menu create", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    return new Response(JSON.stringify({ richMenuId: "richmenu-created" }), { status: 200, headers: { "content-type": "application/json" } });
+  };
+
+  try {
+    const response = await call("/v1/internal/line/rich-menu/public-world/create");
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.created, true);
+    assert.equal(payload.rich_menu_type, "public_world");
+    assert.equal(payload.rich_menu_id, "richmenu-created");
+    assert.equal(calls[0].url, "https://api.line.me/v2/bot/richmenu");
+    assert.equal(calls[0].init.method, "POST");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("upload endpoint rejects missing rich_menu_id", async () => {
+  const response = await call("/v1/internal/line/rich-menu/public-world/upload-image", {
+    body: { image_url: "https://cdn.example/rich-menu.png" },
+  });
+  assert.equal(response.status, 400);
+  assert.equal((await response.json()).error, "rich_menu_id_missing");
+});
+
+test("upload endpoint rejects invalid image content type", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response("<svg></svg>", {
+    status: 200,
+    headers: { "content-type": "image/svg+xml" },
+  });
+
+  try {
+    const response = await call("/v1/internal/line/rich-menu/public-world/upload-image", {
+      body: { rich_menu_id: "richmenu-created", image_url: "https://cdn.example/rich-menu.svg" },
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(payload.error, "rich_menu_image_type_invalid");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("upload endpoint calls api-data rich menu content", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    if (String(url).startsWith("https://cdn.example/")) {
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { "content-type": "image/png" },
+      });
+    }
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await call("/v1/internal/line/rich-menu/public-world/upload-image", {
+      body: { rich_menu_id: "richmenu-created", image_url: "https://cdn.example/rich-menu.png" },
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.image_uploaded, true);
+    assert.equal(calls[1].url, "https://api-data.line.me/v2/bot/richmenu/richmenu-created/content");
+    assert.equal(calls[1].init.method, "POST");
+    assert.equal(calls[1].init.headers["content-type"], "image/png");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("set-default calls LINE all-user default endpoint", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await call("/v1/internal/line/rich-menu/public-world/set-default", {
+      body: { rich_menu_id: "richmenu-created" },
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.default_set, true);
+    assert.equal(calls[0].url, "https://api.line.me/v2/bot/user/all/richmenu/richmenu-created");
+    assert.equal(calls[0].init.method, "POST");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("publish does not set default if image upload fails", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    if (String(url).endsWith("/validate")) return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    if (String(url) === "https://api.line.me/v2/bot/richmenu") return new Response(JSON.stringify({ richMenuId: "richmenu-created" }), { status: 200, headers: { "content-type": "application/json" } });
+    if (String(url).startsWith("https://cdn.example/")) return new Response("jpg-bytes", { status: 200, headers: { "content-type": "image/jpeg" } });
+    if (String(url).startsWith("https://api-data.line.me/v2/bot/richmenu/")) return new Response("upload failed", { status: 400 });
+    throw new Error("set default should not be called");
+  };
+
+  try {
+    const response = await call("/v1/internal/line/rich-menu/public-world/publish", {
+      body: { image_url: "https://cdn.example/rich-menu.jpg" },
+    });
+    const payload = await response.json();
+
+    assert.equal(response.status, 502);
+    assert.equal(payload.ok, false);
+    assert.equal(payload.created, true);
+    assert.equal(payload.image_uploaded, false);
+    assert.equal(payload.default_set, false);
+    assert.equal(payload.error, "rich_menu_image_upload_failed");
+    assert.equal(calls.some((callItem) => callItem.url.includes("/user/all/richmenu/")), false);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("publish returns sanitized success result", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url: String(url), init });
+    if (String(url).endsWith("/validate")) return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    if (String(url) === "https://api.line.me/v2/bot/richmenu") return new Response(JSON.stringify({ richMenuId: "richmenu-created" }), { status: 200, headers: { "content-type": "application/json" } });
+    if (String(url).startsWith("https://cdn.example/")) return new Response(new Uint8Array([1, 2, 3]), { status: 200, headers: { "content-type": "image/jpeg" } });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await call("/v1/internal/line/rich-menu/public-world/publish", {
+      body: { image_url: "https://cdn.example/rich-menu.jpg" },
+    });
+    const payload = await response.json();
+    const rendered = JSON.stringify(payload);
+
+    assert.equal(response.status, 200);
+    assert.equal(payload.validated, true);
+    assert.equal(payload.created, true);
+    assert.equal(payload.image_uploaded, true);
+    assert.equal(payload.default_set, true);
+    assert.equal(payload.rich_menu_type, "public_world");
+    assert.doesNotMatch(rendered, /line-token|internal-token|authorization|secret/i);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("list/default endpoints require auth", async () => {
+  for (const [method, path] of [
+    ["GET", "/v1/internal/line/rich-menu/list"],
+    ["GET", "/v1/internal/line/rich-menu/default"],
+  ]) {
+    const response = await worker.fetch(request(path, { method }), AUTH_ENV);
+    assert.equal(response.status, 401);
+    assert.equal((await response.json()).error, "internal_auth_required");
+  }
+});
+
+test("list and default endpoints return sanitized LINE data", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url) => {
+    if (String(url).endsWith("/list")) {
+      return new Response(JSON.stringify({
+        richmenus: [{
+          richMenuId: "richmenu-public",
+          name: "MMD Public World",
+          chatBarText: "MMD Public World",
+          selected: true,
+          areas: [{}, {}],
+        }],
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    }
+    return new Response(JSON.stringify({ richMenuId: "richmenu-public" }), { status: 200, headers: { "content-type": "application/json" } });
+  };
+
+  try {
+    const list = await call("/v1/internal/line/rich-menu/list", { method: "GET" });
+    const def = await call("/v1/internal/line/rich-menu/default", { method: "GET" });
+    const listPayload = await list.json();
+    const defPayload = await def.json();
+
+    assert.equal(list.status, 200);
+    assert.deepEqual(listPayload.richmenus[0], {
+      richMenuId: "richmenu-public",
+      name: "MMD Public World",
+      chatBarText: "MMD Public World",
+      selected: true,
+      areas_count: 2,
+    });
+    assert.equal(def.status, 200);
+    assert.equal(defPayload.rich_menu_id, "richmenu-public");
+    assert.doesNotMatch(JSON.stringify({ listPayload, defPayload }), /line-token|internal-token|authorization|secret/i);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("publisher responses never include token secret or authorization", async () => {
+  const response = await call("/v1/internal/line/rich-menu/public-world/draft", {}, {
+    INTERNAL_TOKEN: "very-secret-internal",
+    LINE_CHANNEL_ACCESS_TOKEN: "very-secret-line-token",
+  });
+  const rendered = JSON.stringify(await response.json());
+
+  assert.doesNotMatch(rendered, /very-secret-internal|very-secret-line-token|authorization|secret/i);
+});

--- a/member-dashboard-chat-worker/test/rich-menu-sync.test.mjs
+++ b/member-dashboard-chat-worker/test/rich-menu-sync.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import worker from "../src/index.js";
+
+const LINE_USER_ID = "U1234567890abcdef1234567890abcdef";
+const AUTH_ENV = {
+  INTERNAL_TOKEN: "internal-token",
+  LINE_CHANNEL_ACCESS_TOKEN: "line-token",
+  LINE_RICH_MENU_PUBLIC_ID: "richmenu-public",
+  LINE_RICH_MENU_PRIVATE_ID: "richmenu-private",
+  LINE_RICH_MENU_RENEWAL_ID: "richmenu-renewal",
+  LINE_RICH_MENU_BLACKCARD_ID: "richmenu-blackcard",
+};
+
+function syncRequest(body = {}, headers = {}) {
+  return new Request("https://worker/v1/internal/line/rich-menu/sync", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+async function callSync(body = {}, env = AUTH_ENV, headers = { authorization: "Bearer internal-token" }) {
+  return worker.fetch(syncRequest(body, headers), env);
+}
+
+test("internal sync rejects without auth", async () => {
+  const response = await callSync({ line_user_id: LINE_USER_ID }, AUTH_ENV, {});
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { ok: false, error: "internal_auth_required" });
+});
+
+test("internal sync rejects missing line_user_id", async () => {
+  const response = await callSync({ membership_state: "active", package_state: "current" });
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { ok: false, error: "line_user_id_missing" });
+});
+
+test("active/current premium maps to private_member", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await callSync({ line_user_id: LINE_USER_ID, membership_state: "active", package_state: "current", tier: "premium" });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.rich_menu_target, "private_member");
+    assert.equal(body.linked, true);
+    assert.match(calls[0].url, /\/richmenu\/richmenu-private$/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("expired maps to renewal", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await callSync({ line_user_id: LINE_USER_ID, membership_state: "expired", package_state: "expired" });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.rich_menu_target, "renewal");
+    assert.match(calls[0].url, /\/richmenu\/richmenu-renewal$/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("unknown maps to public_member", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await callSync({ line_user_id: LINE_USER_ID, membership_state: "unknown", package_state: "unknown" });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.rich_menu_target, "public_member");
+    assert.match(calls[0].url, /\/richmenu\/richmenu-public$/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("blackcard active maps to blackcard", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await callSync({ line_user_id: LINE_USER_ID, membership_state: "active", package_state: "current", tier: "blackcard" });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.rich_menu_target, "blackcard");
+    assert.match(calls[0].url, /\/richmenu\/richmenu-blackcard$/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("missing rich menu id returns rich_menu_id_missing", async () => {
+  const response = await callSync(
+    { line_user_id: LINE_USER_ID, membership_state: "active", package_state: "current", tier: "premium" },
+    { INTERNAL_TOKEN: "internal-token", LINE_CHANNEL_ACCESS_TOKEN: "line-token" },
+  );
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { ok: false, error: "rich_menu_id_missing", rich_menu_target: "private_member" });
+});
+
+test("link call uses POST /v2/bot/user/{userId}/richmenu/{richMenuId}", async () => {
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), init });
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const response = await callSync({ line_user_id: LINE_USER_ID, membership_state: "active", package_state: "current", tier: "standard" });
+    assert.equal(response.status, 200);
+    assert.equal(calls[0].url, `https://api.line.me/v2/bot/user/${LINE_USER_ID}/richmenu/richmenu-private`);
+    assert.equal(calls[0].init.method, "POST");
+    assert.equal(calls[0].init.headers.authorization, "Bearer line-token");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("no token returns line_token_missing", async () => {
+  const response = await callSync(
+    { line_user_id: LINE_USER_ID, membership_state: "unknown", package_state: "unknown" },
+    { INTERNAL_TOKEN: "internal-token", LINE_RICH_MENU_PUBLIC_ID: "richmenu-public" },
+  );
+  assert.equal(response.status, 500);
+  assert.equal((await response.json()).error, "line_token_missing");
+});
+
+test("no frontend/browser token exposure", () => {
+  const source = readFileSync(new URL("../../member-pages-worker/src/index.js", import.meta.url), "utf8");
+  assert.doesNotMatch(source, /LINE_CHANNEL_ACCESS_TOKEN/);
+  assert.doesNotMatch(source, /LINE_RICH_MENU_(PUBLIC|MEMBER|PRIVATE|RENEWAL|BLACKCARD)_ID/);
+});


### PR DESCRIPTION
Restores backend-owned LINE Rich Menu internal publisher and sync coverage.

- Adds internal Public World Rich Menu publisher routes in member-dashboard-chat-worker
- Restores Rich Menu sync and publisher tests
- Adds service-bound admin publisher coverage
- Keeps LINE token server-side only
- Rejects public external spoofing
- No deploy
- No LINE publish
- No Webflow publish
- Does not touch Kenji Board, partners-worker, or mmd-redirect-worker