### PR TITLE
feat: ship Kenji member application gate and remove recovery shell

### DIFF
--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -10,7 +10,7 @@ export const MEMBER_PAGES_UPSTREAM = "https://member-pages-worker.malemodel-bkk.
 export const ADMIN_WORKER_UPSTREAM = "https://admin-worker.malemodel-bkk.workers.dev";
 export const SIGIL_WORKER_UPSTREAM = "https://sigil.mmdbkk.com";
 export const FRONT_GATE = "mmd-redirect-worker";
-export const FRONT_VERSION = "20260701-sigil-pay-membership-exact-safe";
+export const FRONT_VERSION = "20260710-member-apply-webflow-pass-through";
 export const PUBLIC_BLACKCARD_PAGE = "public-blackcard";
 export const SIGIL_APPLY_ROUTE_OWNER = "sigil-worker";
 
@@ -18,11 +18,11 @@ export const REDIRECT_HOSTS = new Set(["www.mmdbkk.com", "mmdbkk.com", "mmdprive
 export const NEVER_TOUCH_HOSTS = new Set(["sigil.mmdbkk.com"]);
 export const LINE_WEBHOOK_PATHS = new Set(["/webhooks/line", "/webhooks/line/", "/webhook/line", "/webhook/line/"]);
 export const PUBLIC_BLACKCARD_PATHS = new Set(["/blackcard", "/blackcard/", "/blackcard/black-card", "/blackcard/black-card/"]);
-export const WEBFLOW_MEMBER_PAGE_PATHS = new Set(["/member/promotion", "/member/promotion/"]);
+export const WEBFLOW_MEMBER_PAGE_PATHS = new Set(["/member/promotion", "/member/promotion/", "/member/apply", "/member/apply/"]);
 export const MEMBER_PAGE_PATHS = new Set(["/member/membership", "/member/membership/", "/member/profile", "/member/profile/", "/pay/membership", "/pay/membership/", "/pay/pending-verification", "/pay/pending-verification/", "/sigil/pay/renewal", "/sigil/pay/renewal/"]);
 export const MEMBER_API_PATHS = new Set(["/member/api/liff/identify", "/member/api/liff/identify/"]);
 export const NEVER_TOUCH_PREFIXES = ["/api/", "/webhook/", "/webhooks/", "/payments/", "/payment/", "/payment-webhook/", "/admin/", "/sigil/", "/cdn-cgi/", "/assets/", "/static/", "/uploads/"];
-export const NEVER_REDIRECT_EXACT_PATHS = new Set(["/member/promotion", "/member/promotion/", "/member/dashboard", "/member/dashboard/", "/member/membership", "/member/membership/", "/member/profile", "/member/profile/", "/member/payments", "/member/payments/", "/pay/membership", "/pay/membership/", "/pay/pending-verification", "/pay/pending-verification/", "/sigil/pay/membership", "/sigil/pay/membership/", "/sigil/pay/renewal", "/sigil/pay/renewal/", "/hall", "/hall/", "/model/console", "/model/console/", "/blackcard", "/blackcard/", "/blackcard/black-card", "/blackcard/black-card/"]);
+export const NEVER_REDIRECT_EXACT_PATHS = new Set(["/member/promotion", "/member/promotion/", "/member/apply", "/member/apply/", "/member/dashboard", "/member/dashboard/", "/member/membership", "/member/membership/", "/member/profile", "/member/profile/", "/member/payments", "/member/payments/", "/pay/membership", "/pay/membership/", "/pay/pending-verification", "/pay/pending-verification/", "/sigil/pay/membership", "/sigil/pay/membership/", "/sigil/pay/renewal", "/sigil/pay/renewal/", "/hall", "/hall/", "/model/console", "/model/console/", "/blackcard", "/blackcard/", "/blackcard/black-card", "/blackcard/black-card/"]);
 export const EXACT_PATH_REDIRECTS = { "/trust/inme": "/sigil/start", "/inme": "/sigil/start", "/login": "/sigil/start", "/member": "/member/dashboard", "/member/membership/benefits": "/member/membership", "/members": "/sigil/start", "/membership": "/member/membership", "/membership/benefits": "/member/membership", "/renew": "/sigil/membership", "/renewal": "/sigil/membership", "/trust": "/sigil/start" };
 export const FOLDER_REDIRECTS = [{ from: "/old-academy/", to: "/academy/" }, { from: "/old-trust/", to: "/trust/" }];
 

--- a/mmd-redirect-worker/test/member-apply-route.test.mjs
+++ b/mmd-redirect-worker/test/member-apply-route.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import worker, { FRONT_VERSION, shouldNeverTouch } from "../src/index.js";
+
+let originalFetch;
+let passThroughRequests;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  passThroughRequests = [];
+  globalThis.fetch = async (request) => {
+    passThroughRequests.push(request);
+    return new Response("<main id=\"webflow-member-apply\">Member Apply</main>", {
+      status: 200,
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+        "x-origin": "webflow",
+      },
+    });
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("member apply route ownership", () => {
+  it("marks both /member/apply variants as never-redirect exact paths", () => {
+    assert.equal(shouldNeverTouch(new URL("https://mmdbkk.com/member/apply")), true);
+    assert.equal(shouldNeverTouch(new URL("https://mmdbkk.com/member/apply/")), true);
+  });
+
+  it("passes /member/apply through to Webflow without recovery shell or redirect", async () => {
+    const query = "t=test-token&code=KJ-PRV-123456&promo=gold&x=1";
+
+    for (const path of ["/member/apply", "/member/apply/"]) {
+      const url = `https://mmdbkk.com${path}?${query}`;
+      const response = await worker.fetch(new Request(url));
+      const html = await response.text();
+
+      assert.equal(response.status, 200, path);
+      assert.equal(response.headers.get("location"), null, path);
+      assert.equal(response.headers.get("x-mmd-front-gate"), "mmd-redirect-worker", path);
+      assert.equal(response.headers.get("x-mmd-front-version"), FRONT_VERSION, path);
+      assert.equal(response.headers.get("x-mmd-temporary-route"), null, path);
+      assert.equal(response.headers.get("x-origin"), "webflow", path);
+      assert.match(html, /webflow-member-apply/, path);
+      assert.doesNotMatch(html, /data-mmd-page-shell="member-static"/, path);
+      assert.equal(passThroughRequests.at(-1).url, url, path);
+    }
+
+    assert.equal(passThroughRequests.length, 2);
+  });
+
+  it("preserves query parameters exactly for www host pass-through", async () => {
+    const url = "https://www.mmdbkk.com/member/apply?t=abc&code=x&promo=y&payment_ref=p1";
+    const response = await worker.fetch(new Request(url));
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("location"), null);
+    assert.equal(passThroughRequests.length, 1);
+    assert.equal(passThroughRequests[0].url, url);
+  });
+});

--- a/webflow/member/apply/README.md
+++ b/webflow/member/apply/README.md
@@ -1,0 +1,162 @@
+# MMD Privé Member Application Gate
+
+Production-oriented Webflow module for `/member/apply`.
+
+## Files
+
+- `member-apply.html` — page markup and connection contract
+- `member-apply.css` — mobile-first visual system
+- `member-apply.js` — five-step wizard, validation, review, draft restore
+- `member-apply-os.css` — Worker health status styles
+- `member-apply-os.js` — resilient submission, offline queue, retry, duplicate guard and analytics hooks
+
+## Webflow load order
+
+```html
+<link rel="stylesheet" href="https://models.mmdbkk.com/webflow/member/apply/member-apply.css">
+<link rel="stylesheet" href="https://models.mmdbkk.com/webflow/member/apply/member-apply-os.css">
+```
+
+Paste `member-apply.html` into the Webflow Embed element.
+
+Load scripts before `</body>`:
+
+```html
+<script src="https://models.mmdbkk.com/webflow/member/apply/member-apply.js"></script>
+<script src="https://models.mmdbkk.com/webflow/member/apply/member-apply-os.js"></script>
+```
+
+The OS add-on must load after the base wizard script. It intercepts the final form submission in capture phase and becomes the authoritative browser submission layer.
+
+## Connection contract
+
+All public configuration lives on the root HTML element:
+
+```html
+data-api-base="https://sigil.mmdbkk.com"
+data-submit-path="/v1/member/applications"
+data-dashboard-url="/member/dashboard"
+data-membership-url="/member/membership"
+data-help-url="https://t.me/mmdapply"
+```
+
+Optional:
+
+```html
+data-health-path="/ping"
+```
+
+No secret, bearer token or API key belongs in these attributes or any frontend file.
+
+## Worker request
+
+```http
+POST https://sigil.mmdbkk.com/v1/member/applications
+Content-Type: application/json
+X-Idempotency-Key: member-apply:YYYY-MM-DD:<fingerprint>
+X-MMD-Client: member-apply-os/1.0.0
+```
+
+The request body includes:
+
+- canonical query fields: `t`, `code`, `promo`
+- member profile and contact fields
+- `primary_channel`: `line | telegram | email`
+- application intent and preference arrays
+- consent flags
+- `client_version`, `timezone`, `locale`, `page_url`, `submitted_at`
+
+## Recommended Worker response
+
+```json
+{
+  "ok": true,
+  "application_reference": "MMD-MA-260710-AB12",
+  "status": "received",
+  "next_url": "/member/membership"
+}
+```
+
+Accepted reference aliases in the current frontend:
+
+- `application_reference`
+- `reference`
+- `application_id`
+- `id`
+
+## Duplicate and idempotency behavior
+
+The frontend derives a one-way SHA-256 fingerprint from normalized contact/application identifiers. It does not send a device fingerprint containing hardware or invasive browser attributes.
+
+- duplicate submissions from the same browser are blocked for 10 minutes
+- an `X-Idempotency-Key` is sent to the Worker
+- the Worker should persist and enforce that key
+- HTTP `409` is treated as an already-created application, not a fatal failure
+
+Backend idempotency remains authoritative.
+
+## Offline queue
+
+When offline or when a retryable network/Worker failure occurs, the request is stored in localStorage under:
+
+```text
+mmd_member_application_queue_v1
+```
+
+The queue is retried when the browser emits the `online` event or on the next page load. It keeps at most 10 requests.
+
+The draft and queue remain local to the browser. Never place server secrets or internal notes in either payload.
+
+## Retry policy
+
+Retryable conditions:
+
+- timeout / aborted request
+- offline network
+- HTTP 408, 425, 429
+- HTTP 5xx
+
+Policy:
+
+- maximum 5 attempts
+- exponential backoff
+- jitter added to reduce request bursts
+
+Validation and non-retryable 4xx responses are shown to the user without automatic retries.
+
+## Analytics hooks
+
+The OS layer dispatches browser events and also pushes to `window.dataLayer` when available.
+
+Event names include:
+
+- `mmd:member_application_os_ready`
+- `mmd:member_application_submit_started`
+- `mmd:member_application_retry`
+- `mmd:member_application_queued`
+- `mmd:member_application_success`
+- `mmd:member_application_submit_failed`
+- `mmd:member_application_duplicate_blocked`
+
+No analytics vendor is embedded. The page only emits neutral events.
+
+## Production checklist
+
+1. Implement `POST /v1/member/applications` on `sigil.mmdbkk.com`.
+2. Implement CORS for the approved MMD/Webflow origins.
+3. Support `OPTIONS` preflight for `X-Idempotency-Key` and `X-MMD-Client`.
+4. Return a stable `application_reference`.
+5. Enforce backend idempotency.
+6. Validate and sanitize all fields server-side.
+7. Rate limit abusive requests without blocking normal retries.
+8. Confirm `/ping` is public-safe or change `data-health-path`.
+9. Deploy assets from GitHub to R2 and load them from `models.mmdbkk.com`.
+10. Smoke test online, offline, timeout, 409, 422, 429 and 500 states.
+
+## Route locks
+
+- `/member/apply` is a member application gate, not model recruitment.
+- Kenji is the client/member continuity surface.
+- `/member/membership` owns package selection.
+- `/member/dashboard` owns member home/status continuity.
+- query parameters `t`, `code` and `promo` are preserved into both routes.

--- a/webflow/member/apply/member-application.contract.json
+++ b/webflow/member/apply/member-application.contract.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://sigil.mmdbkk.com/schema/member-application.contract.json",
+  "title": "MMD Member Application Request",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "preferred_name",
+    "full_name",
+    "birth_date",
+    "nationality",
+    "primary_channel",
+    "phone",
+    "application_intent",
+    "languages",
+    "interests",
+    "consent_accuracy",
+    "consent_privacy",
+    "source",
+    "route",
+    "submitted_at"
+  ],
+  "properties": {
+    "t": { "type": "string", "maxLength": 2048 },
+    "code": { "type": "string", "maxLength": 160 },
+    "promo": { "type": "string", "maxLength": 160 },
+    "preferred_name": { "type": "string", "minLength": 1, "maxLength": 80 },
+    "full_name": { "type": "string", "minLength": 1, "maxLength": 140 },
+    "birth_date": { "type": "string", "format": "date" },
+    "nationality": { "type": "string", "minLength": 1, "maxLength": 80 },
+    "primary_channel": { "type": "string", "enum": ["line", "telegram", "email"] },
+    "line_contact": { "type": "string", "maxLength": 100 },
+    "telegram_username": { "type": "string", "maxLength": 100 },
+    "email": { "type": "string", "format": "email", "maxLength": 160 },
+    "phone": { "type": "string", "minLength": 1, "maxLength": 30 },
+    "application_intent": {
+      "type": "string",
+      "enum": ["new_membership", "renew_membership", "upgrade_membership", "continue_application"]
+    },
+    "notes": { "type": "string", "maxLength": 1200 },
+    "languages": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "enum": ["th", "en", "zh", "jp"] }
+    },
+    "interests": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "enum": ["membership", "private_models", "public_work", "travel", "black_card"]
+      }
+    },
+    "care_preference": { "type": "string", "maxLength": 900 },
+    "consent_accuracy": { "const": true },
+    "consent_privacy": { "const": true },
+    "source": { "const": "member_apply" },
+    "route": { "const": "/member/apply" },
+    "page_url": { "type": "string", "format": "uri", "maxLength": 4096 },
+    "submitted_at": { "type": "string", "format": "date-time" },
+    "client_version": { "type": "string", "maxLength": 80 },
+    "timezone": { "type": "string", "maxLength": 100 },
+    "locale": { "type": "string", "maxLength": 40 }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "primary_channel": { "const": "line" } } },
+      "then": { "required": ["line_contact"] }
+    },
+    {
+      "if": { "properties": { "primary_channel": { "const": "telegram" } } },
+      "then": { "required": ["telegram_username"] }
+    },
+    {
+      "if": { "properties": { "primary_channel": { "const": "email" } } },
+      "then": { "required": ["email"] }
+    }
+  ]
+}

