### PR TITLE
fix(telegram): add HYPE preview customer action buttons

### DIFF
--- a/telegram-worker/lib/hype-preview.js
+++ b/telegram-worker/lib/hype-preview.js
@@ -271,6 +271,10 @@ function alreadyIssuedText(code) {
 
 function signupUrl(code, campaignId, env) {
   const base = str(env.HYPE_PREVIEW_SIGNUP_URL || "https://mmdbkk.com/trust/inme");
+  return withPreviewQuery(base, code, campaignId);
+}
+
+function withPreviewQuery(base, code, campaignId) {
   const url = new URL(base);
   url.searchParams.set("promo", code);
   url.searchParams.set("src", "telegram_preview");
@@ -278,12 +282,28 @@ function signupUrl(code, campaignId, env) {
   return url.toString();
 }
 
-function inlineButtons(code, campaignId, env) {
+function hallUrl(code, campaignId, env) {
+  return withPreviewQuery(str(env.HYPE_PREVIEW_HALL_URL || "https://mmdbkk.com/hall"), code, campaignId);
+}
+
+function bookingUrl(code, campaignId, env) {
+  return withPreviewQuery(str(env.HYPE_PREVIEW_BOOKING_URL || "https://mmdbkk.com/sigil/booking"), code, campaignId);
+}
+
+function benefitsUrl(code, campaignId, env) {
+  return withPreviewQuery(str(env.HYPE_PREVIEW_PACKAGES_URL || "https://mmdbkk.com/member/membership"), code, campaignId);
+}
+
+export function inlineButtons(code, campaignId, env) {
   return {
     inline_keyboard: [
-      [{ text: "สมัครสมาชิกใหม่", url: signupUrl(code, campaignId, env) }],
-      [{ text: "ดูแพ็กเกจ", url: str(env.HYPE_PREVIEW_PACKAGES_URL || "https://mmdbkk.com/member/membership") }],
-      [{ text: "กลับไป Preview Channel", url: str(env.HYPE_PREVIEW_CHANNEL_URL || "https://t.me/MMDPriveTH") }],
+      [
+        { text: "Preview Models", url: hallUrl(code, campaignId, env) },
+        { text: "Booking", url: bookingUrl(code, campaignId, env) },
+      ],
+      [{ text: "Apply for Membership", url: signupUrl(code, campaignId, env) }],
+      [{ text: "Our Benefits", url: benefitsUrl(code, campaignId, env) }],
+      [{ text: "Back to Preview Channel", url: str(env.HYPE_PREVIEW_CHANNEL_URL || "https://t.me/MMDPriveTH") }],
     ],
   };
 }

--- a/telegram-worker/test/hype-preview-buttons.test.mjs
+++ b/telegram-worker/test/hype-preview-buttons.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+import { inlineButtons } from "../lib/hype-preview.js";
+
+const CODE = "123456";
+const CAMPAIGN = "preview_pride_jun2026";
+
+function flatButtons(markup) {
+  return markup.inline_keyboard.flat();
+}
+
+function byLabel(markup, label) {
+  return flatButtons(markup).find((button) => button.text === label);
+}
+
+function assertPreviewParams(rawUrl) {
+  const url = new URL(rawUrl);
+  assert.equal(url.searchParams.get("promo"), CODE);
+  assert.equal(url.searchParams.get("src"), "telegram_preview");
+  assert.equal(url.searchParams.get("campaign"), CAMPAIGN);
+}
+
+describe("HYPE preview inline buttons", () => {
+  it("renders exactly the customer action labels in the expected layout", () => {
+    const markup = inlineButtons(CODE, CAMPAIGN, {});
+    const labels = flatButtons(markup).map((button) => button.text);
+
+    assert.deepEqual(labels, [
+      "Preview Models",
+      "Booking",
+      "Apply for Membership",
+      "Our Benefits",
+      "Back to Preview Channel",
+    ]);
+    assert.equal(markup.inline_keyboard.length, 4);
+    assert.equal(markup.inline_keyboard[0].length, 2);
+  });
+
+  it("preserves promo, src, and campaign on customer action URLs", () => {
+    const markup = inlineButtons(CODE, CAMPAIGN, {});
+
+    assertPreviewParams(byLabel(markup, "Preview Models").url);
+    assertPreviewParams(byLabel(markup, "Booking").url);
+    assertPreviewParams(byLabel(markup, "Apply for Membership").url);
+    assertPreviewParams(byLabel(markup, "Our Benefits").url);
+
+    assert.equal(new URL(byLabel(markup, "Preview Models").url).pathname, "/hall");
+    assert.equal(new URL(byLabel(markup, "Booking").url).pathname, "/sigil/booking");
+    assert.equal(new URL(byLabel(markup, "Apply for Membership").url).pathname, "/trust/inme");
+    assert.equal(new URL(byLabel(markup, "Our Benefits").url).pathname, "/member/membership");
+    assert.equal(byLabel(markup, "Back to Preview Channel").url, "https://t.me/MMDPriveTH");
+  });
+
+  it("honors safe URL env overrides without using legacy benefits URL", () => {
+    const markup = inlineButtons(CODE, CAMPAIGN, {
+      HYPE_PREVIEW_HALL_URL: "https://example.com/custom-hall",
+      HYPE_PREVIEW_BOOKING_URL: "https://example.com/custom-booking",
+      HYPE_PREVIEW_SIGNUP_URL: "https://example.com/custom-signup",
+      HYPE_PREVIEW_PACKAGES_URL: "https://example.com/member/membership",
+      HYPE_PREVIEW_CHANNEL_URL: "https://t.me/customPreview",
+    });
+
+    assert.equal(new URL(byLabel(markup, "Preview Models").url).pathname, "/custom-hall");
+    assert.equal(new URL(byLabel(markup, "Booking").url).pathname, "/custom-booking");
+    assert.equal(new URL(byLabel(markup, "Apply for Membership").url).pathname, "/custom-signup");
+    assert.equal(new URL(byLabel(markup, "Our Benefits").url).pathname, "/member/membership");
+    assert.doesNotMatch(byLabel(markup, "Our Benefits").url, /\/membership\/benefits/);
+    assert.equal(byLabel(markup, "Back to Preview Channel").url, "https://t.me/customPreview");
+  });
+
+  it("keeps customer-facing HYPE copy away from forbidden package claims", () => {
+    const source = readFileSync(new URL("../lib/hype-preview.js", import.meta.url), "utf8");
+
+    assert.match(source, /Standard ได้ 150 Points/);
+    assert.match(source, /Premium ได้ 250 Points/);
+    assert.doesNotMatch(source, /SVIP/i);
+    assert.doesNotMatch(source, /Black Card รับ 350 Points/i);
+    assert.doesNotMatch(source, /ทีมงาน|ทีม/);
+  });
+});


### PR DESCRIPTION
## Summary
Adds the locked 5-button Telegram Preview action keyboard after HYPE code issue/reissue.

Buttons:
- Preview Models -> /hall
- Booking -> /sigil/booking
- Apply for Membership -> existing signupUrl(...)
- Our Benefits -> /member/membership
- Back to Preview Channel -> env channel URL fallback

## MMD guardrails
- HYPE stays Telegram Preview only
- LINE central / Hi Per / Per AI untouched
- chat-worker untouched
- payment/membership verification untouched
- points crediting untouched
- Black Card approval untouched
- SVIP untouched
- booking confirmation untouched
- SIGIL route ownership untouched
- secrets untouched
- micro-QA intentionally skipped to avoid normal text routing changes

## Verification
- node --check telegram-worker/lib/hype-preview.js
- node --test telegram-worker/test/*.test.mjs