### PR TITLE
fix: lock member application to /sigil/member/apply

### DIFF
--- a/webflow/member/apply/README.md
+++ b/webflow/member/apply/README.md
@@ -1,162 +1,60 @@
 # MMD Privé Member Application Gate
 
-Production-oriented Webflow module for `/member/apply`.
+Canonical frontend route: `/sigil/member/apply`.
 
-## Files
+## Webflow placement
 
-- `member-apply.html` — page markup and connection contract
-- `member-apply.css` — mobile-first visual system
-- `member-apply.js` — five-step wizard, validation, review, draft restore
-- `member-apply-os.css` — Worker health status styles
-- `member-apply-os.js` — resilient submission, offline queue, retry, duplicate guard and analytics hooks
+- HTML: Webflow Embed
+- CSS: Page Settings, before `</head>`
+- JS: Page Settings, before `</body>`
 
-## Webflow load order
-
-```html
-<link rel="stylesheet" href="https://models.mmdbkk.com/webflow/member/apply/member-apply.css">
-<link rel="stylesheet" href="https://models.mmdbkk.com/webflow/member/apply/member-apply-os.css">
-```
-
-Paste `member-apply.html` into the Webflow Embed element.
-
-Load scripts before `</body>`:
-
-```html
-<script src="https://models.mmdbkk.com/webflow/member/apply/member-apply.js"></script>
-<script src="https://models.mmdbkk.com/webflow/member/apply/member-apply-os.js"></script>
-```
-
-The OS add-on must load after the base wizard script. It intercepts the final form submission in capture phase and becomes the authoritative browser submission layer.
-
-## Connection contract
-
-All public configuration lives on the root HTML element:
+## Public configuration
 
 ```html
 data-api-base="https://sigil.mmdbkk.com"
 data-submit-path="/v1/member/applications"
-data-dashboard-url="/member/dashboard"
+data-dashboard-url="/sigil/member/dashboard"
 data-membership-url="/member/membership"
 data-help-url="https://t.me/mmdapply"
 ```
 
-Optional:
+No secret, bearer token, API key, confirm key, or admin credential belongs in the frontend.
 
-```html
-data-health-path="/ping"
-```
-
-No secret, bearer token or API key belongs in these attributes or any frontend file.
-
-## Worker request
+## Request contract
 
 ```http
 POST https://sigil.mmdbkk.com/v1/member/applications
 Content-Type: application/json
 X-Idempotency-Key: member-apply:YYYY-MM-DD:<fingerprint>
-X-MMD-Client: member-apply-os/1.0.0
 ```
 
-The request body includes:
-
-- canonical query fields: `t`, `code`, `promo`
-- member profile and contact fields
-- `primary_channel`: `line | telegram | email`
-- application intent and preference arrays
-- consent flags
-- `client_version`, `timezone`, `locale`, `page_url`, `submitted_at`
-
-## Recommended Worker response
+Required locks:
 
 ```json
 {
-  "ok": true,
-  "application_reference": "MMD-MA-260710-AB12",
-  "status": "received",
-  "next_url": "/member/membership"
+  "source": "member_apply",
+  "route": "/sigil/member/apply"
 }
 ```
 
-Accepted reference aliases in the current frontend:
+The page preserves `t`, `code`, and `promo` and carries them into Membership and Member Dashboard links.
 
-- `application_reference`
-- `reference`
-- `application_id`
-- `id`
+## Browser privacy
 
-## Duplicate and idempotency behavior
+Draft data uses `sessionStorage`, not `localStorage`. The draft is scoped to the current browser tab/session and is removed after successful submission.
 
-The frontend derives a one-way SHA-256 fingerprint from normalized contact/application identifiers. It does not send a device fingerprint containing hardware or invasive browser attributes.
+## Member lane
 
