### PR TITLE
fix(telegram): correct HYPE preview button URLs

### DIFF
--- a/telegram-worker/lib/hype-preview.js
+++ b/telegram-worker/lib/hype-preview.js
@@ -274,6 +274,11 @@ function signupUrl(code, campaignId, env) {
   return withPreviewQuery(base, code, campaignId);
 }
 
+function applyMembershipUrl(code, campaignId, env) {
+  const base = str(env.HYPE_PREVIEW_APPLY_URL || "https://mmdbkk.com/member/apply");
+  return withPreviewQuery(base, code, campaignId);
+}
+
 function withPreviewQuery(base, code, campaignId) {
   const url = new URL(base);
   url.searchParams.set("promo", code);
@@ -283,7 +288,7 @@ function withPreviewQuery(base, code, campaignId) {
 }
 
 function hallUrl(code, campaignId, env) {
-  return withPreviewQuery(str(env.HYPE_PREVIEW_HALL_URL || "https://mmdbkk.com/hall"), code, campaignId);
+  return withPreviewQuery(str(env.HYPE_PREVIEW_PROFILES_URL || "https://mmdbkk.com/profiles"), code, campaignId);
 }
 
 function bookingUrl(code, campaignId, env) {
@@ -301,7 +306,7 @@ export function inlineButtons(code, campaignId, env) {
         { text: "Preview Models", url: hallUrl(code, campaignId, env) },
         { text: "Booking", url: bookingUrl(code, campaignId, env) },
       ],
-      [{ text: "Apply for Membership", url: signupUrl(code, campaignId, env) }],
+      [{ text: "Apply for Membership", url: applyMembershipUrl(code, campaignId, env) }],
       [{ text: "Our Benefits", url: benefitsUrl(code, campaignId, env) }],
       [{ text: "Back to Preview Channel", url: str(env.HYPE_PREVIEW_CHANNEL_URL || "https://t.me/MMDPriveTH") }],
     ],

--- a/telegram-worker/test/hype-preview-buttons.test.mjs
+++ b/telegram-worker/test/hype-preview-buttons.test.mjs
@@ -46,25 +46,32 @@ describe("HYPE preview inline buttons", () => {
     assertPreviewParams(byLabel(markup, "Apply for Membership").url);
     assertPreviewParams(byLabel(markup, "Our Benefits").url);
 
-    assert.equal(new URL(byLabel(markup, "Preview Models").url).pathname, "/hall");
+    assert.equal(new URL(byLabel(markup, "Preview Models").url).pathname, "/profiles");
     assert.equal(new URL(byLabel(markup, "Booking").url).pathname, "/sigil/booking");
-    assert.equal(new URL(byLabel(markup, "Apply for Membership").url).pathname, "/trust/inme");
+    assert.equal(new URL(byLabel(markup, "Apply for Membership").url).pathname, "/member/apply");
     assert.equal(new URL(byLabel(markup, "Our Benefits").url).pathname, "/member/membership");
     assert.equal(byLabel(markup, "Back to Preview Channel").url, "https://t.me/MMDPriveTH");
+
+    for (const button of flatButtons(markup)) {
+      assert.doesNotMatch(button.url, /\/hall(?:[/?#]|$)/);
+      assert.doesNotMatch(button.url, /\/membership\/benefits(?:[/?#]|$)/);
+      assert.doesNotMatch(button.url, /line|liff/i);
+    }
+    assert.doesNotMatch(byLabel(markup, "Our Benefits").url, /\/pay\/membership(?:[/?#]|$)/);
   });
 
   it("honors safe URL env overrides without using legacy benefits URL", () => {
     const markup = inlineButtons(CODE, CAMPAIGN, {
-      HYPE_PREVIEW_HALL_URL: "https://example.com/custom-hall",
+      HYPE_PREVIEW_PROFILES_URL: "https://example.com/custom-profiles",
       HYPE_PREVIEW_BOOKING_URL: "https://example.com/custom-booking",
-      HYPE_PREVIEW_SIGNUP_URL: "https://example.com/custom-signup",
+      HYPE_PREVIEW_APPLY_URL: "https://example.com/custom-apply",
       HYPE_PREVIEW_PACKAGES_URL: "https://example.com/member/membership",
       HYPE_PREVIEW_CHANNEL_URL: "https://t.me/customPreview",
     });
 
-    assert.equal(new URL(byLabel(markup, "Preview Models").url).pathname, "/custom-hall");
+    assert.equal(new URL(byLabel(markup, "Preview Models").url).pathname, "/custom-profiles");
     assert.equal(new URL(byLabel(markup, "Booking").url).pathname, "/custom-booking");
-    assert.equal(new URL(byLabel(markup, "Apply for Membership").url).pathname, "/custom-signup");
+    assert.equal(new URL(byLabel(markup, "Apply for Membership").url).pathname, "/custom-apply");
     assert.equal(new URL(byLabel(markup, "Our Benefits").url).pathname, "/member/membership");
     assert.doesNotMatch(byLabel(markup, "Our Benefits").url, /\/membership\/benefits/);
     assert.equal(byLabel(markup, "Back to Preview Channel").url, "https://t.me/customPreview");


### PR DESCRIPTION
## Summary
Corrects the HYPE Telegram Preview 5-button destination URLs after real Telegram smoke showed the buttons were visible but some links were wrong.

Locked routes:
- Preview Models -> /profiles
- Booking -> /sigil/booking
- Apply for Membership -> /member/apply
- Our Benefits -> /member/membership
- Back to Preview Channel -> Telegram Preview Channel

## Guardrails
- HYPE stays Telegram Preview only
- No LINE / LIFF main-route usage
- LINE central / Hi Per / Per AI untouched
- chat-worker untouched
- payment/membership verification untouched
- points crediting untouched
- Black Card approval untouched
- SVIP untouched
- booking confirmation untouched
- SIGIL route ownership untouched
- secrets untouched
- micro-QA still skipped

## Verification
- node --check telegram-worker/lib/hype-preview.js
- node --test telegram-worker/test/*.test.mjs

Do not deploy until PR is reviewed/merged.