### PR TITLE
feat(admin): enforce authoritative create-session model access

### DIFF
--- a/admin-worker/create-session-access.test.mjs
+++ b/admin-worker/create-session-access.test.mjs
@@ -26,6 +26,8 @@ const tables = {
     member("recMemBlack000001", "client_black", "mem_black", "black@example.test"),
     member("recMemSvip0000001", "client_svip", "mem_svip", "svip@example.test"),
     member("recMemExpired0001", "client_expired", "mem_expired", "expired@example.test"),
+    member("recMemInactive01", "client_inactive", "mem_inactive", "inactive@example.test"),
+    member("recMemGuest00001", "client_guest", "mem_guest", "guest@example.test"),
   ],
   member_packages: [
     pkg("recPkgStandard001", "standard@example.test", "Standard", future),
@@ -34,6 +36,8 @@ const tables = {
     pkg("recPkgBlack00001", "black@example.test", "Black Card", future),
     pkg("recPkgSvip000001", "svip@example.test", "SVIP", future),
     pkg("recPkgExpired001", "expired@example.test", "Black Card", past),
+    pkg("recPkgInactive01", "inactive@example.test", "Black Card", future, "inactive"),
+    pkg("recPkgGuest0001", "guest@example.test", "Guest", future),
   ],
   models: [
     model("recStandardModel01", "Standard Straight", "standard", "straight"),
@@ -69,13 +73,13 @@ function member(id, clientId, memberId, email) {
   };
 }
 
-function pkg(id, email, packageCode, endDate) {
+function pkg(id, email, packageCode, endDate, status = "active") {
   return {
     id,
     fields: {
       member_email: email,
       package_code: packageCode,
-      status: "active",
+      status,
       end_date: endDate,
     },
   };
@@ -218,6 +222,12 @@ assert.deepEqual(gaySearch.items.map((item) => item.model_name), ["VIP Gay"]);
 
 const expiredSearch = await searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=straight&selected_access_folder=exclusive&client_id=client_expired&allowed_model_folders=exclusive&normalized_membership_tier=blackcard"));
 assert.deepEqual(expiredSearch.items, []);
+
+const inactiveSearch = await searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=straight&selected_access_folder=exclusive&client_id=client_inactive&allowed_model_folders=exclusive&normalized_membership_tier=blackcard"));
+assert.deepEqual(inactiveSearch.items, []);
+
+const guestSearch = await searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=straight&selected_access_folder=standard&client_id=client_guest&allowed_model_folders=standard&normalized_membership_tier=standard"));
+assert.deepEqual(guestSearch.items, []);
 
 await rejectsWithCode(
   searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=straight&selected_access_folder=standard&client_id=client_missing")),

--- a/admin-worker/create-session-access.test.mjs
+++ b/admin-worker/create-session-access.test.mjs
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import worker, {
+  CreateSessionAccessError,
+  enforcePrivateCreateAccess,
+  resolveAuthoritativeMemberAccess,
+  searchCreateSessionModels,
+} from "./src/index.js";
+
+const env = {
+  AIRTABLE_API_KEY: "test",
+  AIRTABLE_BASE_ID: "appTest",
+  ADMIN_BEARER: "admin-test",
+  AIRTABLE_TABLE_MEMBERS: "members",
+  AIRTABLE_TABLE_MEMBER_PACKAGES: "member_packages",
+  AIRTABLE_TABLE_MODELS: "models",
+};
+
+const future = "2099-01-01";
+const past = "2000-01-01";
+
+const tables = {
+  members: [
+    member("recMemStandard0001", "client_standard", "mem_standard", "standard@example.test"),
+    member("recMemPremium0001", "client_premium", "mem_premium", "premium@example.test"),
+    member("recMemVip00000001", "client_vip", "mem_vip", "vip@example.test"),
+    member("recMemBlack000001", "client_black", "mem_black", "black@example.test"),
+    member("recMemSvip0000001", "client_svip", "mem_svip", "svip@example.test"),
+    member("recMemExpired0001", "client_expired", "mem_expired", "expired@example.test"),
+  ],
+  member_packages: [
+    pkg("recPkgStandard001", "standard@example.test", "Standard", future),
+    pkg("recPkgPremium001", "premium@example.test", "Premium", future),
+    pkg("recPkgVip0000001", "vip@example.test", "VIP", future),
+    pkg("recPkgBlack00001", "black@example.test", "Black Card", future),
+    pkg("recPkgSvip000001", "svip@example.test", "SVIP", future),
+    pkg("recPkgExpired001", "expired@example.test", "Black Card", past),
+  ],
+  models: [
+    model("recStandardModel01", "Standard Straight", "standard", "straight"),
+    model("recPremiumModel001", "Premium Both", "premium", "both"),
+    model("recVipModel000001", "VIP Gay", "vip", "gay"),
+    model("recExclusiveModel1", "Exclusive Both", "exclusive", "both"),
+    {
+      id: "recPublicTravel001",
+      fields: {
+        display_name: "Public Travel",
+        booking_visibility: "public",
+        service_layer: "Travel",
+        customer_lane: "both",
+        status: "active",
+        availability_status: "available",
+        available_now: true,
+      },
+    },
+  ],
+};
+
+function member(id, clientId, memberId, email) {
+  return {
+    id,
+    fields: {
+      client_id: clientId,
+      member_id: memberId,
+      email,
+      "Contact Email": email,
+      line_record_id: `${clientId}_line_record`,
+      line_user_id: `${clientId}_line_user`,
+    },
+  };
+}
+
+function pkg(id, email, packageCode, endDate) {
+  return {
+    id,
+    fields: {
+      member_email: email,
+      package_code: packageCode,
+      status: "active",
+      end_date: endDate,
+    },
+  };
+}
+
+function model(id, name, accessFolder, lane) {
+  return {
+    id,
+    fields: {
+      display_name: name,
+      model_lookup_key: id,
+      booking_visibility: "private",
+      access_folder: accessFolder,
+      customer_lane: lane,
+      status: "active",
+      availability_status: "available",
+      available_now: true,
+      telegram_username: `@${name.toLowerCase().replace(/[^a-z0-9]+/g, "_")}`,
+    },
+  };
+}
+
+function installAirtableMock() {
+  const calls = [];
+  globalThis.fetch = async (input) => {
+    const url = new URL(String(input));
+    calls.push(url);
+    const parts = url.pathname.split("/").filter(Boolean);
+    const table = decodeURIComponent(parts[2] || "");
+    const id = parts[3] ? decodeURIComponent(parts[3]) : "";
+    const records = tables[table] || [];
+
+    if (id) {
+      const record = records.find((item) => item.id === id);
+      return jsonResponse(record || { error: "not_found" }, record ? 200 : 404);
+    }
+
+    const formula = url.searchParams.get("filterByFormula") || "";
+    const filtered = formula ? records.filter((record) => formulaMatches(record.fields, formula)) : records;
+    return jsonResponse({ records: filtered.slice(0, Number(url.searchParams.get("pageSize") || 100)) });
+  };
+  return calls;
+}
+
+function formulaMatches(fields, formula) {
+  const value = (formula.match(/=\s*"([^"]*)"/) || [])[1] || "";
+  const field = (formula.match(/\{([^}]+)\}/) || [])[1] || "";
+  if (!field) return true;
+  const actual = String(fields[field] ?? "");
+  return /^LOWER\(/.test(formula) ? actual.toLowerCase() === value.toLowerCase() : actual === value;
+}
+
+function jsonResponse(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function privateBody(clientId, folder, modelId, overrides = {}) {
+  return {
+    client_lineage: {
+      client_id: clientId,
+      membership_status: overrides.forgedMembershipStatus || "expired",
+      normalized_membership_tier: overrides.forgedTier || "blackcard",
+    },
+    line_identity: {},
+    work: {
+      job_visibility: "private",
+      model_folder: folder,
+    },
+    private_access: {
+      eligibility_checked: true,
+      eligibility_result: "allowed",
+      private_access_level: overrides.forgedAccessLevel || "black_card",
+      allowed_private_folders: overrides.forgedFolders || ["standard", "premium", "vip", "exclusive"],
+      selected_orientation: overrides.orientation || "straight",
+      selected_private_folder: folder,
+    },
+    model: {
+      model_id: modelId,
+      selected_orientation: overrides.orientation || "straight",
+    },
+    telegram_gate: {
+      customer_telegram_status: overrides.customerTelegram || "linked",
+      model_telegram_status: overrides.modelTelegram || "verified",
+    },
+  };
+}
+
+async function rejectsWithCode(promise, code) {
+  await assert.rejects(
+    promise,
+    (error) => error instanceof CreateSessionAccessError && error.code === code,
+  );
+}
+
+installAirtableMock();
+
+assert.deepEqual((await resolveAuthoritativeMemberAccess(env, { client_id: "client_standard" })).allowed_folders, ["standard"]);
+assert.deepEqual((await resolveAuthoritativeMemberAccess(env, { client_id: "client_premium" })).allowed_folders, ["standard", "premium"]);
+assert.deepEqual((await resolveAuthoritativeMemberAccess(env, { client_id: "client_vip" })).allowed_folders, ["standard", "premium", "vip"]);
+assert.deepEqual((await resolveAuthoritativeMemberAccess(env, { client_id: "client_black" })).allowed_folders, ["standard", "premium", "vip", "exclusive"]);
+const svip = await resolveAuthoritativeMemberAccess(env, { client_id: "client_svip" });
+assert.equal(svip.tier, "black_card");
+assert.deepEqual(svip.allowed_folders, ["standard", "premium", "vip", "exclusive"]);
+
+await rejectsWithCode(
+  enforcePrivateCreateAccess(env, privateBody("client_standard", "premium", "recPremiumModel001", { forgedAccessLevel: "black_card" })),
+  "private_folder_not_allowed",
+);
+await rejectsWithCode(
+  enforcePrivateCreateAccess(env, privateBody("client_expired", "standard", "recStandardModel01", { forgedMembershipStatus: "active" })),
+  "private_eligibility_blocked",
+);
+await rejectsWithCode(
+  enforcePrivateCreateAccess(env, privateBody("client_standard", "exclusive", "recExclusiveModel1", { forgedTier: "blackcard" })),
+  "private_folder_not_allowed",
+);
+await rejectsWithCode(
+  enforcePrivateCreateAccess(env, privateBody("client_standard", "exclusive", "recExclusiveModel1", { forgedFolders: ["exclusive"] })),
+  "private_folder_not_allowed",
+);
+await rejectsWithCode(
+  enforcePrivateCreateAccess(env, privateBody("client_vip", "vip", "recExclusiveModel1")),
+  "private_model_folder_denied",
+);
+
+const standardSearch = await searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=straight&selected_access_folder=standard&client_id=client_standard"));
+assert.deepEqual(standardSearch.items.map((item) => item.model_name), ["Standard Straight"]);
+
+const premiumSearch = await searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=straight&selected_access_folder=premium&client_id=client_premium"));
+assert.deepEqual(premiumSearch.items.map((item) => item.model_name), ["Premium Both"]);
+
+const straightSearch = await searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=straight&selected_access_folder=premium&client_id=client_black"));
+assert.deepEqual(straightSearch.items.map((item) => item.model_name), ["Premium Both"]);
+
+const gaySearch = await searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=gay&selected_access_folder=vip&client_id=client_black"));
+assert.deepEqual(gaySearch.items.map((item) => item.model_name), ["VIP Gay"]);
+
+const expiredSearch = await searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=straight&selected_access_folder=exclusive&client_id=client_expired&allowed_model_folders=exclusive&normalized_membership_tier=blackcard"));
+assert.deepEqual(expiredSearch.items, []);
+
+await rejectsWithCode(
+  searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=straight&selected_access_folder=standard&client_id=client_missing")),
+  "AUTHORITATIVE_MEMBER_NOT_FOUND",
+);
+
+const routeRes = await worker.fetch(
+  new Request("https://worker/v1/admin/models/search?work_type=private&booking_visibility=private&customer_lane=straight&selected_access_folder=standard&client_id=client_standard", {
+    headers: { Authorization: "Bearer admin-test" },
+  }),
+  env,
+);
+assert.equal(routeRes.status, 200);
+assert.equal((await routeRes.json()).ok, true);
+
+const publicSearch = await searchCreateSessionModels(env, new URL("https://worker/v1/admin/models/search?work_type=public&selected_access_folder=travel"));
+assert.deepEqual(publicSearch.items.map((item) => item.model_name), ["Public Travel"]);
+
+await rejectsWithCode(
+  enforcePrivateCreateAccess(env, privateBody("client_black", "exclusive", "recExclusiveModel1", { modelTelegram: "missing" })),
+  "private_telegram_gate_required",
+);
+
+assert.match(await import("node:fs/promises").then((fs) => fs.readFile(new URL("../../assets/sigil/create-session.js", import.meta.url), "utf8")), /saveDraft\(\)/);
+
+console.log("admin create-session access tests passed");

--- a/admin-worker/index.js
+++ b/admin-worker/index.js
@@ -516,6 +516,22 @@ export default {
       }
 
       // ----------------------------------------------------
+      // Models search (create-session booking search)
+      // Entitlement-enforced + sanitized; /v1/admin/models/list
+      // stays the raw admin inventory endpoint.
+      // ----------------------------------------------------
+      if (method === "GET" && path === "/v1/admin/models/search") {
+        try {
+          return withCors(json(await searchCreateSessionModels(env, url)), cors);
+        } catch (e) {
+          if (e instanceof CreateSessionAccessError) {
+            return withCors(json({ ok: false, error: { code: e.code, message: e.message } }, e.status), cors);
+          }
+          return withCors(json({ ok: false, error: String(e?.message || e || "models_search_failed") }, 500), cors);
+        }
+      }
+
+      // ----------------------------------------------------
       // Models source resolver
       // ----------------------------------------------------
       if (method === "GET" && path === "/v1/admin/models/resolve-source") {
@@ -589,7 +605,11 @@ export default {
             cors
           );
         } catch (e) {
-          return withCors(json({ ok: false, error: String(e?.message || e || "job_create_failed") }, 500), cors);
+          if (e instanceof CreateSessionAccessError) {
+            return withCors(json({ ok: false, error: { code: e.code, message: e.message } }, e.status), cors);
+          }
+          const error = String(e?.message || e || "job_create_failed");
+          return withCors(json({ ok: false, error }, error.startsWith("private_") ? 403 : 500), cors);
         }
       }
 
@@ -2130,22 +2150,412 @@ export {
 };
 
 /* =========================
+   Create Session Private Access
+   Authoritative membership + model gate. Frontend membership fields
+   (private_access.*, client_lineage.tier / membership_status,
+   allowed_private_folders) are advisory UX data only and never grant access.
+========================= */
+const PRIVATE_ACCESS_FOLDERS = {
+  standard: ["standard"],
+  premium: ["standard", "premium"],
+  vip: ["standard", "premium", "vip"],
+  black_card: ["standard", "premium", "vip", "exclusive"],
+};
+const PRIVATE_ACCESS_TIER_RANK = { standard: 1, premium: 2, vip: 3, black_card: 4 };
+const CANONICAL_PRIVATE_FOLDERS = new Set(["standard", "premium", "vip", "exclusive"]);
+const PUBLIC_MODEL_FOLDERS = new Set(["travel", "extreme"]);
+const MODEL_BLOCKED_STATUS_TOKENS = new Set(["inactive", "blocked", "suspended", "archived", "disabled", "banned", "off", "retired"]);
+const MODEL_UNAVAILABLE_TOKENS = new Set(["unavailable", "not_available", "paused", "busy", "on_hold", "hold"]);
+
+class CreateSessionAccessError extends Error {
+  constructor(code, message, status = 403) {
+    super(message);
+    this.name = "CreateSessionAccessError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function accessToken(value) {
+  return String(value == null ? "" : value).toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function membershipTierFromText(value) {
+  const token = accessToken(value);
+  if (!token) return "";
+  // legacy SVIP normalizes to Black Card access; check before the "vip" substring
+  if (token.includes("black") || token.includes("svip")) return "black_card";
+  if (token.includes("vip")) return "vip";
+  if (token.includes("premium")) return "premium";
+  if (token.includes("standard") || token.includes("lite")) return "standard";
+  return "";
+}
+
+function normalizeCustomerLane(value) {
+  const token = accessToken(value);
+  if (token === "gay") return "gay";
+  if (token === "straight") return "straight";
+  if (token === "both" || token === "bi" || token === "all") return "both";
+  return "";
+}
+
+function formulaText(value) {
+  return `"${String(value == null ? "" : value).replace(/"/g, '\\"')}"`;
+}
+
+async function airtableListByFormula(env, tableName, filterByFormula, limit = 50) {
+  if (!env.AIRTABLE_API_KEY || !env.AIRTABLE_BASE_ID) return [];
+  const params = new URLSearchParams();
+  params.set("pageSize", String(Math.max(1, Math.min(100, limit))));
+  if (filterByFormula) params.set("filterByFormula", filterByFormula);
+  const r = await airtableFetch(env, `/${encodeURIComponent(tableName)}?${params.toString()}`);
+  if (!r.ok) return [];
+  return (r.data?.records || []).map((rec) => ({ id: rec.id, fields: rec.fields || {}, createdTime: rec.createdTime }));
+}
+
+async function resolveAuthoritativeMemberAccess(env, ids = {}) {
+  const membersTable = env.AIRTABLE_TABLE_MEMBERS || "members";
+  const lookups = [
+    ["client_id", ids.client_id, false],
+    ["member_id", ids.member_id, false],
+    ["Member ID", ids.member_id, false],
+    ["memberstack_id", ids.memberstack_id, false],
+    ["line_record_id", ids.line_record_id, false],
+    ["line_record", ids.line_record_id, false],
+    ["line_user_id", ids.line_user_id, false],
+    ["line_id", ids.line_user_id, false],
+    ["email", ids.member_email, true],
+    ["Contact Email", ids.member_email, true],
+    ["telegram_username", ids.telegram_username, true],
+  ];
+
+  let member = null;
+  for (const [field, value, lower] of lookups) {
+    const raw = str(value);
+    if (!raw) continue;
+    const left = lower ? `LOWER({${field}})` : `{${field}}`;
+    member = await airtableFindOne(env, membersTable, `${left}=${formulaText(lower ? raw.toLowerCase() : raw)}`);
+    if (member) break;
+  }
+  if (!member) return { resolved: false, allowed_folders: [] };
+
+  const memberFields = member.fields || {};
+  const memberEmail = str(memberFields["Contact Email"] || memberFields.member_email || memberFields.email || ids.member_email).toLowerCase();
+
+  // member_packages ledger is the membership source of truth (mirrors auth-worker derivePackageAccess)
+  let best = null;
+  if (memberEmail) {
+    const ledgerTable = env.AIRTABLE_TABLE_MEMBER_PACKAGES || "member_packages";
+    const now = Date.now();
+    const records = await airtableListByFormula(env, ledgerTable, `LOWER({member_email})=${formulaText(memberEmail)}`, 20);
+    for (const record of records) {
+      const f = record.fields || {};
+      if (accessToken(f.status) !== "active") continue;
+      const endAt = Date.parse(str(f.end_date || f.end_at || f.expire_at || f.expires_at));
+      if (!endAt || endAt < now) continue;
+      const tier = membershipTierFromText(f.package_code || f.tier);
+      if (!tier) continue;
+      const rank = PRIVATE_ACCESS_TIER_RANK[tier] || 0;
+      if (!best || rank > best.rank || (rank === best.rank && endAt > best.endAt)) {
+        best = { tier, rank, endAt, package_code: str(f.package_code || f.tier), expire_at: str(f.end_date || f.end_at || f.expire_at || f.expires_at) };
+      }
+    }
+  }
+
+  if (!best) {
+    return {
+      resolved: true,
+      member_record_id: member.id,
+      member_id: str(memberFields.member_id || memberFields["Member ID"]),
+      member_email: memberEmail,
+      membership_status: memberEmail ? "no_active_membership" : "no_ledger_identity",
+      tier: "",
+      allowed_folders: [],
+    };
+  }
+
+  return {
+    resolved: true,
+    member_record_id: member.id,
+    member_id: str(memberFields.member_id || memberFields["Member ID"]),
+    member_email: memberEmail,
+    membership_status: "active",
+    tier: best.tier,
+    package_code: best.package_code,
+    expire_at: best.expire_at,
+    allowed_folders: PRIVATE_ACCESS_FOLDERS[best.tier].slice(),
+  };
+}
+
+function modelAccessProfile(fields = {}) {
+  const rawTags = []
+    .concat(Array.isArray(fields.legacy_tags) ? fields.legacy_tags : String(fields.legacy_tags || "").split(/[,\n]/))
+    .concat(Array.isArray(fields.tags) ? fields.tags : String(fields.tags || "").split(/[,\n]/));
+  const tags = new Set(rawTags.map(accessToken).filter(Boolean));
+
+  const visibilityToken = accessToken(fields.booking_visibility);
+  const salesLayer = accessToken(fields.sales_layer);
+  let bookingVisibility = "";
+  if (visibilityToken === "private" || salesLayer.includes("private")) bookingVisibility = "private";
+  else if (visibilityToken === "public" || salesLayer.includes("public")) bookingVisibility = "public";
+
+  let accessFolder = accessToken(fields.access_folder || fields.model_access_folder || fields.model_folder);
+  if (!CANONICAL_PRIVATE_FOLDERS.has(accessFolder)) {
+    accessFolder = "";
+    const tierSource = accessToken([fields.model_tier, fields.approved_client_visibility, fields.private_tier].filter(Boolean).join(" "));
+    if (tierSource.includes("exclusive") || tierSource.includes("black")) accessFolder = "exclusive";
+    else if (tierSource.includes("vip")) accessFolder = "vip";
+    else if (tierSource.includes("premium")) accessFolder = "premium";
+    else if (tierSource.includes("standard")) accessFolder = "standard";
+  }
+
+  const serviceSource = accessToken([fields.service_layer, fields.job_types, fields.private_tier].filter(Boolean).join(" "));
+  const publicFolders = [];
+  if (serviceSource.includes("travel") || tags.has("travel")) publicFolders.push("travel");
+  if (serviceSource.includes("extreme") || tags.has("extreme")) publicFolders.push("extreme");
+
+  const lane = normalizeCustomerLane(fields.customer_lane || fields.orientation_label || fields.orientation);
+  const statusActive = !MODEL_BLOCKED_STATUS_TOKENS.has(accessToken(fields.status));
+  const availabilityToken = accessToken(fields.availability_status);
+  const availableNow =
+    fields.available_now === true ||
+    ["yes", "true", "1", "available"].includes(accessToken(fields.available_now)) ||
+    ["available", "active", "bookable"].includes(availabilityToken);
+  const explicitlyUnavailable =
+    fields.available_now === false ||
+    accessToken(fields.available_now) === "no" ||
+    MODEL_UNAVAILABLE_TOKENS.has(availabilityToken);
+
+  // burn / mk / live / pn are operational compatibility flags, never membership access folders
+  const ops = {
+    burn: accessToken(fields.burn_ability) === "yes" || tags.has("burn"),
+    mk: accessToken(fields.mk_ability) === "yes" || tags.has("mk"),
+    live: accessToken(fields.live_ability) === "yes" || tags.has("live"),
+    pn_compatible: accessToken(fields.pn_ability) === "yes" || tags.has("pn"),
+  };
+
+  return { bookingVisibility, accessFolder, publicFolders, lane, statusActive, availableNow, explicitlyUnavailable, ops };
+}
+
+function sanitizeCreateSessionModel(record, profile) {
+  const fields = record.fields || {};
+  const folders = profile.bookingVisibility === "private"
+    ? (profile.accessFolder ? [profile.accessFolder] : [])
+    : profile.publicFolders.slice();
+  return {
+    model_id: record.id,
+    model_name: str(fields.working_name || fields.display_name || fields.model_name || fields.nickname || fields.name || fields.Name),
+    model_lookup_key: str(fields.model_lookup_key || fields.unique_key || fields.model_code),
+    telegram_username: str(fields.telegram_username),
+    telegram_status: str(fields.telegram_status) || (str(fields.telegram_username) ? "linked" : "missing"),
+    folders,
+    orientation: profile.lane,
+    status: !profile.statusActive ? "inactive" : profile.availableNow ? "available" : "active",
+    available: profile.availableNow && !profile.explicitlyUnavailable,
+    operational: { ...profile.ops },
+  };
+}
+
+async function resolveCreateSessionModel(env, { model_id = "", model_key = "" } = {}) {
+  const modelsTable = env.AIRTABLE_TABLE_MODELS || "models";
+  const id = str(model_id);
+  if (/^rec[A-Za-z0-9]{14,}$/.test(id)) {
+    const r = await airtableFetch(env, `/${encodeURIComponent(modelsTable)}/${id}`);
+    if (r.ok && r.data?.id) return { id: r.data.id, fields: r.data.fields || {} };
+  }
+  const key = str(model_key || id);
+  if (!key) return null;
+  for (const field of ["model_lookup_key", "unique_key", "model_code"]) {
+    const found = await airtableFindOne(env, modelsTable, `{${field}}=${formulaText(key)}`);
+    if (found) return found;
+  }
+  return null;
+}
+
+async function enforcePrivateCreateAccess(env, body = {}) {
+  const work = body?.work || {};
+  const model = body?.model || {};
+  const privateAccess = body?.private_access || {};
+  const telegramGate = body?.telegram_gate || {};
+  const lineage = body?.client_lineage || {};
+  const lineIdentity = body?.line_identity || {};
+
+  const selectedFolder = accessToken(privateAccess.selected_private_folder || work.model_folder || body.model_folder);
+  const selectedOrientation = normalizeCustomerLane(privateAccess.selected_orientation || model.selected_orientation || body.selected_orientation);
+  const customerTelegram = str(telegramGate.customer_telegram_status || body.customer_telegram_status);
+  const modelTelegram = str(telegramGate.model_telegram_status || body.model_telegram_status);
+  const telegramOk = ["linked", "verified"].includes(customerTelegram) && ["linked", "verified"].includes(modelTelegram);
+
+  // Membership comes from the backend ledger; frontend tier/status fields never grant access.
+  const memberAccess = await resolveAuthoritativeMemberAccess(env, {
+    member_id: str(body.member_id || lineage.member_id),
+    client_id: str(body.client_id || lineage.client_id),
+    memberstack_id: str(body.memberstack_id || lineage.memberstack_id),
+    line_record_id: str(lineIdentity.line_record_id || body.line_record_id),
+    line_user_id: str(lineIdentity.line_user_id || body.line_user_id),
+    member_email: str(lineage.member_email || body.member_email || lineage.email),
+    telegram_username: str(telegramGate.customer_telegram_username || lineage.customer_telegram_username),
+  });
+  if (!memberAccess.resolved) {
+    throw new CreateSessionAccessError("AUTHORITATIVE_MEMBER_NOT_FOUND", "The client membership record could not be resolved.", 404);
+  }
+  const allowedFolders = memberAccess.allowed_folders;
+  if (!allowedFolders.length) throw new CreateSessionAccessError("private_eligibility_blocked", "Client membership is not active for private work.");
+  if (!CANONICAL_PRIVATE_FOLDERS.has(selectedFolder)) throw new CreateSessionAccessError("private_folder_invalid", "Selected private folder is not a canonical membership access folder.");
+  if (!allowedFolders.includes(selectedFolder)) throw new CreateSessionAccessError("private_folder_not_allowed", "Selected private folder is above the client's membership access.");
+  if (selectedOrientation !== "straight" && selectedOrientation !== "gay") throw new CreateSessionAccessError("private_orientation_required", "Private work requires a straight or gay customer lane.");
+  if (!telegramOk) throw new CreateSessionAccessError("private_telegram_gate_required", "Customer and model Telegram must be linked or verified for private work.");
+
+  // Never trust browser-submitted model metadata; re-resolve the model record.
+  const modelRecord = await resolveCreateSessionModel(env, {
+    model_id: str(model.model_id || body.model_id),
+    model_key: str(model.model_lookup_key || body.model_lookup_key || body.model_key),
+  });
+  if (!modelRecord) throw new CreateSessionAccessError("private_model_not_found", "The selected model could not be resolved.", 404);
+  const profile = modelAccessProfile(modelRecord.fields || {});
+  if (profile.bookingVisibility !== "private") throw new CreateSessionAccessError("private_model_not_private", "The selected model is not a private-work model.");
+  if (!CANONICAL_PRIVATE_FOLDERS.has(profile.accessFolder)) throw new CreateSessionAccessError("private_model_folder_invalid", "The selected model has no canonical private access folder.");
+  if (profile.accessFolder !== selectedFolder) throw new CreateSessionAccessError("private_model_folder_denied", "The selected model is outside the selected access folder.");
+  if (!allowedFolders.includes(profile.accessFolder)) throw new CreateSessionAccessError("private_model_folder_denied", "The selected model is above the client's membership access.");
+  if (profile.lane !== selectedOrientation && profile.lane !== "both") throw new CreateSessionAccessError("private_model_lane_mismatch", "The selected model does not serve the selected customer lane.");
+  if (!profile.statusActive) throw new CreateSessionAccessError("private_model_inactive", "The selected model is not active.");
+  if (profile.explicitlyUnavailable) throw new CreateSessionAccessError("private_model_unavailable", "The selected model is not currently bookable.");
+
+  return { memberAccess, modelRecord, profile, selectedFolder, selectedOrientation };
+}
+
+async function searchCreateSessionModels(env, url) {
+  const q = str(url.searchParams.get("q") || url.searchParams.get("search") || "");
+  const limit = clampInt(url.searchParams.get("limit"), 1, 100, 50);
+  const workType = accessToken(url.searchParams.get("work_type"));
+  const visibilityParam = accessToken(url.searchParams.get("booking_visibility"));
+  const bookingVisibility = visibilityParam === "private" || (!visibilityParam && workType === "private") ? "private" : "public";
+  const lane = normalizeCustomerLane(url.searchParams.get("customer_lane") || url.searchParams.get("orientation"));
+  const selectedFolder = accessToken(url.searchParams.get("selected_access_folder") || url.searchParams.get("folder"));
+  const flag = (name) => ["1", "true", "yes"].includes(accessToken(url.searchParams.get(name)));
+  const availableOnly = flag("available_only");
+  const wantBurn = flag("burn");
+  const wantMk = flag("mk");
+  const wantLive = flag("live");
+
+  let allowedFolders = null;
+  let memberSummary = null;
+  if (bookingVisibility === "private") {
+    const ids = {
+      member_id: str(url.searchParams.get("member_id")),
+      client_id: str(url.searchParams.get("client_id")),
+      memberstack_id: str(url.searchParams.get("memberstack_id")),
+      line_record_id: str(url.searchParams.get("line_record_id")),
+      line_user_id: str(url.searchParams.get("line_user_id")),
+      member_email: str(url.searchParams.get("member_email")),
+      telegram_username: str(url.searchParams.get("customer_telegram_username")),
+    };
+    if (!Object.values(ids).some(Boolean)) {
+      throw new CreateSessionAccessError("AUTHORITATIVE_MEMBER_NOT_FOUND", "The client membership record could not be resolved.", 404);
+    }
+    const memberAccess = await resolveAuthoritativeMemberAccess(env, ids);
+    if (!memberAccess.resolved) {
+      throw new CreateSessionAccessError("AUTHORITATIVE_MEMBER_NOT_FOUND", "The client membership record could not be resolved.", 404);
+    }
+    allowedFolders = memberAccess.allowed_folders;
+    memberSummary = {
+      eligibility_checked: true,
+      eligibility_result: allowedFolders.length ? "allowed" : "blocked",
+      private_access_level: memberAccess.tier || "blocked",
+      allowed_private_folders: allowedFolders.slice(),
+    };
+    if (!allowedFolders.length) {
+      // blocked or unknown-entitlement members receive no protected model names
+      return { ok: true, layer: "core", booking_visibility: bookingVisibility, folder: selectedFolder, customer_lane: lane, items: [], private_access: memberSummary };
+    }
+    if (!CANONICAL_PRIVATE_FOLDERS.has(selectedFolder)) throw new CreateSessionAccessError("private_folder_invalid", "Selected private folder is not a canonical membership access folder.");
+    if (!allowedFolders.includes(selectedFolder)) throw new CreateSessionAccessError("private_folder_not_allowed", "Selected private folder is above the client's membership access.");
+    if (lane !== "straight" && lane !== "gay") throw new CreateSessionAccessError("private_orientation_required", "Private model search requires a straight or gay customer lane.");
+  } else if (selectedFolder && !PUBLIC_MODEL_FOLDERS.has(selectedFolder)) {
+    throw new CreateSessionAccessError("public_folder_invalid", "Public work uses the travel or extreme folder.", 400);
+  }
+
+  const modelsTable = env.AIRTABLE_TABLE_MODELS || "models";
+  const records = await airtableList(env, modelsTable, {
+    q,
+    limit: 100,
+    matchFields: getModelSearchFields(env),
+    fallbackMatchFields: MODEL_SAFE_SEARCH_FIELDS,
+  });
+
+  const items = [];
+  for (const record of records) {
+    const profile = modelAccessProfile(record.fields || {});
+    if (!profile.statusActive) continue;
+    if (availableOnly && (!profile.availableNow || profile.explicitlyUnavailable)) continue;
+    if (wantBurn && !profile.ops.burn) continue;
+    if (wantMk && !profile.ops.mk) continue;
+    if (wantLive && !profile.ops.live) continue;
+    if (bookingVisibility === "private") {
+      if (profile.bookingVisibility !== "private") continue;
+      if (!CANONICAL_PRIVATE_FOLDERS.has(profile.accessFolder)) continue;
+      if (profile.accessFolder !== selectedFolder) continue;
+      if (!allowedFolders.includes(profile.accessFolder)) continue;
+      if (profile.lane !== lane && profile.lane !== "both") continue;
+    } else {
+      if (profile.bookingVisibility === "private") continue;
+      if (selectedFolder && !profile.publicFolders.includes(selectedFolder)) continue;
+      if (lane && profile.lane && profile.lane !== lane && profile.lane !== "both") continue;
+    }
+    items.push(sanitizeCreateSessionModel(record, profile));
+    if (items.length >= limit) break;
+  }
+
+  const out = { ok: true, layer: "core", booking_visibility: bookingVisibility, folder: selectedFolder, customer_lane: lane, items };
+  if (memberSummary) out.private_access = memberSummary;
+  return out;
+}
+
+export {
+  CreateSessionAccessError,
+  PRIVATE_ACCESS_FOLDERS,
+  membershipTierFromText,
+  normalizeCustomerLane,
+  modelAccessProfile,
+  sanitizeCreateSessionModel,
+  resolveAuthoritativeMemberAccess,
+  resolveCreateSessionModel,
+  enforcePrivateCreateAccess,
+  searchCreateSessionModels,
+};
+
+/* =========================
    Job create
 ========================= */
 async function createAdminJob(env, body) {
-  const client_name = strReq(body.client_name, "client_name");
-  const model_name = strReq(body.model_name, "model_name");
-  const job_type = strReq(body.job_type, "job_type");
-  const job_date = strReq(body.job_date, "job_date");
-  const start_time = strReq(body.start_time, "start_time");
-  const end_time = strReq(body.end_time, "end_time");
-  const location_name = strReq(body.location_name, "location_name");
+  const work = body?.work || {};
+  const model = body?.model || {};
+  const jobDetails = body?.job_details || {};
+  const payment = body?.payment || {};
+  const notes = body?.notes || {};
+  const privateAccess = body?.private_access || {};
+  const telegramGate = body?.telegram_gate || {};
+  const jobVisibility = str(work.job_visibility || body.job_visibility || body.booking_visibility || "");
 
-  const google_map_url = str(body.google_map_url || "");
-  const note = str(body.note || body.notes || "");
-  const payment_type = str(body.payment_type || "full");
-  const payment_method = str(body.payment_method || "promptpay");
-  const amount_thb = numReq(body.amount_thb, "amount_thb");
+  if (jobVisibility === "private") {
+    // Authoritative gate: resolves the member from the backend ledger and the
+    // model from Airtable. Browser-supplied membership/model fields never grant access.
+    await enforcePrivateCreateAccess(env, body);
+  }
+
+  const client_name = strReq(body.client_name || body.client_lineage?.client_name, "client_name");
+  const model_name = strReq(body.model_name || model.model_name, "model_name");
+  const job_type = strReq(body.job_type || work.job_lane || work.work_type, "job_type");
+  const job_date = strReq(body.job_date || jobDetails.job_date, "job_date");
+  const start_time = strReq(body.start_time || jobDetails.start_time, "start_time");
+  const end_time = strReq(body.end_time || jobDetails.end_time, "end_time");
+  const location_name = strReq(body.location_name || jobDetails.location_name, "location_name");
+
+  const google_map_url = str(body.google_map_url || jobDetails.google_map_url || "");
+  const note = str(body.note || notes.operation_note || notes.handling_note || body.notes || "");
+  const payment_type = str(body.payment_type || payment.payment_type || "full");
+  const payment_method = str(body.payment_method || payment.payment_method || "promptpay");
+  const amount_thb = numReq(body.amount_thb || payment.amount_thb, "amount_thb");
 
   const webBase = str(env.WEB_BASE_URL || "https://mmdbkk.com").replace(/\/+$/, "");
   const confirm_page = absoluteUrl(body.confirm_page || "/confirm/job-confirmation", webBase);

--- a/admin-worker/src/index.js
+++ b/admin-worker/src/index.js
@@ -593,6 +593,22 @@ export default {
       }
 
       // ----------------------------------------------------
+      // Models search (create-session booking search)
+      // Entitlement-enforced + sanitized; /v1/admin/models/list
+      // stays the raw admin inventory endpoint.
+      // ----------------------------------------------------
+      if (method === "GET" && path === "/v1/admin/models/search") {
+        try {
+          return withCors(json(await searchCreateSessionModels(env, url)), cors);
+        } catch (e) {
+          if (e instanceof CreateSessionAccessError) {
+            return withCors(json({ ok: false, error: { code: e.code, message: e.message } }, e.status), cors);
+          }
+          return withCors(json({ ok: false, error: String(e?.message || e || "models_search_failed") }, 500), cors);
+        }
+      }
+
+      // ----------------------------------------------------
       // Models source resolver
       // ----------------------------------------------------
       if (method === "GET" && path === "/v1/admin/models/resolve-source") {
@@ -666,7 +682,11 @@ export default {
             cors
           );
         } catch (e) {
-          return withCors(json({ ok: false, error: String(e?.message || e || "job_create_failed") }, 500), cors);
+          if (e instanceof CreateSessionAccessError) {
+            return withCors(json({ ok: false, error: { code: e.code, message: e.message } }, e.status), cors);
+          }
+          const error = String(e?.message || e || "job_create_failed");
+          return withCors(json({ ok: false, error }, error.startsWith("private_") ? 403 : 500), cors);
         }
       }
 
@@ -3550,22 +3570,412 @@ export {
 };
 
 /* =========================
+   Create Session Private Access
+   Authoritative membership + model gate. Frontend membership fields
+   (private_access.*, client_lineage.tier / membership_status,
+   allowed_private_folders) are advisory UX data only and never grant access.
+========================= */
+const PRIVATE_ACCESS_FOLDERS = {
+  standard: ["standard"],
+  premium: ["standard", "premium"],
+  vip: ["standard", "premium", "vip"],
+  black_card: ["standard", "premium", "vip", "exclusive"],
+};
+const PRIVATE_ACCESS_TIER_RANK = { standard: 1, premium: 2, vip: 3, black_card: 4 };
+const CANONICAL_PRIVATE_FOLDERS = new Set(["standard", "premium", "vip", "exclusive"]);
+const PUBLIC_MODEL_FOLDERS = new Set(["travel", "extreme"]);
+const MODEL_BLOCKED_STATUS_TOKENS = new Set(["inactive", "blocked", "suspended", "archived", "disabled", "banned", "off", "retired"]);
+const MODEL_UNAVAILABLE_TOKENS = new Set(["unavailable", "not_available", "paused", "busy", "on_hold", "hold"]);
+
+class CreateSessionAccessError extends Error {
+  constructor(code, message, status = 403) {
+    super(message);
+    this.name = "CreateSessionAccessError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+function accessToken(value) {
+  return String(value == null ? "" : value).toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function membershipTierFromText(value) {
+  const token = accessToken(value);
+  if (!token) return "";
+  // legacy SVIP normalizes to Black Card access; check before the "vip" substring
+  if (token.includes("black") || token.includes("svip")) return "black_card";
+  if (token.includes("vip")) return "vip";
+  if (token.includes("premium")) return "premium";
+  if (token.includes("standard") || token.includes("lite")) return "standard";
+  return "";
+}
+
+function normalizeCustomerLane(value) {
+  const token = accessToken(value);
+  if (token === "gay") return "gay";
+  if (token === "straight") return "straight";
+  if (token === "both" || token === "bi" || token === "all") return "both";
+  return "";
+}
+
+function formulaText(value) {
+  return `"${String(value == null ? "" : value).replace(/"/g, '\\"')}"`;
+}
+
+async function airtableListByFormula(env, tableName, filterByFormula, limit = 50) {
+  if (!env.AIRTABLE_API_KEY || !env.AIRTABLE_BASE_ID) return [];
+  const params = new URLSearchParams();
+  params.set("pageSize", String(Math.max(1, Math.min(100, limit))));
+  if (filterByFormula) params.set("filterByFormula", filterByFormula);
+  const r = await airtableFetch(env, `/${encodeURIComponent(tableName)}?${params.toString()}`);
+  if (!r.ok) return [];
+  return (r.data?.records || []).map((rec) => ({ id: rec.id, fields: rec.fields || {}, createdTime: rec.createdTime }));
+}
+
+async function resolveAuthoritativeMemberAccess(env, ids = {}) {
+  const membersTable = env.AIRTABLE_TABLE_MEMBERS || "members";
+  const lookups = [
+    ["client_id", ids.client_id, false],
+    ["member_id", ids.member_id, false],
+    ["Member ID", ids.member_id, false],
+    ["memberstack_id", ids.memberstack_id, false],
+    ["line_record_id", ids.line_record_id, false],
+    ["line_record", ids.line_record_id, false],
+    ["line_user_id", ids.line_user_id, false],
+    ["line_id", ids.line_user_id, false],
+    ["email", ids.member_email, true],
+    ["Contact Email", ids.member_email, true],
+    ["telegram_username", ids.telegram_username, true],
+  ];
+
+  let member = null;
+  for (const [field, value, lower] of lookups) {
+    const raw = str(value);
+    if (!raw) continue;
+    const left = lower ? `LOWER({${field}})` : `{${field}}`;
+    member = await airtableFindOne(env, membersTable, `${left}=${formulaText(lower ? raw.toLowerCase() : raw)}`);
+    if (member) break;
+  }
+  if (!member) return { resolved: false, allowed_folders: [] };
+
+  const memberFields = member.fields || {};
+  const memberEmail = str(memberFields["Contact Email"] || memberFields.member_email || memberFields.email || ids.member_email).toLowerCase();
+
+  // member_packages ledger is the membership source of truth (mirrors auth-worker derivePackageAccess)
+  let best = null;
+  if (memberEmail) {
+    const ledgerTable = env.AIRTABLE_TABLE_MEMBER_PACKAGES || "member_packages";
+    const now = Date.now();
+    const records = await airtableListByFormula(env, ledgerTable, `LOWER({member_email})=${formulaText(memberEmail)}`, 20);
+    for (const record of records) {
+      const f = record.fields || {};
+      if (accessToken(f.status) !== "active") continue;
+      const endAt = Date.parse(str(f.end_date || f.end_at || f.expire_at || f.expires_at));
+      if (!endAt || endAt < now) continue;
+      const tier = membershipTierFromText(f.package_code || f.tier);
+      if (!tier) continue;
+      const rank = PRIVATE_ACCESS_TIER_RANK[tier] || 0;
+      if (!best || rank > best.rank || (rank === best.rank && endAt > best.endAt)) {
+        best = { tier, rank, endAt, package_code: str(f.package_code || f.tier), expire_at: str(f.end_date || f.end_at || f.expire_at || f.expires_at) };
+      }
+    }
+  }
+
+  if (!best) {
+    return {
+      resolved: true,
+      member_record_id: member.id,
+      member_id: str(memberFields.member_id || memberFields["Member ID"]),
+      member_email: memberEmail,
+      membership_status: memberEmail ? "no_active_membership" : "no_ledger_identity",
+      tier: "",
+      allowed_folders: [],
+    };
+  }
+
+  return {
+    resolved: true,
+    member_record_id: member.id,
+    member_id: str(memberFields.member_id || memberFields["Member ID"]),
+    member_email: memberEmail,
+    membership_status: "active",
+    tier: best.tier,
+    package_code: best.package_code,
+    expire_at: best.expire_at,
+    allowed_folders: PRIVATE_ACCESS_FOLDERS[best.tier].slice(),
+  };
+}
+
+function modelAccessProfile(fields = {}) {
+  const rawTags = []
+    .concat(Array.isArray(fields.legacy_tags) ? fields.legacy_tags : String(fields.legacy_tags || "").split(/[,\n]/))
+    .concat(Array.isArray(fields.tags) ? fields.tags : String(fields.tags || "").split(/[,\n]/));
+  const tags = new Set(rawTags.map(accessToken).filter(Boolean));
+
+  const visibilityToken = accessToken(fields.booking_visibility);
+  const salesLayer = accessToken(fields.sales_layer);
+  let bookingVisibility = "";
+  if (visibilityToken === "private" || salesLayer.includes("private")) bookingVisibility = "private";
+  else if (visibilityToken === "public" || salesLayer.includes("public")) bookingVisibility = "public";
+
+  let accessFolder = accessToken(fields.access_folder || fields.model_access_folder || fields.model_folder);
+  if (!CANONICAL_PRIVATE_FOLDERS.has(accessFolder)) {
+    accessFolder = "";
+    const tierSource = accessToken([fields.model_tier, fields.approved_client_visibility, fields.private_tier].filter(Boolean).join(" "));
+    if (tierSource.includes("exclusive") || tierSource.includes("black")) accessFolder = "exclusive";
+    else if (tierSource.includes("vip")) accessFolder = "vip";
+    else if (tierSource.includes("premium")) accessFolder = "premium";
+    else if (tierSource.includes("standard")) accessFolder = "standard";
+  }
+
+  const serviceSource = accessToken([fields.service_layer, fields.job_types, fields.private_tier].filter(Boolean).join(" "));
+  const publicFolders = [];
+  if (serviceSource.includes("travel") || tags.has("travel")) publicFolders.push("travel");
+  if (serviceSource.includes("extreme") || tags.has("extreme")) publicFolders.push("extreme");
+
+  const lane = normalizeCustomerLane(fields.customer_lane || fields.orientation_label || fields.orientation);
+  const statusActive = !MODEL_BLOCKED_STATUS_TOKENS.has(accessToken(fields.status));
+  const availabilityToken = accessToken(fields.availability_status);
+  const availableNow =
+    fields.available_now === true ||
+    ["yes", "true", "1", "available"].includes(accessToken(fields.available_now)) ||
+    ["available", "active", "bookable"].includes(availabilityToken);
+  const explicitlyUnavailable =
+    fields.available_now === false ||
+    accessToken(fields.available_now) === "no" ||
+    MODEL_UNAVAILABLE_TOKENS.has(availabilityToken);
+
+  // burn / mk / live / pn are operational compatibility flags, never membership access folders
+  const ops = {
+    burn: accessToken(fields.burn_ability) === "yes" || tags.has("burn"),
+    mk: accessToken(fields.mk_ability) === "yes" || tags.has("mk"),
+    live: accessToken(fields.live_ability) === "yes" || tags.has("live"),
+    pn_compatible: accessToken(fields.pn_ability) === "yes" || tags.has("pn"),
+  };
+
+  return { bookingVisibility, accessFolder, publicFolders, lane, statusActive, availableNow, explicitlyUnavailable, ops };
+}
+
+function sanitizeCreateSessionModel(record, profile) {
+  const fields = record.fields || {};
+  const folders = profile.bookingVisibility === "private"
+    ? (profile.accessFolder ? [profile.accessFolder] : [])
+    : profile.publicFolders.slice();
+  return {
+    model_id: record.id,
+    model_name: str(fields.working_name || fields.display_name || fields.model_name || fields.nickname || fields.name || fields.Name),
+    model_lookup_key: str(fields.model_lookup_key || fields.unique_key || fields.model_code),
+    telegram_username: str(fields.telegram_username),
+    telegram_status: str(fields.telegram_status) || (str(fields.telegram_username) ? "linked" : "missing"),
+    folders,
+    orientation: profile.lane,
+    status: !profile.statusActive ? "inactive" : profile.availableNow ? "available" : "active",
+    available: profile.availableNow && !profile.explicitlyUnavailable,
+    operational: { ...profile.ops },
+  };
+}
+
+async function resolveCreateSessionModel(env, { model_id = "", model_key = "" } = {}) {
+  const modelsTable = env.AIRTABLE_TABLE_MODELS || "models";
+  const id = str(model_id);
+  if (/^rec[A-Za-z0-9]{14,}$/.test(id)) {
+    const r = await airtableFetch(env, `/${encodeURIComponent(modelsTable)}/${id}`);
+    if (r.ok && r.data?.id) return { id: r.data.id, fields: r.data.fields || {} };
+  }
+  const key = str(model_key || id);
+  if (!key) return null;
+  for (const field of ["model_lookup_key", "unique_key", "model_code"]) {
+    const found = await airtableFindOne(env, modelsTable, `{${field}}=${formulaText(key)}`);
+    if (found) return found;
+  }
+  return null;
+}
+
+async function enforcePrivateCreateAccess(env, body = {}) {
+  const work = body?.work || {};
+  const model = body?.model || {};
+  const privateAccess = body?.private_access || {};
+  const telegramGate = body?.telegram_gate || {};
+  const lineage = body?.client_lineage || {};
+  const lineIdentity = body?.line_identity || {};
+
+  const selectedFolder = accessToken(privateAccess.selected_private_folder || work.model_folder || body.model_folder);
+  const selectedOrientation = normalizeCustomerLane(privateAccess.selected_orientation || model.selected_orientation || body.selected_orientation);
+  const customerTelegram = str(telegramGate.customer_telegram_status || body.customer_telegram_status);
+  const modelTelegram = str(telegramGate.model_telegram_status || body.model_telegram_status);
+  const telegramOk = ["linked", "verified"].includes(customerTelegram) && ["linked", "verified"].includes(modelTelegram);
+
+  // Membership comes from the backend ledger; frontend tier/status fields never grant access.
+  const memberAccess = await resolveAuthoritativeMemberAccess(env, {
+    member_id: str(body.member_id || lineage.member_id),
+    client_id: str(body.client_id || lineage.client_id),
+    memberstack_id: str(body.memberstack_id || lineage.memberstack_id),
+    line_record_id: str(lineIdentity.line_record_id || body.line_record_id),
+    line_user_id: str(lineIdentity.line_user_id || body.line_user_id),
+    member_email: str(lineage.member_email || body.member_email || lineage.email),
+    telegram_username: str(telegramGate.customer_telegram_username || lineage.customer_telegram_username),
+  });
+  if (!memberAccess.resolved) {
+    throw new CreateSessionAccessError("AUTHORITATIVE_MEMBER_NOT_FOUND", "The client membership record could not be resolved.", 404);
+  }
+  const allowedFolders = memberAccess.allowed_folders;
+  if (!allowedFolders.length) throw new CreateSessionAccessError("private_eligibility_blocked", "Client membership is not active for private work.");
+  if (!CANONICAL_PRIVATE_FOLDERS.has(selectedFolder)) throw new CreateSessionAccessError("private_folder_invalid", "Selected private folder is not a canonical membership access folder.");
+  if (!allowedFolders.includes(selectedFolder)) throw new CreateSessionAccessError("private_folder_not_allowed", "Selected private folder is above the client's membership access.");
+  if (selectedOrientation !== "straight" && selectedOrientation !== "gay") throw new CreateSessionAccessError("private_orientation_required", "Private work requires a straight or gay customer lane.");
+  if (!telegramOk) throw new CreateSessionAccessError("private_telegram_gate_required", "Customer and model Telegram must be linked or verified for private work.");
+
+  // Never trust browser-submitted model metadata; re-resolve the model record.
+  const modelRecord = await resolveCreateSessionModel(env, {
+    model_id: str(model.model_id || body.model_id),
+    model_key: str(model.model_lookup_key || body.model_lookup_key || body.model_key),
+  });
+  if (!modelRecord) throw new CreateSessionAccessError("private_model_not_found", "The selected model could not be resolved.", 404);
+  const profile = modelAccessProfile(modelRecord.fields || {});
+  if (profile.bookingVisibility !== "private") throw new CreateSessionAccessError("private_model_not_private", "The selected model is not a private-work model.");
+  if (!CANONICAL_PRIVATE_FOLDERS.has(profile.accessFolder)) throw new CreateSessionAccessError("private_model_folder_invalid", "The selected model has no canonical private access folder.");
+  if (profile.accessFolder !== selectedFolder) throw new CreateSessionAccessError("private_model_folder_denied", "The selected model is outside the selected access folder.");
+  if (!allowedFolders.includes(profile.accessFolder)) throw new CreateSessionAccessError("private_model_folder_denied", "The selected model is above the client's membership access.");
+  if (profile.lane !== selectedOrientation && profile.lane !== "both") throw new CreateSessionAccessError("private_model_lane_mismatch", "The selected model does not serve the selected customer lane.");
+  if (!profile.statusActive) throw new CreateSessionAccessError("private_model_inactive", "The selected model is not active.");
+  if (profile.explicitlyUnavailable) throw new CreateSessionAccessError("private_model_unavailable", "The selected model is not currently bookable.");
+
+  return { memberAccess, modelRecord, profile, selectedFolder, selectedOrientation };
+}
+
+async function searchCreateSessionModels(env, url) {
+  const q = str(url.searchParams.get("q") || url.searchParams.get("search") || "");
+  const limit = clampInt(url.searchParams.get("limit"), 1, 100, 50);
+  const workType = accessToken(url.searchParams.get("work_type"));
+  const visibilityParam = accessToken(url.searchParams.get("booking_visibility"));
+  const bookingVisibility = visibilityParam === "private" || (!visibilityParam && workType === "private") ? "private" : "public";
+  const lane = normalizeCustomerLane(url.searchParams.get("customer_lane") || url.searchParams.get("orientation"));
+  const selectedFolder = accessToken(url.searchParams.get("selected_access_folder") || url.searchParams.get("folder"));
+  const flag = (name) => ["1", "true", "yes"].includes(accessToken(url.searchParams.get(name)));
+  const availableOnly = flag("available_only");
+  const wantBurn = flag("burn");
+  const wantMk = flag("mk");
+  const wantLive = flag("live");
+
+  let allowedFolders = null;
+  let memberSummary = null;
+  if (bookingVisibility === "private") {
+    const ids = {
+      member_id: str(url.searchParams.get("member_id")),
+      client_id: str(url.searchParams.get("client_id")),
+      memberstack_id: str(url.searchParams.get("memberstack_id")),
+      line_record_id: str(url.searchParams.get("line_record_id")),
+      line_user_id: str(url.searchParams.get("line_user_id")),
+      member_email: str(url.searchParams.get("member_email")),
+      telegram_username: str(url.searchParams.get("customer_telegram_username")),
+    };
+    if (!Object.values(ids).some(Boolean)) {
+      throw new CreateSessionAccessError("AUTHORITATIVE_MEMBER_NOT_FOUND", "The client membership record could not be resolved.", 404);
+    }
+    const memberAccess = await resolveAuthoritativeMemberAccess(env, ids);
+    if (!memberAccess.resolved) {
+      throw new CreateSessionAccessError("AUTHORITATIVE_MEMBER_NOT_FOUND", "The client membership record could not be resolved.", 404);
+    }
+    allowedFolders = memberAccess.allowed_folders;
+    memberSummary = {
+      eligibility_checked: true,
+      eligibility_result: allowedFolders.length ? "allowed" : "blocked",
+      private_access_level: memberAccess.tier || "blocked",
+      allowed_private_folders: allowedFolders.slice(),
+    };
+    if (!allowedFolders.length) {
+      // blocked or unknown-entitlement members receive no protected model names
+      return { ok: true, layer: "core", booking_visibility: bookingVisibility, folder: selectedFolder, customer_lane: lane, items: [], private_access: memberSummary };
+    }
+    if (!CANONICAL_PRIVATE_FOLDERS.has(selectedFolder)) throw new CreateSessionAccessError("private_folder_invalid", "Selected private folder is not a canonical membership access folder.");
+    if (!allowedFolders.includes(selectedFolder)) throw new CreateSessionAccessError("private_folder_not_allowed", "Selected private folder is above the client's membership access.");
+    if (lane !== "straight" && lane !== "gay") throw new CreateSessionAccessError("private_orientation_required", "Private model search requires a straight or gay customer lane.");
+  } else if (selectedFolder && !PUBLIC_MODEL_FOLDERS.has(selectedFolder)) {
+    throw new CreateSessionAccessError("public_folder_invalid", "Public work uses the travel or extreme folder.", 400);
+  }
+
+  const modelsTable = env.AIRTABLE_TABLE_MODELS || "models";
+  const records = await airtableList(env, modelsTable, {
+    q,
+    limit: 100,
+    matchFields: getModelSearchFields(env),
+    fallbackMatchFields: MODEL_SAFE_SEARCH_FIELDS,
+  });
+
+  const items = [];
+  for (const record of records) {
+    const profile = modelAccessProfile(record.fields || {});
+    if (!profile.statusActive) continue;
+    if (availableOnly && (!profile.availableNow || profile.explicitlyUnavailable)) continue;
+    if (wantBurn && !profile.ops.burn) continue;
+    if (wantMk && !profile.ops.mk) continue;
+    if (wantLive && !profile.ops.live) continue;
+    if (bookingVisibility === "private") {
+      if (profile.bookingVisibility !== "private") continue;
+      if (!CANONICAL_PRIVATE_FOLDERS.has(profile.accessFolder)) continue;
+      if (profile.accessFolder !== selectedFolder) continue;
+      if (!allowedFolders.includes(profile.accessFolder)) continue;
+      if (profile.lane !== lane && profile.lane !== "both") continue;
+    } else {
+      if (profile.bookingVisibility === "private") continue;
+      if (selectedFolder && !profile.publicFolders.includes(selectedFolder)) continue;
+      if (lane && profile.lane && profile.lane !== lane && profile.lane !== "both") continue;
+    }
+    items.push(sanitizeCreateSessionModel(record, profile));
+    if (items.length >= limit) break;
+  }
+
+  const out = { ok: true, layer: "core", booking_visibility: bookingVisibility, folder: selectedFolder, customer_lane: lane, items };
+  if (memberSummary) out.private_access = memberSummary;
+  return out;
+}
+
+export {
+  CreateSessionAccessError,
+  PRIVATE_ACCESS_FOLDERS,
+  membershipTierFromText,
+  normalizeCustomerLane,
+  modelAccessProfile,
+  sanitizeCreateSessionModel,
+  resolveAuthoritativeMemberAccess,
+  resolveCreateSessionModel,
+  enforcePrivateCreateAccess,
+  searchCreateSessionModels,
+};
+
+/* =========================
    Job create
 ========================= */
 async function createAdminJob(env, body) {
-  const client_name = strReq(body.client_name, "client_name");
-  const model_name = strReq(body.model_name, "model_name");
-  const job_type = strReq(body.job_type, "job_type");
-  const job_date = strReq(body.job_date, "job_date");
-  const start_time = strReq(body.start_time, "start_time");
-  const end_time = strReq(body.end_time, "end_time");
-  const location_name = strReq(body.location_name, "location_name");
+  const work = body?.work || {};
+  const model = body?.model || {};
+  const jobDetails = body?.job_details || {};
+  const payment = body?.payment || {};
+  const notes = body?.notes || {};
+  const privateAccess = body?.private_access || {};
+  const telegramGate = body?.telegram_gate || {};
+  const jobVisibility = str(work.job_visibility || body.job_visibility || body.booking_visibility || "");
 
-  const google_map_url = str(body.google_map_url || "");
-  const note = str(body.note || body.notes || "");
-  const payment_type = str(body.payment_type || "full");
-  const payment_method = str(body.payment_method || "promptpay");
-  const amount_thb = numReq(body.amount_thb, "amount_thb");
+  if (jobVisibility === "private") {
+    // Authoritative gate: resolves the member from the backend ledger and the
+    // model from Airtable. Browser-supplied membership/model fields never grant access.
+    await enforcePrivateCreateAccess(env, body);
+  }
+
+  const client_name = strReq(body.client_name || body.client_lineage?.client_name, "client_name");
+  const model_name = strReq(body.model_name || model.model_name, "model_name");
+  const job_type = strReq(body.job_type || work.job_lane || work.work_type, "job_type");
+  const job_date = strReq(body.job_date || jobDetails.job_date, "job_date");
+  const start_time = strReq(body.start_time || jobDetails.start_time, "start_time");
+  const end_time = strReq(body.end_time || jobDetails.end_time, "end_time");
+  const location_name = strReq(body.location_name || jobDetails.location_name, "location_name");
+
+  const google_map_url = str(body.google_map_url || jobDetails.google_map_url || "");
+  const note = str(body.note || notes.operation_note || notes.handling_note || body.notes || "");
+  const payment_type = str(body.payment_type || payment.payment_type || "full");
+  const payment_method = str(body.payment_method || payment.payment_method || "promptpay");
+  const amount_thb = numReq(body.amount_thb || payment.amount_thb, "amount_thb");
 
   const webBase = str(env.WEB_BASE_URL || "https://mmdbkk.com").replace(/\/+$/, "");
   const confirm_page = absoluteUrl(body.confirm_page || "/confirm/job-confirmation", webBase);

--- a/immigrate-worker/public/a/create-session.js
+++ b/immigrate-worker/public/a/create-session.js
@@ -34,6 +34,7 @@
     clients: [],
     selectedClient: null,
     workType: "",
+    privateOrientation: "",
     modelFolder: "",
     models: [],
     selectedModel: null,
@@ -139,8 +140,10 @@
       ["extreme", "Extreme Model", "แฟ้ม Public Work ที่ต้องใช้ energy / performance / intensity สูงกว่า", "Choose Extreme"]
     ],
     private: [
-      ["vip", "VIP", "แฟ้ม Private Work ระดับ VIP", "Choose VIP"],
-      ["pn", "PN", "แฟ้ม PN โดยอนุญาต Model ในแฟ้ม VIP ที่ compatible เข้า PN ได้ด้วย", "Choose PN"]
+      ["standard", "Standard", "แฟ้ม Private Work สำหรับ membership Standard (active) ขึ้นไป", "Choose Standard"],
+      ["premium", "Premium", "แฟ้ม Private Work สำหรับ membership Premium (active) ขึ้นไป", "Choose Premium"],
+      ["vip", "VIP", "แฟ้ม Private Work สำหรับ membership VIP (active) ขึ้นไป", "Choose VIP"],
+      ["exclusive", "Exclusive", "แฟ้ม Private Work สำหรับ Black Card (active) เท่านั้น", "Choose Exclusive"]
     ]
   };
 
@@ -159,6 +162,8 @@
   const demoClients = [
     {
       client_id: "cli_ruch_001",
+      member_id: "mmd_demo_ruch_001",
+      member_email: "ruch.vip@demo.mmd",
       client_name: "รัช",
       username: "ruch vip",
       phone: "hidden",
@@ -177,6 +182,8 @@
     },
     {
       client_id: "cli_man_001",
+      member_id: "mmd_demo_man_001",
+      member_email: "man.premium@demo.mmd",
       client_name: "Man",
       username: "man 24",
       phone: "hidden",
@@ -195,8 +202,10 @@
     },
     {
       client_id: "cli_win_002",
+      member_id: "mmd_demo_win_002",
+      member_email: "win.vip@demo.mmd",
       client_name: "Win",
-      username: "win pn",
+      username: "win vip",
       phone: "hidden",
       package_code: "VIP",
       tier: "vip",
@@ -220,8 +229,8 @@
       lookup_key: "TMIB-HITO-01",
       telegram_username: "@hito_sigil",
       telegram_status: "linked",
-      folders: ["travel", "extreme", "vip", "pn"],
-      vip_can_pn: true,
+      folders: ["travel", "extreme", "premium", "vip", "exclusive"],
+      orientation: "both",
       status: "available",
       note: "Steady route / calm personal assistant"
     },
@@ -231,8 +240,8 @@
       lookup_key: "TMIB-KJ-01",
       telegram_username: "@kenji_sigil",
       telegram_status: "linked",
-      folders: ["travel", "vip", "pn"],
-      vip_can_pn: true,
+      folders: ["travel", "standard", "premium", "vip"],
+      orientation: "straight",
       status: "available",
       note: "Client continuity / premium lead"
     },
@@ -242,8 +251,8 @@
       lookup_key: "TMIB-TT-01",
       telegram_username: "@tart_sigil",
       telegram_status: "linked",
-      folders: ["travel", "extreme"],
-      vip_can_pn: false,
+      folders: ["travel", "extreme", "standard"],
+      orientation: "both",
       status: "available",
       note: "Scout / public work"
     },
@@ -253,8 +262,8 @@
       lookup_key: "TMIB-YUKI-01",
       telegram_username: "@yuki_sigil",
       telegram_status: "verified",
-      folders: ["vip", "pn"],
-      vip_can_pn: true,
+      folders: ["vip", "exclusive"],
+      orientation: "gay",
       status: "approval",
       note: "Approval / partnership authority"
     }
@@ -341,6 +350,9 @@
   function normalizeClients(data) {
     return (data?.records || data?.items || data?.data || []).map((item, index) => ({
       client_id: item.client_id || item.id || `client_${index}`,
+      member_id: item.member_id || "",
+      member_email: item.member_email || item.contact_email || item.email || "",
+      memberstack_id: item.memberstack_id || "",
       client_name: item.client_name || item.clientName || item.name || item.nickname || "",
       username: item.username || item.member_username || "",
       phone: item.phone || item.member_phone || "",
@@ -367,10 +379,85 @@
       telegram_username: item.telegram_username || item.model_telegram_username || "",
       telegram_status: item.telegram_status || "missing",
       folders: Array.isArray(item.folders) ? item.folders : [],
-      vip_can_pn: Boolean(item.vip_can_pn || item.pn_compatible),
+      orientation: normalizeOrientation(item.orientation || item.model_orientation || item.private_orientation || item.booking_orientation),
       status: item.status || "available",
       note: item.note || item.description || ""
     }));
+  }
+
+  function normalizeToken(value) {
+    return String(value || "").toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+  }
+
+  function normalizeOrientation(value) {
+    const token = normalizeToken(value);
+    if (token === "gay") return "gay";
+    if (token === "both" || token === "bi" || token === "all") return "both";
+    if (token === "straight") return "straight";
+    return "";
+  }
+
+  function selectedClientSnapshot() {
+    const client = state.selectedClient || {};
+    return {
+      package_code: String(val(el.package) || client.package_code || ""),
+      tier: String(client.tier || ""),
+      membership_status: String(val(el.membershipStatus) || client.membership_status || "")
+    };
+  }
+
+  const privateAccessFolders = {
+    standard: ["standard"],
+    premium: ["standard", "premium"],
+    vip: ["standard", "premium", "vip"],
+    black_card: ["standard", "premium", "vip", "exclusive"]
+  };
+
+  const privateAccessLabels = {
+    standard: "Standard",
+    premium: "Premium",
+    vip: "VIP",
+    black_card: "Black Card"
+  };
+
+  function membershipAccessLevel(tierText) {
+    // legacy SVIP normalizes to Black Card access; check before "vip" (substring)
+    if (tierText.includes("black") || tierText.includes("svip")) return "black_card";
+    if (tierText.includes("vip")) return "vip";
+    if (tierText.includes("premium")) return "premium";
+    if (tierText.includes("standard")) return "standard";
+    return "";
+  }
+
+  function privateEligibility() {
+    const client = selectedClientSnapshot();
+    const status = normalizeToken(client.membership_status);
+    const tierText = normalizeToken([client.package_code, client.tier].filter(Boolean).join(" "));
+    const active = status === "active";
+    const level = active ? membershipAccessLevel(tierText) : "";
+    if (!state.selectedClient || !active || !level) {
+      return {
+        eligibility_checked: Boolean(state.selectedClient),
+        eligibility_result: "blocked",
+        private_access_level: "blocked",
+        allowed_private_folders: []
+      };
+    }
+    return {
+      eligibility_checked: true,
+      eligibility_result: "allowed",
+      private_access_level: level,
+      allowed_private_folders: privateAccessFolders[level].slice()
+    };
+  }
+
+  function privateAccessPayload() {
+    const access = privateEligibility();
+    return {
+      ...access,
+      selected_orientation: state.workType === "private" ? state.privateOrientation : "",
+      selected_private_folder: state.workType === "private" ? state.modelFolder : ""
+    };
   }
 
   async function checkSession() {
@@ -546,6 +633,8 @@
       el.lineageNotice.classList.add("is-ok");
     }
     renderClients();
+    renderFolders();
+    renderModels();
     updateAll();
     setStatus("Client lineage selected.", "ok");
     scrollToNode($("#work-panel"));
@@ -565,6 +654,10 @@
       el.customerTelegram
     ].forEach((node) => setVal(node, ""));
     setVal(el.customerTelegramStatus, "missing");
+    state.privateOrientation = "";
+    state.modelFolder = "";
+    state.models = [];
+    state.selectedModel = null;
     text(el.clientInitial, "C");
     text(el.selectedClientName, "-");
     text(el.selectedClientMeta, "-");
@@ -578,12 +671,15 @@
       el.lineageNotice.classList.remove("is-ok", "is-bad");
     }
     renderClients();
+    renderFolders();
+    renderModels();
     updateAll();
     scrollToNode($("#client-search"));
   }
 
   function selectWorkType(type) {
     state.workType = type;
+    state.privateOrientation = "";
     state.modelFolder = "";
     state.models = [];
     state.selectedModel = null;
@@ -592,7 +688,7 @@
     });
     renderFolders();
     renderModels();
-    text(el.folderHelper, type === "public" ? "Public Work: เลือกแฟ้ม Travel Model หรือ Extreme Model" : "Private Work: เลือกแฟ้ม VIP หรือ PN");
+    text(el.folderHelper, type === "public" ? "Public Work: เลือกแฟ้ม Travel Model หรือ Extreme Model" : "Private Work: ตรวจ eligibility ก่อน แล้วเลือก Straight หรือ Gay");
     setStatus(type === "public" ? "Public Work selected." : "Private Work selected.", "ok");
     updateAll();
     scrollToNode($("#model-panel"));
@@ -605,10 +701,37 @@
 
   function renderFolders() {
     if (!el.folderGrid) return;
-    const rows = folders[state.workType] || [];
+    let rows = folders[state.workType] || [];
     if (!rows.length) {
       el.folderGrid.innerHTML = '<div class="mmdop__empty">เลือก Public Work หรือ Private Work ก่อน</div>';
       return;
+    }
+    if (state.workType === "private") {
+      const access = privateEligibility();
+      if (access.eligibility_result !== "allowed") {
+        el.folderGrid.innerHTML = '<div class="mmdop__empty">Private create ถูกบล็อกสำหรับ inactive / expired / guest / unknown ให้บันทึก draft หรือ pending review เท่านั้น</div>';
+        return;
+      }
+      if (!state.privateOrientation) {
+        el.folderGrid.innerHTML = `
+        <button class="mmdop__folder" type="button" data-op-private-orientation="straight">
+          <span>PRIVATE ORIENTATION</span>
+          <strong>Straight</strong>
+          <p>Eligibility ผ่านแล้ว เลือก orientation ก่อนแสดงแฟ้ม Private</p>
+          <em>Choose Straight</em>
+        </button>
+        <button class="mmdop__folder" type="button" data-op-private-orientation="gay">
+          <span>PRIVATE ORIENTATION</span>
+          <strong>Gay</strong>
+          <p>Eligibility ผ่านแล้ว เลือก orientation ก่อนแสดงแฟ้ม Private</p>
+          <em>Choose Gay</em>
+        </button>`;
+        $$('[data-op-private-orientation]').forEach((button) => {
+          button.addEventListener("click", () => selectPrivateOrientation(button.dataset.opPrivateOrientation));
+        });
+        return;
+      }
+      rows = rows.filter(([id]) => access.allowed_private_folders.includes(id));
     }
     el.folderGrid.innerHTML = rows
       .map(([id, title, copy, cta]) => `
@@ -624,6 +747,16 @@
     });
   }
 
+  function selectPrivateOrientation(orientation) {
+    state.privateOrientation = normalizeOrientation(orientation);
+    state.modelFolder = "";
+    state.models = [];
+    state.selectedModel = null;
+    renderFolders();
+    renderModels();
+    updateAll();
+  }
+
   async function selectFolder(folderId) {
     state.modelFolder = folderId;
     state.selectedModel = null;
@@ -634,10 +767,13 @@
   }
 
   function demoModelsForFolder(folderId) {
-    if (folderId === "pn") {
-      return demoModels.filter((model) => model.folders.includes("pn") || (model.folders.includes("vip") && model.vip_can_pn));
-    }
-    return demoModels.filter((model) => model.folders.includes(folderId));
+    const allowedByFolder = (model) => model.folders.includes(folderId);
+    const allowedByOrientation = (model) => {
+      if (state.workType !== "private") return true;
+      const orientation = normalizeOrientation(model.orientation);
+      return orientation === state.privateOrientation || orientation === "both";
+    };
+    return demoModels.filter((model) => allowedByFolder(model) && allowedByOrientation(model));
   }
 
   async function loadModels() {
@@ -654,7 +790,25 @@
     }
     setStatus("กำลังโหลด Model Pool...", "");
     try {
-      const url = `${api(config.endpoints.modelSearch)}?work_type=${encodeURIComponent(state.workType)}&folder=${encodeURIComponent(state.modelFolder)}`;
+      const params = new URLSearchParams({
+        work_type: state.workType,
+        selected_access_folder: state.modelFolder
+      });
+      if (state.workType === "private") {
+        // entitlement is resolved server-side from the client identifier;
+        // frontend eligibility fields are advisory UX only
+        params.set("booking_visibility", "private");
+        params.set("customer_lane", state.privateOrientation);
+        const client = state.selectedClient || {};
+        if (client.client_id) params.set("client_id", client.client_id);
+        if (client.member_id) params.set("member_id", client.member_id);
+        if (client.memberstack_id) params.set("memberstack_id", client.memberstack_id);
+        if (client.member_email) params.set("member_email", client.member_email);
+        if (client.line_record_id) params.set("line_record_id", client.line_record_id);
+        if (client.line_user_id) params.set("line_user_id", client.line_user_id);
+        if (client.customer_telegram_username) params.set("customer_telegram_username", client.customer_telegram_username);
+      }
+      const url = `${api(config.endpoints.modelSearch)}?${params.toString()}`;
       const result = await requestJson(url);
       if (!result.ok) throw new Error(`HTTP ${result.status}`);
       state.models = normalizeModels(result.data);
@@ -690,12 +844,9 @@
     el.modelSelect.innerHTML =
       '<option value="">เลือก Model</option>' +
       state.models
-        .map((model) => {
-          const suffix = state.modelFolder === "pn" && model.folders.includes("vip") ? " · VIP compatible" : "";
-          return `<option value="${esc(model.model_id)}">${esc(model.model_name + suffix)}</option>`;
-        })
+        .map((model) => `<option value="${esc(model.model_id)}">${esc(model.model_name)}</option>`)
         .join("");
-    text(el.modelRule, state.modelFolder === "pn" ? "PN shows PN + VIP-compatible models" : folderLabel(state.modelFolder));
+    text(el.modelRule, folderLabel(state.modelFolder));
     renderModelPreview();
   }
 
@@ -798,6 +949,11 @@
     if (!String(val(el.clientName) || "").trim()) missing.push("Client Name");
     if (!String(val(el.lineUserId) || "").trim()) missing.push("LINE User ID");
     if (!state.workType) missing.push("Work Type");
+    if (state.workType === "private") {
+      const access = privateEligibility();
+      if (access.eligibility_result !== "allowed") missing.push("Private Eligibility");
+      if (!state.privateOrientation) missing.push("Private Orientation");
+    }
     if (!state.modelFolder) missing.push("Model Folder");
     if (!state.selectedModel) missing.push("Model");
     if (!String(val(el.date) || "").trim()) missing.push("Date");
@@ -844,7 +1000,13 @@
       return;
     }
     if (!state.modelFolder) {
-      setNext("เลือก Model Folder", state.workType === "public" ? "Travel หรือ Extreme" : "VIP หรือ PN");
+      if (state.workType === "private" && privateEligibility().eligibility_result !== "allowed") {
+        setNext("Private Pending Review", "บันทึก draft เท่านั้น ลูกค้ายังไม่ active eligible");
+      } else if (state.workType === "private" && !state.privateOrientation) {
+        setNext("เลือก Orientation", "Straight หรือ Gay ก่อนเลือกแฟ้ม Private");
+      } else {
+        setNext("เลือก Model Folder", state.workType === "public" ? "Travel หรือ Extreme" : "แฟ้ม Private ที่ eligibility อนุญาต");
+      }
       setActiveStep("folder");
       return;
     }
@@ -877,8 +1039,13 @@
     text(el.statStatus, getMissingFields().length ? "Not ready" : "Ready");
     text(el.railFolder, state.modelFolder ? folderLabel(state.modelFolder) : "Not selected");
     if (state.workType === "public") text(el.railFolderCopy, "Public Work ใช้ Travel Model หรือ Extreme Model");
-    else if (state.workType === "private") text(el.railFolderCopy, "Private Work ใช้ VIP / PN และ PN รับ VIP-compatible ได้");
-    else text(el.railFolderCopy, "Public = Travel / Extreme · Private = VIP / PN");
+    else if (state.workType === "private") {
+      const access = privateEligibility();
+      text(el.railFolderCopy, access.eligibility_result === "allowed"
+        ? `Private ${privateAccessLabels[access.private_access_level] || access.private_access_level}: ${access.allowed_private_folders.map(folderLabel).join(" / ")} · ${state.privateOrientation || "เลือก orientation"}`
+        : "Private create blocked: draft / pending review only");
+    }
+    else text(el.railFolderCopy, "Public = Travel / Extreme · Private = Standard / Premium / VIP / Exclusive");
   }
 
   function updateReadyState() {
@@ -928,12 +1095,14 @@
         model_folder_label: folderLabel(state.modelFolder),
         privacy_level: state.workType === "private" ? "restricted" : "standard"
       },
+      private_access: privateAccessPayload(),
       model: {
         model_id: model.model_id || "",
         model_name: model.model_name || "",
         model_lookup_key: model.lookup_key || "",
         model_pool: state.modelFolder,
-        model_pool_rule: state.modelFolder === "pn" ? "pn_allows_vip_compatible" : "strict_folder_match"
+        selected_orientation: state.workType === "private" ? state.privateOrientation : "",
+        model_pool_rule: "strict_folder_match"
       },
       telegram_gate: {
         telegram_required: true,
@@ -1017,7 +1186,11 @@
       selectClient(state.clients[0].client_id);
     }
     if (!state.workType) selectWorkType("public");
-    if (!state.modelFolder) await selectFolder(state.workType === "private" ? "vip" : "travel");
+    if (state.workType === "private" && !state.privateOrientation) selectPrivateOrientation("straight");
+    if (!state.modelFolder) {
+      const access = privateEligibility();
+      await selectFolder(state.workType === "private" ? access.allowed_private_folders[0] || "standard" : "travel");
+    }
     if (!state.selectedModel) {
       const firstModel = state.models[0] || demoModelsForFolder(state.modelFolder)[0];
       if (firstModel && el.modelSelect) {
@@ -1227,6 +1400,7 @@
     state.clients = [];
     state.selectedClient = null;
     state.workType = "";
+    state.privateOrientation = "";
     state.modelFolder = "";
     state.models = [];
     state.selectedModel = null;


### PR DESCRIPTION
## Summary
- Adds authoritative Create Sessions private model access enforcement through backend members + member_packages resolution.
- Implements cumulative model folder access: Standard -> Standard, Premium -> Standard + Premium, VIP -> Standard + Premium + VIP, Black Card -> all folders including Exclusive.
- Normalizes legacy SVIP to Black Card internally.
- Enforces Straight/Gay model compatibility with model lane both allowed as compatible.
- Revalidates selected models server-side before private create.
- Keeps Telegram as a hard gate for private create.
- Adds GET /v1/admin/models/search for sanitized server-side model search.
- Retains PN only as operational compatibility, never as a membership access folder.
- Adds targeted test coverage including inactive, expired, guest, unknown, forged entitlement, lane, Telegram gate, and public-work behavior.

## Deployment
- No production deploy performed.
- Source-code route addition only; no production route activation in this PR.

## Companion PR
- Parent MMDPrive PR: https://github.com/mmdprive/MMDPrive/pull/9