-- duplicate submissions from the same browser are blocked for 10 minutes
-- an `X-Idempotency-Key` is sent to the Worker
-- the Worker should persist and enforce that key
-- HTTP `409` is treated as an already-created application, not a fatal failure
-
-Backend idempotency remains authoritative.
-
-## Offline queue
-
-When offline or when a retryable network/Worker failure occurs, the request is stored in localStorage under:
-
-```text
-mmd_member_application_queue_v1
-```
-
-The queue is retried when the browser emits the `online` event or on the next page load. It keeps at most 10 requests.
-
-The draft and queue remain local to the browser. Never place server secrets or internal notes in either payload.
-
-## Retry policy
-
-Retryable conditions:
-
-- timeout / aborted request
-- offline network
-- HTTP 408, 425, 429
-- HTTP 5xx
-
-Policy:
-
-- maximum 5 attempts
-- exponential backoff
-- jitter added to reduce request bursts
-
-Validation and non-retryable 4xx responses are shown to the user without automatic retries.
-
-## Analytics hooks
-
-The OS layer dispatches browser events and also pushes to `window.dataLayer` when available.
-
-Event names include:
-
-- `mmd:member_application_os_ready`
-- `mmd:member_application_submit_started`
-- `mmd:member_application_retry`
-- `mmd:member_application_queued`
-- `mmd:member_application_success`
-- `mmd:member_application_submit_failed`
-- `mmd:member_application_duplicate_blocked`
-
-No analytics vendor is embedded. The page only emits neutral events.
-
-## Production checklist
-
-1. Implement `POST /v1/member/applications` on `sigil.mmdbkk.com`.
-2. Implement CORS for the approved MMD/Webflow origins.
-3. Support `OPTIONS` preflight for `X-Idempotency-Key` and `X-MMD-Client`.
-4. Return a stable `application_reference`.
-5. Enforce backend idempotency.
-6. Validate and sanitize all fields server-side.
-7. Rate limit abusive requests without blocking normal retries.
-8. Confirm `/ping` is public-safe or change `data-health-path`.
-9. Deploy assets from GitHub to R2 and load them from `models.mmdbkk.com`.
-10. Smoke test online, offline, timeout, 409, 422, 429 and 500 states.
-
-## Route locks
-
-- `/member/apply` is a member application gate, not model recruitment.
 - Kenji is the client/member continuity surface.
-- `/member/membership` owns package selection.
-- `/member/dashboard` owns member home/status continuity.
-- query parameters `t`, `code` and `promo` are preserved into both routes.
+- The page is for MMD membership, Public Models, curated male-model services, and member privileges.
+- It is not model recruitment.
+- Membership selection remains at `/member/membership`.
+- Member continuity goes to `/sigil/member/dashboard`.
+
+## Deployment order
+
+1. Deploy the Worker/backend contract accepting `route = /sigil/member/apply`.
+2. Publish the Webflow frontend at `/sigil/member/apply`.
+3. Verify `POST /v1/member/applications` with `t`, `code`, and `promo`.
+4. Confirm successful responses return a stable `application_reference`.
+5. Smoke test online, timeout, validation, duplicate, and error states.

--- a/webflow/member/apply/member-application.contract.json
+++ b/webflow/member/apply/member-application.contract.json
@@ -35,7 +35,7 @@
     "phone": { "type": "string", "minLength": 1, "maxLength": 30 },
     "application_intent": {
       "type": "string",
-      "enum": ["new_membership", "renew_membership", "upgrade_membership", "continue_application"]
+      "enum": ["public_models", "mmd_curated_models", "member_privileges", "continue_application"]
     },
     "notes": { "type": "string", "maxLength": 1200 },
     "languages": {
@@ -50,14 +50,14 @@
       "uniqueItems": true,
       "items": {
         "type": "string",
-        "enum": ["membership", "private_models", "public_work", "travel", "black_card"]
+        "enum": ["public_models", "model_matching", "membership", "promotion", "black_card"]
       }
     },
     "care_preference": { "type": "string", "maxLength": 900 },
     "consent_accuracy": { "const": true },
     "consent_privacy": { "const": true },
     "source": { "const": "member_apply" },
-    "route": { "const": "/member/apply" },
+    "route": { "const": "/sigil/member/apply" },
     "page_url": { "type": "string", "format": "uri", "maxLength": 4096 },
     "submitted_at": { "type": "string", "format": "date-time" },
     "client_version": { "type": "string", "maxLength": 80 },


### PR DESCRIPTION
## Summary

- updates the member application JSON contract to require `route = /sigil/member/apply`
- keeps `source = member_apply`
- aligns accepted intent and interest values with the current V6/V7 member application UI
- updates deployment documentation for `/sigil/member/apply`
- locks Member Dashboard continuity to `/sigil/member/dashboard`
- documents `sessionStorage` as the only browser draft storage

## Deployment order

1. Deploy backend validation that accepts `/sigil/member/apply`.
2. Publish the Webflow page at `/sigil/member/apply`.
3. Verify `POST https://sigil.mmdbkk.com/v1/member/applications`.
4. Confirm `t`, `code`, and `promo` are preserved.

## Safety

This PR intentionally does not include the earlier truncated front-gate replacement. PR #157 was closed without merge.