--- a/webflow/member/apply/member-apply-os.css
+++ b/webflow/member/apply/member-apply-os.css
@@ -1,0 +1,40 @@
+/* MMD PRIVÉ — MEMBER APPLICATION OS ADD-ON */
+.mmd-member-application__health {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: 10px;
+  padding-left: 10px;
+  border-left: 1px solid var(--line);
+}
+
+.mmd-member-application__health span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+  box-shadow: 0 0 10px transparent;
+}
+
+.mmd-member-application__health b {
+  color: var(--muted);
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: .1em;
+}
+
+.mmd-member-application__health[data-health="online"] span {
+  background: var(--success);
+  box-shadow: 0 0 12px var(--success);
+}
+
+.mmd-member-application__health[data-health="online"] b { color: var(--success); }
+.mmd-member-application__health[data-health="degraded"] span { background: var(--danger); }
+.mmd-member-application__health[data-health="degraded"] b { color: var(--danger); }
+.mmd-member-application__health[data-health="offline"] span { background: #d9a45f; }
+.mmd-member-application__health[data-health="offline"] b { color: #d9a45f; }
+
+@media (max-width: 599px) {
+  .mmd-member-application__health b { display: none; }
+  .mmd-member-application__health { margin-left: 4px; padding-left: 7px; }
+}

--- a/webflow/member/apply/member-apply-os.js
+++ b/webflow/member/apply/member-apply-os.js
@@ -1,0 +1,412 @@
+/* MMD PRIVÉ — MEMBER APPLICATION OS ADD-ON
+ * Load after member-apply.js.
+ * Adds health checks, offline queue, idempotency, duplicate guard,
+ * exponential retry, analytics hooks, and resilient submit handling.
+ */
+(() => {
+  "use strict";
+
+  const root = document.getElementById("mmd-member-application");
+  const form = document.getElementById("mmdMemberApplicationForm");
+  if (!root || !form || root.dataset.osReady === "true") return;
+  root.dataset.osReady = "true";
+
+  const API_BASE = (root.dataset.apiBase || location.origin).replace(/\/$/, "");
+  const SUBMIT_PATH = root.dataset.submitPath || "/v1/member/applications";
+  const HEALTH_PATH = root.dataset.healthPath || "/ping";
+  const DASHBOARD_URL = root.dataset.dashboardUrl || "/member/dashboard";
+  const MEMBERSHIP_URL = root.dataset.membershipUrl || "/member/membership";
+  const HELP_URL = root.dataset.helpUrl || "https://t.me/mmdapply";
+
+  const QUEUE_KEY = "mmd_member_application_queue_v1";
+  const LAST_SUBMISSION_KEY = "mmd_member_application_last_submission_v1";
+  const DRAFT_KEY = "mmd_member_application_draft_v1";
+  const MAX_ATTEMPTS = 5;
+  const DUPLICATE_WINDOW_MS = 10 * 60 * 1000;
+
+  const stateEl = root.querySelector("#mmdApplicationState");
+  const submitBtn = root.querySelector("#mmdApplicationSubmit");
+  const backBtn = root.querySelector("#mmdApplicationBack");
+  const successModal = root.querySelector("#mmdApplicationSuccess");
+  const referenceEl = root.querySelector("#mmdApplicationReference");
+
+  let health = "checking";
+  let submitting = false;
+
+  const healthBadge = document.createElement("div");
+  healthBadge.className = "mmd-member-application__health";
+  healthBadge.innerHTML = '<span aria-hidden="true"></span><b>Checking Worker</b>';
+  root.querySelector(".mmd-member-application__header-status")?.appendChild(healthBadge);
+
+  function emit(name, detail = {}) {
+    const payload = {
+      event: name,
+      route: "/member/apply",
+      at: new Date().toISOString(),
+      ...detail
+    };
+    window.dispatchEvent(new CustomEvent(`mmd:${name}`, { detail: payload }));
+    if (Array.isArray(window.dataLayer)) window.dataLayer.push(payload);
+  }
+
+  function setState(message = "", type = "") {
+    if (!stateEl) return;
+    stateEl.textContent = message;
+    stateEl.className = "mmd-member-application__state";
+    if (type) stateEl.classList.add(`is-${type}`);
+  }
+
+  function setHealth(next, label) {
+    health = next;
+    healthBadge.dataset.health = next;
+    const text = healthBadge.querySelector("b");
+    if (text) text.textContent = label;
+  }
+
+  async function checkHealth() {
+    if (!navigator.onLine) {
+      setHealth("offline", "Offline mode");
+      return false;
+    }
+
+    setHealth("checking", "Checking Worker");
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 4500);
+
+    try {
+      const response = await fetch(`${API_BASE}${HEALTH_PATH}`, {
+        method: "GET",
+        headers: { Accept: "application/json, text/plain" },
+        credentials: "omit",
+        cache: "no-store",
+        signal: controller.signal
+      });
+      if (!response.ok) throw new Error(`Health ${response.status}`);
+      setHealth("online", "Worker online");
+      return true;
+    } catch (error) {
+      setHealth("degraded", "Worker unavailable");
+      return false;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  function normalize(value) {
+    return String(value || "").trim().toLowerCase();
+  }
+
+  function selectedValues(name) {
+    return [...form.querySelectorAll(`[name="${name}"]:checked`)].map(node => node.value);
+  }
+
+  function buildPayload() {
+    const data = new FormData(form);
+    const payload = {};
+
+    for (const [key, value] of data.entries()) {
+      if (["languages", "interests"].includes(key)) continue;
+      payload[key] = typeof value === "string" ? value.trim() : value;
+    }
+
+    payload.languages = selectedValues("languages");
+    payload.interests = selectedValues("interests");
+    payload.consent_accuracy = Boolean(form.elements.consent_accuracy?.checked);
+    payload.consent_privacy = Boolean(form.elements.consent_privacy?.checked);
+    payload.page_url = location.href;
+    payload.submitted_at = new Date().toISOString();
+    payload.client_version = "member-apply-os/1.0.0";
+    payload.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "Asia/Bangkok";
+    payload.locale = document.documentElement.lang || navigator.language || "th";
+    return payload;
+  }
+
+  async function sha256(text) {
+    if (!crypto?.subtle) return btoa(unescape(encodeURIComponent(text))).slice(0, 40);
+    const bytes = new TextEncoder().encode(text);
+    const hash = await crypto.subtle.digest("SHA-256", bytes);
+    return [...new Uint8Array(hash)].map(byte => byte.toString(16).padStart(2, "0")).join("");
+  }
+
+  async function fingerprint(payload) {
+    return sha256([
+      normalize(payload.full_name),
+      normalize(payload.phone),
+      normalize(payload.email),
+      normalize(payload.line_contact),
+      normalize(payload.telegram_username),
+      normalize(payload.code),
+      normalize(payload.promo)
+    ].join("|"));
+  }
+
+  function makeIdempotencyKey(fingerprintValue) {
+    const stamp = new Date().toISOString().slice(0, 10);
+    return `member-apply:${stamp}:${fingerprintValue.slice(0, 32)}`;
+  }
+
+  function readJson(key, fallback) {
+    try {
+      const value = localStorage.getItem(key);
+      return value ? JSON.parse(value) : fallback;
+    } catch (_) {
+      return fallback;
+    }
+  }
+
+  function writeJson(key, value) {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function isRecentDuplicate(fingerprintValue) {
+    const last = readJson(LAST_SUBMISSION_KEY, null);
+    return Boolean(
+      last &&
+      last.fingerprint === fingerprintValue &&
+      Date.now() - Number(last.saved_at || 0) < DUPLICATE_WINDOW_MS
+    );
+  }
+
+  function rememberSubmission(fingerprintValue, reference) {
+    writeJson(LAST_SUBMISSION_KEY, {
+      fingerprint: fingerprintValue,
+      reference,
+      saved_at: Date.now()
+    });
+  }
+
+  function queueRequest(request) {
+    const queue = readJson(QUEUE_KEY, []);
+    const exists = queue.some(item => item.idempotency_key === request.idempotency_key);
+    if (!exists) queue.push(request);
+    writeJson(QUEUE_KEY, queue.slice(-10));
+    emit("member_application_queued", { idempotency_key: request.idempotency_key });
+  }
+
+  function removeQueuedRequest(idempotencyKey) {
+    const queue = readJson(QUEUE_KEY, []);
+    writeJson(QUEUE_KEY, queue.filter(item => item.idempotency_key !== idempotencyKey));
+  }
+
+  function sleep(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
+
+  async function postRequest(request, attempt = 1) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15000);
+
+    try {
+      const response = await fetch(`${API_BASE}${SUBMIT_PATH}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "X-Idempotency-Key": request.idempotency_key,
+          "X-MMD-Client": "member-apply-os/1.0.0"
+        },
+        credentials: "include",
+        body: JSON.stringify(request.payload),
+        signal: controller.signal
+      });
+
+      let result = {};
+      const contentType = response.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) result = await response.json();
+
+      if (response.status === 409) {
+        return {
+          ok: true,
+          duplicate: true,
+          result: result || {}
+        };
+      }
+
+      if (!response.ok) {
+        const retryable = response.status === 408 || response.status === 425 || response.status === 429 || response.status >= 500;
+        const error = new Error(result?.message || result?.error || `Worker returned ${response.status}`);
+        error.retryable = retryable;
+        throw error;
+      }
+
+      return { ok: true, result };
+    } catch (error) {
+      const retryable = error.name === "AbortError" || error.retryable || !navigator.onLine;
+      if (retryable && attempt < MAX_ATTEMPTS && navigator.onLine) {
+        const delay = Math.min(8000, 500 * 2 ** (attempt - 1)) + Math.floor(Math.random() * 250);
+        emit("member_application_retry", { attempt, delay });
+        await sleep(delay);
+        return postRequest(request, attempt + 1);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  function makeFallbackReference() {
+    const stamp = new Date().toISOString().replace(/\D/g, "").slice(2, 12);
+    return `MMD-MA-${stamp}-${Math.random().toString(36).slice(2, 6).toUpperCase()}`;
+  }
+
+  function showSuccess(reference) {
+    applicationReference = reference;
+    if (referenceEl) referenceEl.textContent = reference;
+    if (successModal) successModal.hidden = false;
+    document.body.style.overflow = "hidden";
+    try { localStorage.removeItem(DRAFT_KEY); } catch (_) {}
+    setState("ส่งข้อมูลเรียบร้อย", "success");
+    emit("member_application_success", { reference });
+  }
+
+  async function resilientSubmit() {
+    if (submitting) return;
+    submitting = true;
+    submitBtn.disabled = true;
+    if (backBtn) backBtn.disabled = true;
+
+    try {
+      const payload = buildPayload();
+      if (!payload.consent_accuracy || !payload.consent_privacy) {
+        throw new Error("กรุณายืนยันข้อมูลและนโยบายความเป็นส่วนตัวก่อนส่ง");
+      }
+
+      const fingerprintValue = await fingerprint(payload);
+      if (isRecentDuplicate(fingerprintValue)) {
+        const last = readJson(LAST_SUBMISSION_KEY, {});
+        setState(`ใบสมัครนี้เพิ่งถูกส่งแล้ว Reference: ${last.reference || "กำลังตรวจสอบ"}`, "error");
+        emit("member_application_duplicate_blocked");
+        return;
+      }
+
+      const request = {
+        payload,
+        idempotency_key: makeIdempotencyKey(fingerprintValue),
+        fingerprint: fingerprintValue,
+        queued_at: new Date().toISOString()
+      };
+
+      emit("member_application_submit_started", { idempotency_key: request.idempotency_key });
+
+      if (!navigator.onLine) {
+        queueRequest(request);
+        setState("อุปกรณ์ออฟไลน์ ระบบเก็บใบสมัครไว้และจะส่งให้อัตโนมัติเมื่อออนไลน์", "success");
+        return;
+      }
+
+      setState("กำลังส่งข้อมูลอย่างปลอดภัย...");
+      const response = await postRequest(request);
+      const result = response.result || {};
+      const reference =
+        result.application_reference ||
+        result.reference ||
+        result.application_id ||
+        result.id ||
+        makeFallbackReference();
+
+      rememberSubmission(fingerprintValue, reference);
+      removeQueuedRequest(request.idempotency_key);
+      showSuccess(reference);
+    } catch (error) {
+      const payload = buildPayload();
+      const fingerprintValue = await fingerprint(payload);
+      const request = {
+        payload,
+        idempotency_key: makeIdempotencyKey(fingerprintValue),
+        fingerprint: fingerprintValue,
+        queued_at: new Date().toISOString()
+      };
+
+      if (!navigator.onLine || error.name === "AbortError" || error.retryable) {
+        queueRequest(request);
+        setState("Worker ยังไม่พร้อม ระบบเก็บใบสมัครไว้และจะลองส่งให้อัตโนมัติ", "success");
+      } else {
+        setState(error.message || "ส่งข้อมูลไม่สำเร็จ กรุณาลองอีกครั้ง", "error");
+      }
+      emit("member_application_submit_failed", { message: error.message || "unknown" });
+    } finally {
+      submitting = false;
+      submitBtn.disabled = false;
+      if (backBtn) backBtn.disabled = false;
+    }
+  }
+
+  async function flushQueue() {
+    if (!navigator.onLine) return;
+    const queue = readJson(QUEUE_KEY, []);
+    if (!queue.length) return;
+
+    setState(`กำลังส่งใบสมัครที่รออยู่ ${queue.length} รายการ...`);
+    for (const request of queue) {
+      try {
+        const response = await postRequest(request);
+        const result = response.result || {};
+        const reference =
+          result.application_reference ||
+          result.reference ||
+          result.application_id ||
+          result.id ||
+          makeFallbackReference();
+        rememberSubmission(request.fingerprint, reference);
+        removeQueuedRequest(request.idempotency_key);
+        showSuccess(reference);
+        break;
+      } catch (error) {
+        emit("member_application_queue_flush_failed", { message: error.message || "unknown" });
+        break;
+      }
+    }
+  }
+
+  form.addEventListener("submit", event => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    resilientSubmit();
+  }, true);
+
+  window.addEventListener("online", () => {
+    setHealth("checking", "Back online");
+    checkHealth().then(flushQueue);
+  });
+
+  window.addEventListener("offline", () => {
+    setHealth("offline", "Offline mode");
+    setState("อินเทอร์เน็ตขาดการเชื่อมต่อ ร่างข้อมูลยังถูกเก็บอยู่ในอุปกรณ์", "error");
+  });
+
+  root.querySelector("#mmdApplicationGoMembership")?.addEventListener("click", event => {
+    event.stopImmediatePropagation();
+    location.href = preserveParams(MEMBERSHIP_URL, applicationReference);
+  }, true);
+
+  root.querySelector("#mmdApplicationGoDashboard")?.addEventListener("click", event => {
+    event.stopImmediatePropagation();
+    location.href = preserveParams(DASHBOARD_URL, applicationReference);
+  }, true);
+
+  function preserveParams(url, reference = "") {
+    const target = new URL(url, location.origin);
+    const source = new URLSearchParams(location.search);
+    ["t", "code", "promo"].forEach(name => {
+      const value = source.get(name);
+      if (value) target.searchParams.set(name, value);
+    });
+    if (reference) target.searchParams.set("application_ref", reference);
+    return target.toString();
+  }
+
+  emit("member_application_os_ready", {
+    online: navigator.onLine,
+    queued: readJson(QUEUE_KEY, []).length,
+    help_url: HELP_URL
+  });
+
+  checkHealth().then(() => {
+    if (navigator.onLine) flushQueue();
+  });
+})();

--- a/webflow/member/apply/member-apply.css
+++ b/webflow/member/apply/member-apply.css
@@ -1,0 +1,246 @@
+/* MMD PRIVÉ — KENJI MEMBER APPLICATION GATE / MOBILE FIRST */
+#mmd-member-application,
+#mmd-member-application * { box-sizing: border-box; }
+
+#mmd-member-application {
+  --bg: #070708;
+  --panel: rgba(20,20,22,.92);
+  --panel-soft: rgba(255,255,255,.035);
+  --line: rgba(255,255,255,.11);
+  --line-gold: rgba(214,181,112,.34);
+  --text: #f5f1e8;
+  --muted: #a7a096;
+  --gold: #d6b570;
+  --gold-2: #f1d79c;
+  --violet: #2c2035;
+  --danger: #ff9494;
+  --success: #a8d5b0;
+  min-height: 100vh;
+  color: var(--text);
+  background:
+    radial-gradient(circle at 10% 0%, rgba(128,95,42,.18), transparent 30rem),
+    radial-gradient(circle at 95% 30%, rgba(61,42,75,.18), transparent 28rem),
+    var(--bg);
+  font-family: Inter, "Noto Sans Thai", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.mmd-member-application__bg { position: absolute; inset: 0; z-index: -1; pointer-events: none; }
+.mmd-member-application__glow { position: absolute; border-radius: 50%; filter: blur(85px); opacity: .22; }
+.mmd-member-application__glow--gold { width: 280px; height: 280px; background: #9e773a; top: 22rem; left: -12rem; }
+.mmd-member-application__glow--violet { width: 360px; height: 360px; background: #4d325f; top: 74rem; right: -18rem; }
+.mmd-member-application__grid {
+  position: absolute; inset: 0;
+  background-image:
+    linear-gradient(rgba(255,255,255,.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,.025) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: linear-gradient(to bottom, rgba(0,0,0,.45), transparent 80%);
+}
+
+.mmd-member-application__header,
+.mmd-member-application__main,
+.mmd-member-application__footer {
+  width: min(100% - 28px, 1240px);
+  margin-inline: auto;
+}
+
+.mmd-member-application__header {
+  min-height: 74px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mmd-member-application__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.mmd-member-application__brand-mark {
+  width: 42px;
+  height: 42px;
+  border: 1px solid var(--line-gold);
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-family: Georgia, serif;
+  font-size: 11px;
+  color: var(--gold);
+}
+
+.mmd-member-application__brand > span:last-child { display: flex; flex-direction: column; gap: 2px; }
+.mmd-member-application__brand b { font-family: Georgia, serif; letter-spacing: .14em; font-size: 13px; }
+.mmd-member-application__brand small,
+.mmd-member-application__header-status { font-size: 8px; letter-spacing: .14em; color: var(--muted); }
+.mmd-member-application__header-status { display: flex; align-items: center; gap: 7px; }
+.mmd-member-application__status-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--success); box-shadow: 0 0 14px var(--success); }
+
+.mmd-member-application__hero { padding: 54px 0 66px; display: grid; gap: 32px; }
+.mmd-member-application__eyebrow { color: var(--gold); font-size: 9px; letter-spacing: .17em; }
+.mmd-member-application h1,
+.mmd-member-application h2 { margin: 0; font-family: Georgia, "Noto Serif Thai", serif; font-weight: 400; letter-spacing: -.045em; }
+.mmd-member-application h1 { margin-top: 14px; font-size: clamp(46px, 14vw, 78px); line-height: .97; }
+.mmd-member-application h2 { font-size: clamp(34px, 10vw, 52px); line-height: 1; }
+.mmd-member-application h1 em,
+.mmd-member-application h2 em { color: var(--gold); font-style: italic; }
+.mmd-member-application__hero-copy > p { color: var(--muted); line-height: 1.85; font-size: 14px; margin: 24px 0 0; max-width: 650px; }
+
+.mmd-member-application__kenji-line {
+  margin-top: 26px;
+  display: grid;
+  grid-template-columns: 38px 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 16px;
+  border-left: 1px solid var(--gold);
+  background: linear-gradient(90deg, rgba(214,181,112,.08), transparent);
+}
+.mmd-member-application__kenji-line > span { width: 38px; height: 38px; border-radius: 50%; border: 1px solid var(--line-gold); display: grid; place-items: center; color: var(--gold); font-family: Georgia, serif; }
+.mmd-member-application__kenji-line p { margin: 0; font-family: Georgia, "Noto Serif Thai", serif; line-height: 1.55; }
+
+.mmd-member-application__summary-card {
+  border: 1px solid var(--line);
+  border-radius: 24px;
+  padding: 24px;
+  background: linear-gradient(145deg, rgba(255,255,255,.07), rgba(255,255,255,.02));
+  min-height: 230px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+.mmd-member-application__summary-label { color: var(--gold); font-size: 9px; letter-spacing: .17em; }
+.mmd-member-application__summary-card strong { margin-top: 18px; font-family: Georgia, serif; font-size: 54px; font-weight: 400; }
+.mmd-member-application__summary-card p { color: var(--muted); line-height: 1.6; font-size: 12px; }
+.mmd-member-application__query-badges { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 12px; }
+.mmd-member-application__query-badges span { padding: 7px 9px; border: 1px solid var(--line-gold); border-radius: 99px; color: var(--gold); font-size: 9px; }
+
+.mmd-member-application__wizard-shell { display: grid; gap: 14px; padding-bottom: 82px; }
+.mmd-member-application__steps { display: flex; gap: 8px; overflow-x: auto; scrollbar-width: none; padding-bottom: 4px; }
+.mmd-member-application__steps::-webkit-scrollbar { display: none; }
+.mmd-member-application__steps button { min-width: 110px; border: 1px solid var(--line); border-radius: 15px; background: rgba(255,255,255,.025); color: var(--muted); padding: 12px; text-align: left; cursor: pointer; }
+.mmd-member-application__steps button span { display: block; color: var(--gold); font-size: 9px; margin-bottom: 6px; }
+.mmd-member-application__steps button b { font-size: 12px; }
+.mmd-member-application__steps button.is-active { border-color: var(--gold); background: rgba(214,181,112,.08); color: var(--text); }
+
+.mmd-member-application__form { border: 1px solid var(--line); border-radius: 24px; padding: 18px; background: linear-gradient(160deg, rgba(255,255,255,.055), rgba(255,255,255,.018)); }
+.mmd-member-application__progress { margin-bottom: 28px; }
+.mmd-member-application__progress > div { height: 4px; border-radius: 99px; overflow: hidden; background: rgba(255,255,255,.08); }
+.mmd-member-application__progress > div span { display: block; width: 20%; height: 100%; background: linear-gradient(90deg, var(--gold), var(--gold-2)); transition: width .25s ease; }
+.mmd-member-application__progress small { margin-top: 9px; display: flex; justify-content: space-between; color: var(--muted); }
+.mmd-member-application__progress b { color: var(--text); }
+
+.mmd-member-application__panel { display: none; }
+.mmd-member-application__panel.is-active { display: block; animation: mmdApplicationIn .3s ease; }
+@keyframes mmdApplicationIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+
+.mmd-member-application__panel-head { padding-bottom: 22px; margin-bottom: 22px; border-bottom: 1px solid var(--line); }
+.mmd-member-application__panel-head > span { color: var(--gold); font-size: 9px; letter-spacing: .16em; }
+.mmd-member-application__panel-head h2 { margin-top: 7px; }
+.mmd-member-application__panel-head p { color: var(--muted); font-size: 12px; margin: 10px 0 0; }
+
+.mmd-member-application__fields { display: grid; gap: 16px; }
+.mmd-member-application__fields label,
+.mmd-member-application__textarea { display: grid; gap: 8px; }
+.mmd-member-application__fields label > span,
+.mmd-member-application__textarea > span,
+.mmd-member-application fieldset legend { font-size: 12px; font-weight: 700; color: #ebe5da; }
+.mmd-member-application input,
+.mmd-member-application textarea { font: inherit; }
+.mmd-member-application__fields input,
+.mmd-member-application__textarea textarea { width: 100%; min-height: 50px; border: 1px solid var(--line); border-radius: 13px; background: rgba(0,0,0,.26); color: var(--text); padding: 13px 14px; outline: none; }
+.mmd-member-application__textarea { margin-top: 18px; }
+.mmd-member-application__textarea textarea { resize: vertical; min-height: 120px; }
+.mmd-member-application__textarea small { justify-self: end; color: var(--muted); }
+.mmd-member-application input:focus,
+.mmd-member-application textarea:focus { border-color: var(--gold); box-shadow: 0 0 0 3px rgba(214,181,112,.08); }
+.mmd-member-application .is-invalid { border-color: rgba(255,148,148,.75) !important; }
+.mmd-member-application__error { color: var(--danger); font-size: 10px; min-height: 0; }
+.mmd-member-application__field-row { display: grid; gap: 16px; }
+.mmd-member-application fieldset { margin: 0; padding: 0; border: 0; }
+
+.mmd-member-application__contact-choice,
+.mmd-member-application__option-cards { display: grid; gap: 9px; margin-bottom: 18px; }
+.mmd-member-application__contact-choice label input,
+.mmd-member-application__option-cards label input,
+.mmd-member-application__chip-group label input { position: absolute; opacity: 0; pointer-events: none; }
+.mmd-member-application__contact-choice label > span,
+.mmd-member-application__option-cards label > span { display: grid; gap: 5px; padding: 16px; border: 1px solid var(--line); border-radius: 15px; background: rgba(255,255,255,.025); cursor: pointer; }
+.mmd-member-application__contact-choice small,
+.mmd-member-application__option-cards small { color: var(--muted); line-height: 1.55; }
+.mmd-member-application__contact-choice input:checked + span,
+.mmd-member-application__option-cards input:checked + span { border-color: var(--gold); background: rgba(214,181,112,.08); }
+
+.mmd-member-application__chip-group { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 22px !important; }
+.mmd-member-application__chip-group legend { width: 100%; margin-bottom: 3px; }
+.mmd-member-application__chip-group label span { display: inline-flex; padding: 10px 13px; border: 1px solid var(--line); border-radius: 99px; color: var(--muted); background: rgba(255,255,255,.025); cursor: pointer; font-size: 12px; }
+.mmd-member-application__chip-group input:checked + span { background: var(--gold); border-color: var(--gold); color: #17120a; }
+
+.mmd-member-application__review { display: grid; gap: 8px; margin-bottom: 22px; }
+.mmd-member-application__review-row { display: grid; grid-template-columns: 118px 1fr; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--line); }
+.mmd-member-application__review-row span { color: var(--muted); font-size: 11px; }
+.mmd-member-application__review-row b { font-size: 12px; overflow-wrap: anywhere; }
+.mmd-member-application__consents { display: grid; gap: 12px; }
+.mmd-member-application__consents label { display: grid; grid-template-columns: 20px 1fr; gap: 10px; align-items: start; color: var(--muted); font-size: 12px; line-height: 1.65; }
+.mmd-member-application__consents input { margin-top: 3px; accent-color: var(--gold); }
+.mmd-member-application__final-note { margin-top: 22px; padding: 16px; border-left: 1px solid var(--gold); background: rgba(214,181,112,.06); }
+.mmd-member-application__final-note span { color: var(--gold); font-size: 8px; letter-spacing: .15em; }
+.mmd-member-application__final-note p { margin: 7px 0 0; line-height: 1.65; font-size: 12px; }
+
+.mmd-member-application__actions,
+.mmd-member-application__modal-actions { display: flex; flex-direction: column; gap: 10px; margin-top: 28px; }
+.mmd-member-application__btn { min-height: 52px; border-radius: 99px; padding: 0 19px; display: inline-flex; justify-content: center; align-items: center; font: inherit; font-size: 13px; font-weight: 800; cursor: pointer; transition: .2s ease; }
+.mmd-member-application__btn:hover { transform: translateY(-2px); }
+.mmd-member-application__btn:disabled { opacity: .55; cursor: wait; transform: none; }
+.mmd-member-application__btn--primary { color: #17120a; border: 0; background: linear-gradient(135deg, var(--gold-2), #b8914d); }
+.mmd-member-application__btn--ghost { color: var(--text); border: 1px solid var(--line); background: rgba(255,255,255,.025); }
+.mmd-member-application__state { min-height: 20px; margin-top: 14px; text-align: center; color: var(--muted); font-size: 12px; }
+.mmd-member-application__state.is-error { color: var(--danger); }
+.mmd-member-application__state.is-success { color: var(--success); }
+
+.mmd-member-application__footer { padding: 28px 0 42px; border-top: 1px solid var(--line); display: flex; flex-wrap: wrap; gap: 10px 18px; }
+.mmd-member-application__footer a { color: var(--muted); font-size: 11px; text-decoration: none; }
+.mmd-member-application__footer a:hover { color: var(--gold); }
+
+.mmd-member-application__modal { position: fixed; inset: 0; z-index: 1000; padding: 20px; display: grid; place-items: center; background: rgba(0,0,0,.8); backdrop-filter: blur(18px); }
+.mmd-member-application__modal[hidden] { display: none; }
+.mmd-member-application__modal-card { width: min(100%, 470px); padding: 28px; border: 1px solid var(--line-gold); border-radius: 24px; background: #0d0d0f; text-align: center; }
+.mmd-member-application__modal-card > p:not(.mmd-member-application__eyebrow) { color: var(--muted); line-height: 1.7; }
+.mmd-member-application__modal-icon { width: 54px; height: 54px; border: 1px solid var(--gold); border-radius: 50%; display: grid; place-items: center; margin: 0 auto 20px; color: var(--gold); font-size: 22px; }
+.mmd-member-application__reference { margin: 22px 0; padding: 14px; border: 1px solid var(--line); border-radius: 13px; display: grid; gap: 5px; }
+.mmd-member-application__reference small { color: var(--muted); font-size: 9px; letter-spacing: .14em; }
+.mmd-member-application__reference strong { color: var(--gold); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+@media (min-width: 600px) {
+  .mmd-member-application__header,
+  .mmd-member-application__main,
+  .mmd-member-application__footer { width: min(100% - 48px, 1240px); }
+  .mmd-member-application__field-row { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .mmd-member-application__contact-choice,
+  .mmd-member-application__option-cards { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .mmd-member-application__actions,
+  .mmd-member-application__modal-actions { flex-direction: row; }
+  .mmd-member-application__btn { min-width: 170px; }
+}
+
+@media (min-width: 900px) {
+  .mmd-member-application__hero { padding: 84px 0 92px; grid-template-columns: minmax(0, 1.2fr) minmax(320px, .6fr); align-items: center; gap: 70px; }
+  .mmd-member-application h1 { font-size: clamp(74px, 8vw, 116px); }
+  .mmd-member-application__wizard-shell { grid-template-columns: 190px minmax(0, 1fr); gap: 18px; align-items: start; }
+  .mmd-member-application__steps { position: sticky; top: 22px; display: grid; overflow: visible; }
+  .mmd-member-application__steps button { width: 100%; }
+  .mmd-member-application__form { padding: 30px; }
+  .mmd-member-application__contact-choice { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mmd-member-application *,
+  .mmd-member-application *::before,
+  .mmd-member-application *::after { animation: none !important; transition: none !important; scroll-behavior: auto !important; }
+}

--- a/webflow/member/apply/member-apply.html
+++ b/webflow/member/apply/member-apply.html
@@ -1,0 +1,304 @@
+<!-- MMD PRIVÉ — KENJI MEMBER APPLICATION GATE -->
+<section
+  id="mmd-member-application"
+  class="mmd-member-application"
+  data-api-base="https://sigil.mmdbkk.com"
+  data-submit-path="/v1/member/applications"
+  data-dashboard-url="/member/dashboard"
+  data-membership-url="/member/membership"
+  data-help-url="https://t.me/mmdapply"
+  aria-label="MMD Privé Member Application"
+>
+  <div class="mmd-member-application__bg" aria-hidden="true">
+    <span class="mmd-member-application__glow mmd-member-application__glow--gold"></span>
+    <span class="mmd-member-application__glow mmd-member-application__glow--violet"></span>
+    <span class="mmd-member-application__grid"></span>
+  </div>
+
+  <header class="mmd-member-application__header">
+    <a href="/" class="mmd-member-application__brand" aria-label="MMD Privé Home">
+      <span class="mmd-member-application__brand-mark">MMD</span>
+      <span>
+        <b>PRIVÉ</b>
+        <small>MEMBER APPLICATION GATE</small>
+      </span>
+    </a>
+
+    <div class="mmd-member-application__header-status">
+      <span class="mmd-member-application__status-dot"></span>
+      <span>PRIVATE ACCESS</span>
+    </div>
+  </header>
+
+  <main class="mmd-member-application__main">
+    <section class="mmd-member-application__hero">
+      <div class="mmd-member-application__hero-copy">
+        <span class="mmd-member-application__eyebrow">KENJI / MEMBER CONTINUITY</span>
+        <h1>เริ่มต้นให้ถูกทาง<br><em>แล้วผมจะพาไปต่อเอง</em></h1>
+        <p>
+          หน้านี้คือ Member Application Gate สำหรับผู้ที่ต้องการสมัครสมาชิก
+          ต่อเส้นทางจากโค้ดเชิญ หรือกลับเข้ามาดำเนินการต่ออย่างเป็นส่วนตัว
+        </p>
+
+        <div class="mmd-member-application__kenji-line">
+          <span>K</span>
+          <p>“ตอบเท่าที่จำเป็นครับ ระบบจะบันทึกร่างไว้ในอุปกรณ์ของคุณโดยอัตโนมัติ”</p>
+        </div>
+      </div>
+
+      <aside class="mmd-member-application__summary-card">
+        <span class="mmd-member-application__summary-label">APPLICATION GATE</span>
+        <strong>5 STEPS</strong>
+        <p>Profile · Contact · Intent · Preferences · Review</p>
+        <div class="mmd-member-application__query-badges" id="mmdApplicationQueryBadges"></div>
+      </aside>
+    </section>
+
+    <section class="mmd-member-application__wizard-shell">
+      <aside class="mmd-member-application__steps" aria-label="Application steps">
+        <button type="button" class="is-active" data-step-jump="0"><span>01</span><b>Profile</b></button>
+        <button type="button" data-step-jump="1"><span>02</span><b>Contact</b></button>
+        <button type="button" data-step-jump="2"><span>03</span><b>Intent</b></button>
+        <button type="button" data-step-jump="3"><span>04</span><b>Preferences</b></button>
+        <button type="button" data-step-jump="4"><span>05</span><b>Review</b></button>
+      </aside>
+
+      <form id="mmdMemberApplicationForm" class="mmd-member-application__form" novalidate>
+        <input type="hidden" name="t" id="mmdApplicationToken">
+        <input type="hidden" name="code" id="mmdApplicationCode">
+        <input type="hidden" name="promo" id="mmdApplicationPromo">
+        <input type="hidden" name="source" value="member_apply">
+        <input type="hidden" name="route" value="/member/apply">
+
+        <div class="mmd-member-application__progress">
+          <div><span id="mmdApplicationProgressBar"></span></div>
+          <small>
+            <b id="mmdApplicationProgressLabel">ขั้นตอน 1 จาก 5</b>
+            <span id="mmdApplicationDraftState">Draft ready</span>
+          </small>
+        </div>
+
+        <section class="mmd-member-application__panel is-active" data-panel="0">
+          <div class="mmd-member-application__panel-head">
+            <span>STEP 01</span>
+            <h2>ข้อมูลพื้นฐาน</h2>
+            <p>ใช้ข้อมูลที่คุณสามารถยืนยันได้จริง</p>
+          </div>
+
+          <div class="mmd-member-application__fields">
+            <label>
+              <span>ชื่อที่ต้องการให้เรียก *</span>
+              <input type="text" name="preferred_name" maxlength="80" required autocomplete="name" placeholder="เช่น Per">
+              <small class="mmd-member-application__error"></small>
+            </label>
+
+            <label>
+              <span>ชื่อจริงและนามสกุล *</span>
+              <input type="text" name="full_name" maxlength="140" required autocomplete="name" placeholder="ชื่อสำหรับยืนยันตัวตน">
+              <small class="mmd-member-application__error"></small>
+            </label>
+
+            <div class="mmd-member-application__field-row">
+              <label>
+                <span>วันเกิด *</span>
+                <input type="date" name="birth_date" required>
+                <small class="mmd-member-application__error"></small>
+              </label>
+
+              <label>
+                <span>สัญชาติ *</span>
+                <input type="text" name="nationality" maxlength="80" required placeholder="Thai">
+                <small class="mmd-member-application__error"></small>
+              </label>
+            </div>
+          </div>
+        </section>
+
+        <section class="mmd-member-application__panel" data-panel="1">
+          <div class="mmd-member-application__panel-head">
+            <span>STEP 02</span>
+            <h2>เลือกช่องทางติดต่อ</h2>
+            <p>เลือกช่องทางหลัก 1 ช่องทาง และกรอกข้อมูลให้ตรงกัน</p>
+          </div>
+
+          <fieldset class="mmd-member-application__contact-choice">
+            <legend>ช่องทางหลัก *</legend>
+            <label>
+              <input type="radio" name="primary_channel" value="line" required>
+              <span><b>LINE</b><small>เหมาะกับการติดต่อในไทย</small></span>
+            </label>
+            <label>
+              <input type="radio" name="primary_channel" value="telegram" required>
+              <span><b>Telegram</b><small>เหมาะกับการติดต่อแบบ private</small></span>
+            </label>
+            <label>
+              <input type="radio" name="primary_channel" value="email" required>
+              <span><b>Email</b><small>เหมาะกับข้อมูลทางการ</small></span>
+            </label>
+            <small class="mmd-member-application__error" data-group-error="primary_channel"></small>
+          </fieldset>
+
+          <div class="mmd-member-application__fields">
+            <label data-channel-field="line" hidden>
+              <span>LINE ID หรือชื่อที่แสดง *</span>
+              <input type="text" name="line_contact" maxlength="100" placeholder="LINE ID / Display name">
+              <small class="mmd-member-application__error"></small>
+            </label>
+
+            <label data-channel-field="telegram" hidden>
+              <span>Telegram Username *</span>
+              <input type="text" name="telegram_username" maxlength="100" placeholder="@username">
+              <small class="mmd-member-application__error"></small>
+            </label>
+
+            <label data-channel-field="email" hidden>
+              <span>Email *</span>
+              <input type="email" name="email" maxlength="160" autocomplete="email" placeholder="name@email.com">
+              <small class="mmd-member-application__error"></small>
+            </label>
+
+            <label>
+              <span>เบอร์โทรศัพท์ *</span>
+              <input type="tel" name="phone" maxlength="30" required autocomplete="tel" placeholder="08x xxx xxxx">
+              <small class="mmd-member-application__error"></small>
+            </label>
+          </div>
+        </section>
+
+        <section class="mmd-member-application__panel" data-panel="2">
+          <div class="mmd-member-application__panel-head">
+            <span>STEP 03</span>
+            <h2>จุดประสงค์ของการสมัคร</h2>
+            <p>ช่วยให้ Kenji ส่งคุณไปยัง Membership route ที่เหมาะสม</p>
+          </div>
+
+          <div class="mmd-member-application__option-cards">
+            <label>
+              <input type="radio" name="application_intent" value="new_membership" required>
+              <span><b>สมัครสมาชิกใหม่</b><small>เริ่มต้นเลือกแพ็กเกจและสิทธิ์การเข้าถึง</small></span>
+            </label>
+            <label>
+              <input type="radio" name="application_intent" value="renew_membership" required>
+              <span><b>ต่ออายุสมาชิก</b><small>กลับเข้ามาตรวจสถานะและดำเนินการต่ออายุ</small></span>
+            </label>
+            <label>
+              <input type="radio" name="application_intent" value="upgrade_membership" required>
+              <span><b>อัปเกรดสมาชิก</b><small>พิจารณาระดับการเข้าถึงที่สูงขึ้น</small></span>
+            </label>
+            <label>
+              <input type="radio" name="application_intent" value="continue_application" required>
+              <span><b>ดำเนินการต่อ</b><small>มี token, code หรือ promotion อยู่แล้ว</small></span>
+            </label>
+          </div>
+          <small class="mmd-member-application__error" data-group-error="application_intent"></small>
+
+          <label class="mmd-member-application__textarea">
+            <span>มีอะไรที่ควรให้ MMD ทราบก่อนหรือไม่</span>
+            <textarea name="notes" rows="5" maxlength="1200" placeholder="ไม่จำเป็นต้องตอบ หากยังไม่มีข้อมูลเพิ่มเติม"></textarea>
+            <small><span data-count-for="notes">0</span>/1200</small>
+          </label>
+        </section>
+
+        <section class="mmd-member-application__panel" data-panel="3">
+          <div class="mmd-member-application__panel-head">
+            <span>STEP 04</span>
+            <h2>ความต้องการเบื้องต้น</h2>
+            <p>ยังไม่ใช่การจองจริง ใช้เพื่อช่วยจัด route เท่านั้น</p>
+          </div>
+
+          <fieldset class="mmd-member-application__chip-group">
+            <legend>ภาษาที่สะดวก *</legend>
+            <label><input type="checkbox" name="languages" value="th"><span>ไทย</span></label>
+            <label><input type="checkbox" name="languages" value="en"><span>English</span></label>
+            <label><input type="checkbox" name="languages" value="zh"><span>中文</span></label>
+            <label><input type="checkbox" name="languages" value="jp"><span>日本語</span></label>
+            <small class="mmd-member-application__error" data-group-error="languages"></small>
+          </fieldset>
+
+          <fieldset class="mmd-member-application__chip-group">
+            <legend>สิ่งที่สนใจ *</legend>
+            <label><input type="checkbox" name="interests" value="membership"><span>Membership</span></label>
+            <label><input type="checkbox" name="interests" value="private_models"><span>Private Models</span></label>
+            <label><input type="checkbox" name="interests" value="public_work"><span>Public Work</span></label>
+            <label><input type="checkbox" name="interests" value="travel"><span>Travel Experience</span></label>
+            <label><input type="checkbox" name="interests" value="black_card"><span>Black Card</span></label>
+            <small class="mmd-member-application__error" data-group-error="interests"></small>
+          </fieldset>
+
+          <label class="mmd-member-application__textarea">
+            <span>สไตล์การดูแลที่คุณสบายใจ</span>
+            <textarea name="care_preference" rows="4" maxlength="900" placeholder="เช่น ต้องการคำแนะนำชัดเจน ต้องการความเป็นส่วนตัวสูง หรือยังไม่แน่ใจ"></textarea>
+            <small><span data-count-for="care_preference">0</span>/900</small>
+          </label>
+        </section>
+
+        <section class="mmd-member-application__panel" data-panel="4">
+          <div class="mmd-member-application__panel-head">
+            <span>STEP 05</span>
+            <h2>ตรวจสอบก่อนส่ง</h2>
+            <p>ข้อมูลจะถูกส่งไปยัง Worker เมื่อคุณกดยืนยัน</p>
+          </div>
+
+          <div id="mmdApplicationReview" class="mmd-member-application__review"></div>
+
+          <div class="mmd-member-application__consents">
+            <label>
+              <input type="checkbox" name="consent_accuracy" required>
+              <span>ฉันยืนยันว่าข้อมูลที่ให้เป็นความจริง</span>
+            </label>
+            <label>
+              <input type="checkbox" name="consent_privacy" required>
+              <span>ฉันยินยอมให้ MMD ใช้ข้อมูลนี้เพื่อการตรวจสอบและติดต่อกลับ</span>
+            </label>
+          </div>
+
+          <div class="mmd-member-application__final-note">
+            <span>KENJI / FINAL CHECK</span>
+            <p>การส่งใบสมัครยังไม่ใช่การอนุมัติสมาชิก ระบบจะตรวจสอบก่อนพาคุณไปยังหน้าถัดไปครับ</p>
+          </div>
+        </section>
+
+        <div class="mmd-member-application__actions">
+          <button type="button" id="mmdApplicationBack" class="mmd-member-application__btn mmd-member-application__btn--ghost" hidden>
+            ย้อนกลับ
+          </button>
+          <button type="button" id="mmdApplicationNext" class="mmd-member-application__btn mmd-member-application__btn--primary">
+            ดำเนินการต่อ
+          </button>
+          <button type="submit" id="mmdApplicationSubmit" class="mmd-member-application__btn mmd-member-application__btn--primary" hidden>
+            ส่งใบสมัคร
+          </button>
+        </div>
+
+        <div id="mmdApplicationState" class="mmd-member-application__state" role="status" aria-live="polite"></div>
+      </form>
+    </section>
+  </main>
+
+  <footer class="mmd-member-application__footer">
+    <a id="mmdApplicationMembershipLink" href="/member/membership">Membership Page</a>
+    <a id="mmdApplicationDashboardLink" href="/member/dashboard">Member Dashboard</a>
+    <a id="mmdApplicationHelpLink" href="https://t.me/mmdapply" target="_blank" rel="noopener">Need help?</a>
+  </footer>
+
+  <div id="mmdApplicationSuccess" class="mmd-member-application__modal" hidden>
+    <div class="mmd-member-application__modal-card" role="dialog" aria-modal="true">
+      <span class="mmd-member-application__modal-icon">✓</span>
+      <p class="mmd-member-application__eyebrow">APPLICATION RECEIVED</p>
+      <h2>ระบบรับข้อมูลแล้ว</h2>
+      <p>เก็บหมายเลขอ้างอิงนี้ไว้สำหรับติดตามสถานะ</p>
+      <div class="mmd-member-application__reference">
+        <small>APPLICATION REFERENCE</small>
+        <strong id="mmdApplicationReference">MMD-APP</strong>
+      </div>
+      <div class="mmd-member-application__modal-actions">
+        <button type="button" id="mmdApplicationGoMembership" class="mmd-member-application__btn mmd-member-application__btn--primary">
+          ไป Membership Page
+        </button>
+        <button type="button" id="mmdApplicationGoDashboard" class="mmd-member-application__btn mmd-member-application__btn--ghost">
+          ไป Member Dashboard
+        </button>
+      </div>
+    </div>
+  </div>
+</section>

--- a/webflow/member/apply/member-apply.js
+++ b/webflow/member/apply/member-apply.js
@@ -1,0 +1,454 @@
+/* MMD PRIVÉ — KENJI MEMBER APPLICATION GATE */
+(() => {
+  "use strict";
+
+  const root = document.getElementById("mmd-member-application");
+  if (!root) return;
+
+  const form = root.querySelector("#mmdMemberApplicationForm");
+  const panels = [...root.querySelectorAll("[data-panel]")];
+  const stepButtons = [...root.querySelectorAll("[data-step-jump]")];
+  const backBtn = root.querySelector("#mmdApplicationBack");
+  const nextBtn = root.querySelector("#mmdApplicationNext");
+  const submitBtn = root.querySelector("#mmdApplicationSubmit");
+  const progressBar = root.querySelector("#mmdApplicationProgressBar");
+  const progressLabel = root.querySelector("#mmdApplicationProgressLabel");
+  const draftState = root.querySelector("#mmdApplicationDraftState");
+  const stateEl = root.querySelector("#mmdApplicationState");
+  const reviewEl = root.querySelector("#mmdApplicationReview");
+  const successModal = root.querySelector("#mmdApplicationSuccess");
+  const referenceEl = root.querySelector("#mmdApplicationReference");
+  const queryBadges = root.querySelector("#mmdApplicationQueryBadges");
+
+  const API_BASE = (root.dataset.apiBase || window.location.origin).replace(/\/$/, "");
+  const SUBMIT_PATH = root.dataset.submitPath || "/v1/member/applications";
+  const DASHBOARD_URL = root.dataset.dashboardUrl || "/member/dashboard";
+  const MEMBERSHIP_URL = root.dataset.membershipUrl || "/member/membership";
+  const HELP_URL = root.dataset.helpUrl || "https://t.me/mmdapply";
+
+  const DRAFT_KEY = "mmd_member_application_draft_v1";
+  const params = new URLSearchParams(window.location.search);
+
+  let currentStep = 0;
+  let saveTimer = null;
+  let applicationReference = "";
+
+  const queryMap = {
+    t: "#mmdApplicationToken",
+    code: "#mmdApplicationCode",
+    promo: "#mmdApplicationPromo"
+  };
+
+  Object.entries(queryMap).forEach(([name, selector]) => {
+    const value = params.get(name) || "";
+    const input = root.querySelector(selector);
+    if (input) input.value = value;
+    if (value) {
+      const badge = document.createElement("span");
+      badge.textContent = `${name.toUpperCase()}: ${value}`;
+      queryBadges.appendChild(badge);
+    }
+  });
+
+  root.querySelector("#mmdApplicationMembershipLink").href = appendParams(MEMBERSHIP_URL);
+  root.querySelector("#mmdApplicationDashboardLink").href = appendParams(DASHBOARD_URL);
+  root.querySelector("#mmdApplicationHelpLink").href = HELP_URL;
+
+  function appendParams(url) {
+    const target = new URL(url, window.location.origin);
+    ["t", "code", "promo"].forEach(name => {
+      const value = params.get(name);
+      if (value) target.searchParams.set(name, value);
+    });
+    return target.toString();
+  }
+
+  function setState(message = "", type = "") {
+    stateEl.textContent = message;
+    stateEl.className = "mmd-member-application__state";
+    if (type) stateEl.classList.add(`is-${type}`);
+  }
+
+  function showStep(index, scroll = true) {
+    currentStep = Math.max(0, Math.min(index, panels.length - 1));
+
+    panels.forEach((panel, i) => panel.classList.toggle("is-active", i === currentStep));
+    stepButtons.forEach((button, i) => button.classList.toggle("is-active", i === currentStep));
+
+    const progress = ((currentStep + 1) / panels.length) * 100;
+    progressBar.style.width = `${progress}%`;
+    progressLabel.textContent = `ขั้นตอน ${currentStep + 1} จาก ${panels.length}`;
+
+    backBtn.hidden = currentStep === 0;
+    nextBtn.hidden = currentStep === panels.length - 1;
+    submitBtn.hidden = currentStep !== panels.length - 1;
+
+    if (currentStep === panels.length - 1) buildReview();
+    setState("");
+
+    if (scroll) {
+      root.querySelector(".mmd-member-application__wizard-shell")?.scrollIntoView({
+        behavior: "smooth",
+        block: "start"
+      });
+    }
+  }
+
+  function getFieldLabel(field) {
+    return field.closest("label")?.querySelector(":scope > span")?.textContent?.replace("*", "").trim()
+      || field.name
+      || "ข้อมูล";
+  }
+
+  function setFieldError(field, message = "") {
+    field.classList.toggle("is-invalid", Boolean(message));
+    const error = field.closest("label")?.querySelector(".mmd-member-application__error");
+    if (error) error.textContent = message;
+  }
+
+  function validateField(field) {
+    setFieldError(field, "");
+
+    if (field.disabled || field.type === "hidden") return true;
+    if (!field.required) return true;
+
+    if (!String(field.value || "").trim()) {
+      setFieldError(field, `กรุณากรอก${getFieldLabel(field)}`);
+      return false;
+    }
+
+    if (field.type === "email" && field.value) {
+      const valid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(field.value);
+      if (!valid) {
+        setFieldError(field, "กรุณาตรวจสอบรูปแบบอีเมล");
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  function validateGroup(name) {
+    const fields = [...form.querySelectorAll(`[name="${name}"]`)];
+    const valid = fields.some(field => field.checked);
+    const error = form.querySelector(`[data-group-error="${name}"]`);
+    if (error) error.textContent = valid ? "" : "กรุณาเลือกอย่างน้อย 1 รายการ";
+    return valid;
+  }
+
+  function validateStep(index) {
+    let valid = true;
+    const panel = panels[index];
+
+    [...panel.querySelectorAll("input, textarea")].forEach(field => {
+      if (["radio", "checkbox"].includes(field.type)) return;
+      if (!validateField(field)) valid = false;
+    });
+
+    if (index === 1) {
+      if (!validateGroup("primary_channel")) valid = false;
+      const channel = form.elements.primary_channel?.value;
+      const channelInputMap = {
+        line: form.elements.line_contact,
+        telegram: form.elements.telegram_username,
+        email: form.elements.email
+      };
+      const activeField = channelInputMap[channel];
+      if (activeField) {
+        activeField.required = true;
+        if (!validateField(activeField)) valid = false;
+      }
+    }
+
+    if (index === 2 && !validateGroup("application_intent")) valid = false;
+    if (index === 3) {
+      if (!validateGroup("languages")) valid = false;
+      if (!validateGroup("interests")) valid = false;
+    }
+
+    if (index === 4) {
+      const consentAccuracy = form.elements.consent_accuracy?.checked;
+      const consentPrivacy = form.elements.consent_privacy?.checked;
+      if (!consentAccuracy || !consentPrivacy) {
+        valid = false;
+        setState("กรุณายืนยันข้อมูลและนโยบายความเป็นส่วนตัวก่อนส่ง", "error");
+      }
+    }
+
+    if (!valid && index !== 4) {
+      setState("ยังมีข้อมูลที่ต้องตรวจสอบในขั้นตอนนี้", "error");
+    }
+
+    return valid;
+  }
+
+  function selectedValues(name) {
+    return [...form.querySelectorAll(`[name="${name}"]:checked`)].map(field => field.value);
+  }
+
+  function serializeForm() {
+    const data = new FormData(form);
+    const payload = {};
+
+    for (const [key, value] of data.entries()) {
+      if (["languages", "interests"].includes(key)) continue;
+      payload[key] = typeof value === "string" ? value.trim() : value;
+    }
+
+    payload.languages = selectedValues("languages");
+    payload.interests = selectedValues("interests");
+    payload.consent_accuracy = Boolean(form.elements.consent_accuracy?.checked);
+    payload.consent_privacy = Boolean(form.elements.consent_privacy?.checked);
+    payload.page_url = window.location.href;
+    payload.submitted_at = new Date().toISOString();
+
+    return payload;
+  }
+
+  function saveDraft() {
+    try {
+      const draft = {
+        version: 1,
+        updated_at: new Date().toISOString(),
+        step: currentStep,
+        values: serializeForm()
+      };
+      localStorage.setItem(DRAFT_KEY, JSON.stringify(draft));
+      draftState.textContent = "Draft saved";
+    } catch (error) {
+      console.warn("[MMD Member Application] Draft save failed", error);
+      draftState.textContent = "Draft unavailable";
+    }
+  }
+
+  function scheduleDraftSave() {
+    draftState.textContent = "Saving...";
+    clearTimeout(saveTimer);
+    saveTimer = setTimeout(saveDraft, 450);
+  }
+
+  function restoreDraft() {
+    try {
+      const raw = localStorage.getItem(DRAFT_KEY);
+      if (!raw) return;
+
+      const draft = JSON.parse(raw);
+      if (!draft?.values) return;
+
+      Object.entries(draft.values).forEach(([name, value]) => {
+        if (["t", "code", "promo", "source", "route", "submitted_at", "page_url"].includes(name)) return;
+
+        const fields = [...form.querySelectorAll(`[name="${name}"]`)];
+        if (!fields.length) return;
+
+        if (Array.isArray(value)) {
+          fields.forEach(field => {
+            if (field.type === "checkbox") field.checked = value.includes(field.value);
+          });
+          return;
+        }
+
+        const field = fields[0];
+        if (field.type === "radio") {
+          fields.forEach(item => item.checked = item.value === value);
+        } else if (field.type === "checkbox") {
+          field.checked = Boolean(value);
+        } else {
+          field.value = value ?? "";
+        }
+      });
+
+      currentStep = Number.isInteger(draft.step) ? Math.min(draft.step, panels.length - 1) : 0;
+      draftState.textContent = "Draft restored";
+      updateChannelFields();
+      updateCounters();
+    } catch (error) {
+      console.warn("[MMD Member Application] Draft restore failed", error);
+    }
+  }
+
+  function clearDraft() {
+    try {
+      localStorage.removeItem(DRAFT_KEY);
+      draftState.textContent = "Draft cleared";
+    } catch (_) {}
+  }
+
+  function updateChannelFields() {
+    const selected = form.elements.primary_channel?.value || "";
+    root.querySelectorAll("[data-channel-field]").forEach(wrapper => {
+      const active = wrapper.dataset.channelField === selected;
+      wrapper.hidden = !active;
+      const input = wrapper.querySelector("input");
+      if (input) input.required = active;
+    });
+  }
+
+  function updateCounters() {
+    root.querySelectorAll("textarea[maxlength]").forEach(textarea => {
+      const counter = root.querySelector(`[data-count-for="${textarea.name}"]`);
+      if (counter) counter.textContent = String(textarea.value.length);
+    });
+  }
+
+  function safeText(value) {
+    const text = Array.isArray(value) ? value.join(", ") : String(value || "").trim();
+    return text || "ไม่ได้ระบุ";
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function buildReview() {
+    const payload = serializeForm();
+    const rows = [
+      ["ชื่อที่ใช้เรียก", payload.preferred_name],
+      ["ชื่อจริง", payload.full_name],
+      ["วันเกิด", payload.birth_date],
+      ["สัญชาติ", payload.nationality],
+      ["ช่องทางหลัก", payload.primary_channel],
+      ["LINE", payload.line_contact],
+      ["Telegram", payload.telegram_username],
+      ["Email", payload.email],
+      ["โทรศัพท์", payload.phone],
+      ["จุดประสงค์", payload.application_intent],
+      ["ภาษา", payload.languages],
+      ["ความสนใจ", payload.interests],
+      ["โค้ด", payload.code],
+      ["โปรโมชั่น", payload.promo]
+    ];
+
+    reviewEl.innerHTML = rows.map(([label, value]) => `
+      <div class="mmd-member-application__review-row">
+        <span>${escapeHtml(label)}</span>
+        <b>${escapeHtml(safeText(value))}</b>
+      </div>
+    `).join("");
+  }
+
+  function makeReference() {
+    const now = new Date();
+    const stamp = [
+      now.getFullYear().toString().slice(-2),
+      String(now.getMonth() + 1).padStart(2, "0"),
+      String(now.getDate()).padStart(2, "0"),
+      String(now.getHours()).padStart(2, "0"),
+      String(now.getMinutes()).padStart(2, "0")
+    ].join("");
+    return `MMD-MA-${stamp}-${Math.random().toString(36).slice(2, 6).toUpperCase()}`;
+  }
+
+  async function submitApplication() {
+    if (!validateStep(currentStep)) return;
+
+    submitBtn.disabled = true;
+    backBtn.disabled = true;
+    setState("กำลังส่งข้อมูลไปยัง MMD Worker...");
+
+    try {
+      const response = await fetch(`${API_BASE}${SUBMIT_PATH}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Accept": "application/json"
+        },
+        credentials: "include",
+        body: JSON.stringify(serializeForm())
+      });
+
+      let result = {};
+      const contentType = response.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        result = await response.json();
+      }
+
+      if (!response.ok) {
+        throw new Error(result?.message || result?.error || `Worker returned ${response.status}`);
+      }
+
+      applicationReference =
+        result.application_reference ||
+        result.reference ||
+        result.application_id ||
+        result.id ||
+        makeReference();
+
+      referenceEl.textContent = applicationReference;
+      clearDraft();
+      successModal.hidden = false;
+      document.body.style.overflow = "hidden";
+      setState("ส่งข้อมูลเรียบร้อย", "success");
+    } catch (error) {
+      console.error("[MMD Member Application]", error);
+      setState(
+        error?.message ||
+        "ยังส่งข้อมูลไม่ได้ กรุณาตรวจสอบ Worker endpoint แล้วลองอีกครั้ง",
+        "error"
+      );
+    } finally {
+      submitBtn.disabled = false;
+      backBtn.disabled = false;
+    }
+  }
+
+  nextBtn.addEventListener("click", () => {
+    if (validateStep(currentStep)) {
+      showStep(currentStep + 1);
+      scheduleDraftSave();
+    }
+  });
+
+  backBtn.addEventListener("click", () => {
+    showStep(currentStep - 1);
+    scheduleDraftSave();
+  });
+
+  stepButtons.forEach(button => {
+    button.addEventListener("click", () => {
+      const target = Number(button.dataset.stepJump);
+      if (target <= currentStep) showStep(target);
+    });
+  });
+
+  form.addEventListener("submit", event => {
+    event.preventDefault();
+    submitApplication();
+  });
+
+  form.addEventListener("input", event => {
+    const field = event.target;
+    if (field.matches("input, textarea") && !["checkbox", "radio"].includes(field.type)) {
+      validateField(field);
+    }
+    updateCounters();
+    scheduleDraftSave();
+  });
+
+  form.addEventListener("change", event => {
+    if (event.target.name === "primary_channel") {
+      updateChannelFields();
+      validateGroup("primary_channel");
+    }
+    if (event.target.name === "application_intent") validateGroup("application_intent");
+    if (event.target.name === "languages") validateGroup("languages");
+    if (event.target.name === "interests") validateGroup("interests");
+    scheduleDraftSave();
+  });
+
+  root.querySelector("#mmdApplicationGoMembership").addEventListener("click", () => {
+    window.location.href = appendParams(MEMBERSHIP_URL);
+  });
+
+  root.querySelector("#mmdApplicationGoDashboard").addEventListener("click", () => {
+    window.location.href = appendParams(DASHBOARD_URL);
+  });
+
+  restoreDraft();
+  showStep(currentStep, false);
+})();


### PR DESCRIPTION
## Summary

- adds the full mobile-first Kenji Member Application Gate for Webflow
- adds five-step wizard, local draft restore, validation, review, query preservation and Worker submission contract
- adds resilient application OS layer with offline queue, retry, duplicate guard, idempotency header and health status
- adds JSON request contract and integration documentation
- changes `/member/apply` and `/member/apply/` from the generic member recovery shell to Webflow pass-through
- preserves `t`, `code`, `promo` and any additional query parameters
- adds route tests confirming no redirect and no temporary recovery response

## Production effect

After merge and front-gate deployment, `https://www.mmdbkk.com/member/apply` will no longer render the live `Member Page` recovery shell. It will pass through to the published Webflow page.

## Remaining backend dependency

`POST https://sigil.mmdbkk.com/v1/member/applications` must exist for successful persistence.