### PR TITLE
feat(kenji): add versioned knowledge source of truth

### DIFF
--- a/knowledge/kenji/README.md
+++ b/knowledge/kenji/README.md
@@ -1,0 +1,10 @@
+# Kenji Versioned Knowledge
+
+This directory is the Git source of truth for Kenji AI knowledge content and safety policy.
+
+## Operating model
+
+- Git stores canonical knowledge, schema, routes, boundaries, and published cards.
+- Pull requests are the review and approval gate.
+- Workers may load only validated published cards.
+- Internal admin pages may draft, preview, and propose changes, but must not become the final source of truth by themselves

--- a/knowledge/kenji/boundaries.json
+++ b/knowledge/kenji/boundaries.json
@@ -1,0 +1,26 @@
+{
+  "version": "1.0.0",
+  "allowed": [
+    "acknowledge_intent",
+    "explain_public_route",
+    "summarize_safe_backend_status",
+    "collect_non_sensitive_context",
+    "guide_next_step",
+    "escalate_to_mmd"
+  ],
+  "forbidden": [
+    "approve_payment",
+    "mark_paid",
+    "verify_slip",
+    "unlock_membership",
+    "grant_vip",
+    "grant_svip",
+    "grant_black_card",
+    "mutate_backend_state",
+    "expose_private_identifiers",
+    "expose_admin_notes",
+    "expose_raw_payment_reference",
+    "call_admin_mutation_from_public_chat"
+  ],
+  "safe_fallback": "ผมยังยืนยันเรื่องนี้จากข้อความเพียงอย่างเดียวไม่ได้ครับ ผมจะพาไปยังขั้นตอนที่ถูกต้อง หรือส่งให้ MMD ตรวจต่อครับ"
+}

--- a/knowledge/kenji/cards/membership/member-status-review-required-th.json
+++ b/knowledge/kenji/cards/membership/member-status-review-required-th.json
@@ -1,0 +1,33 @@
+{
+  "id": "member-status-review-required-th",
+  "version": 1,
+  "status": "published",
+  "lane": "membership",
+  "audience": ["member"],
+  "language": "th",
+  "title": "สมาชิกถามว่าสถานะ active หรือยัง",
+  "questions": [
+    "สมาชิก active หรือยัง",
+    "เข้า dashboard ได้ไหม"
+  ],
+  "safe_answer": "ผมยังยืนยันสถานะสมาชิกจากข้อความนี้ไม่ได้ครับ กรุณาเปิด Member Dashboard เพื่อตรวจสถานะที่ระบบอนุญาตให้แสดง หากยังขึ้นว่าต้องตรวจเพิ่มเติม ผมจะส่งเรื่องให้ MMD ตรวจต่อครับ",
+  "allowed_actions": [
+    "explain_safe_status",
+    "route_to_member_dashboard",
+    "escalate_identity_mismatch"
+  ],
+  "forbidden_actions": [
+    "unlock_membership",
+    "set_member_active",
+    "infer_identity_from_chat"
+  ],
+  "escalate_when": [
+    "unclear_identity",
+    "account_mismatch",
+    "manual_review"
+  ],
+  "safe_routes": ["/member/dashboard"],
+  "owner": "Ewvon",
+  "final_reviewer": "Boss Per",
+  "change_reason": "ใช้ตอบเมื่อยังไม่มี authoritative member status ที่ยืนยันได้"
+}

--- a/knowledge/kenji/cards/payment/payment-proof-under-review-th.json
+++ b/knowledge/kenji/cards/payment/payment-proof-under-review-th.json
@@ -1,0 +1,33 @@
+{
+  "id": "payment-proof-under-review-th",
+  "version": 1,
+  "status": "published",
+  "lane": "payment",
+  "audience": ["public_member", "member"],
+  "language": "th",
+  "title": "ลูกค้าส่งสลิปแล้วถามว่าจ่ายสำเร็จหรือยัง",
+  "questions": [
+    "ส่งสลิปแล้ว จ่ายสำเร็จหรือยัง",
+    "ช่วยเช็กยอดให้หน่อย"
+  ],
+  "safe_answer": "ผมรับทราบว่าคุณส่งหลักฐานแล้วครับ แต่ยังยืนยันสถานะชำระเงินจากข้อความเพียงอย่างเดียวไม่ได้ MMD จะตรวจผ่านระบบอย่างเป็นทางการก่อนเปลี่ยนสถานะ คุณสามารถติดตามขั้นตอนต่อได้ที่หน้าชำระเงินครับ",
+  "allowed_actions": [
+    "acknowledge_evidence",
+    "explain_review_process",
+    "route_to_payment_status"
+  ],
+  "forbidden_actions": [
+    "mark_paid",
+    "verify_slip",
+    "unlock_membership"
+  ],
+  "escalate_when": [
+    "amount_mismatch",
+    "refund_request",
+    "payment_dispute"
+  ],
+  "safe_routes": ["/sigil/pay"],
+  "owner": "Boss Per",
+  "final_reviewer": "Boss Per",
+  "change_reason": "ใช้เป็นคำตอบมาตรฐานเมื่อมีหลักฐานการชำระเงินแต่ backend ยังไม่ยืนยันสถานะ"
+}

--- a/knowledge/kenji/escalation.json
+++ b/knowledge/kenji/escalation.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0.0",
+  "required_triggers": [
+    "payment_confirmation",
+    "refund_request",
+    "payment_dispute",
+    "amount_mismatch",
+    "vip_request",
+    "svip_legacy_request",
+    "black_card_request",
+    "complaint",
+    "privacy_concern",
+    "unclear_identity",
+    "account_mismatch",
+    "manual_review",
+    "approval_request",
+    "unlock_request",
+    "access_change",
+    "entitlement_change",
+    "route_ownership_change",
+    "admin_action"
+  ],
+  "destination": "Boss Per / MMD",
+  "public_reply": "เรื่องนี้ต้องให้ Boss Per หรือ MMD ตรวจจากระบบที่เชื่อถือได้ก่อนครับ ผมจะไม่ยืนยันหรือเปลี่ยนสถานะแทนระบบ"
+}

--- a/knowledge/kenji/manifest.json
+++ b/knowledge/kenji/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "mmd-kenji-knowledge",
+  "version": "1.0.0",
+  "status": "draft",
+  "schema_version": "1.0.0",
+  "default_language": "th",
+  "source_of_truth": "git",
+  "review_gate": "pull_request",
+  "final_reviewer": "Boss Per",
+  "allowed_owners": ["Boss Per", "Ewvon", "Chang"],
+  "published_status": "published",
+  "cards_root": "knowledge/kenji/cards",
+  "policy_files": [
+    "knowledge/kenji/routes.json",
+    "knowledge/kenji/boundaries.json",
+    "knowledge/kenji/escalation.json"
+  ]
+}

--- a/knowledge/kenji/routes.json
+++ b/knowledge/kenji/routes.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0.0",
+  "public_and_member_safe_routes": {
+    "/sigil/inme": "Client entry and orientation",
+    "/sigil/start": "Guided start",
+    "/sigil/guide": "Guide selection and explanation",
+    "/sigil/booking": "Booking request flow",
+    "/sigil/pay": "Payment and renewal guidance",
+    "/member/dashboard": "Member home and safe status surface",
+    "/sigil/member/account": "Member account surface",
+    "/sigil/apply": "Model and applicant routing only"
+  },
+  "forbidden_route_classes": [
+    "internal_admin",
+    "secret_worker_route",
+    "service_binding_alias",
+    "mutation_endpoint",
+    "tokenized_private_route"
+  ]
+}

--- a/knowledge/kenji/schema.json
+++ b/knowledge/kenji/schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://mmdbkk.com/schemas/kenji-knowledge-card-v1.json",
+  "title": "Kenji Knowledge Card",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "id",
+    "version",
+    "status",
+    "lane",
+    "audience",
+    "language",
+    "title",
+    "questions",
+    "safe_answer",
+    "allowed_actions",
+    "forbidden_actions",
+    "escalate_when",
+    "safe_routes",
+    "owner",
+    "final_reviewer"
+  ],
+  "properties": {
+    "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]+$" },
+    "version": { "type": "integer", "minimum": 1 },
+    "status": { "enum": ["draft", "review", "published", "archived"] },
+    "lane": { "enum": ["membership", "renewal", "payment", "booking", "guide", "travel", "support", "apply-routing", "privacy", "rules", "escalation"] },
+    "audience": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "enum": ["public", "public_member", "member", "premium", "vip_review", "blackcard_review", "internal_only"] }
+    },
+    "language": { "enum": ["th", "en", "zh", "jp"] },
+    "title": { "type": "string", "minLength": 3, "maxLength": 160 },
+    "questions": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+    "safe_answer": { "type": "string", "minLength": 20, "maxLength": 5000 },
+    "allowed_actions": { "type": "array", "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+    "forbidden_actions": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+    "escalate_when": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 }, "uniqueItems": true },
+    "safe_routes": { "type": "array", "items": { "type": "string", "pattern": "^/" }, "uniqueItems": true },
+    "owner": { "enum": ["Boss Per", "Ewvon", "Chang"] },
+    "final_reviewer": { "const": "Boss Per" },
+    "change_reason": { "type": "string", "maxLength": 1200 },
+    "notes": { "type": "string", "maxLength": 1200 }
+  }
+}

--- a/knowledge/kenji/validate.mjs
+++ b/knowledge/kenji/validate.mjs
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const cardsRoot = path.join(here, "cards");
+const routes = JSON.parse(fs.readFileSync(path.join(here, "routes.json"), "utf8"));
+const safeRoutes = new Set(Object.keys(routes.public_and_member_safe_routes || {}));
+const allowedOwners = new Set(["Boss Per", "Ewvon", "Chang"]);
+const allowedStatuses = new Set(["draft", "review", "published", "archived"]);
+const forbiddenPatterns = [
+  /authorization:\s*bearer/i,
+  /x-confirm-key/i,
+  /api[_-]?key/i,
+  /client_secret/i,
+  /line_user_id/i,
+  /telegram_id/i,
+  /memberstack_id/i,
+  /airtable record/i,
+  /mark\s*paid/i,
+  /unlock(?:ed)?\s*membership/i
+];
+
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return walk(full);
+    return entry.name.endsWith(".json") ? [full] : [];
+  });
+}
+
+function fail(file, message) {
+  console.error(`FAIL ${path.relative(here, file)}: ${message}`);
+  process.exitCode = 1;
+}
+
+for (const file of walk(cardsRoot)) {
+  let card;
+  try {
+    card = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (error) {
+    fail(file, `invalid JSON: ${error.message}`);
+    continue;
+  }
+
+  const required = [
+    "id", "version", "status", "lane", "audience", "language", "title",
+    "questions", "safe_answer", "allowed_actions", "forbidden_actions",
+    "escalate_when", "safe_routes", "owner", "final_reviewer"
+  ];
+
+  for (const key of required) {
+    if (card[key] === undefined || card[key] === null || card[key] === "") {
+      fail(file, `missing required field ${key}`);
+    }
+  }
+
+  if (!/^[a-z0-9][a-z0-9-]+$/.test(card.id || "")) fail(file, "invalid id");
+  if (!Number.isInteger(card.version) || card.version < 1) fail(file, "version must be a positive integer");
+  if (!allowedStatuses.has(card.status)) fail(file, `invalid status ${card.status}`);
+  if (!allowedOwners.has(card.owner)) fail(file, `invalid owner ${card.owner}`);
+  if (card.final_reviewer !== "Boss Per") fail(file, "final_reviewer must be Boss Per");
+
+  for (const route of card.safe_routes || []) {
+    if (!safeRoutes.has(route)) fail(file, `unsafe or unknown route ${route}`);
+  }
+
+  const text = JSON.stringify(card);
+  for (const pattern of forbiddenPatterns) {
+    if (pattern.test(text)) fail(file, `forbidden content matched ${pattern}`);
+  }
+
+  if (!Array.isArray(card.forbidden_actions) || card.forbidden_actions.length === 0) {
+    fail(file, "forbidden_actions must not be empty");
+  }
+
+  if (!Array.isArray(card.escalate_when) || card.escalate_when.length === 0) {
+    fail(file, "escalate_when must not be empty");
+  }
+
+  console.log(`OK   ${path.relative(here, file)}`);
+}
+
+if (process.exitCode) process.exit(process.exitCode);
+console.log("Kenji knowledge validation passed.");


### PR DESCRIPTION
## What changed

- adds `knowledge/kenji` as the Git source of truth for Kenji knowledge
- adds manifest, JSON Schema, safe routes, reply boundaries, and escalation policy
- adds starter Thai knowledge cards for payment review and unresolved member status
- adds a dependency-free Node validator for card structure, route allowlisting, owners, reviewer lock, and forbidden content

## Why

Kenji knowledge should be reviewed, versioned, auditable, and reversible through Git and pull requests. The Internal Admin page remains an authoring and preview surface, not the final authority.

## Safety locks

- Kenji may guide, explain, route, summarize safe backend status, and escalate
- Kenji must not approve payment, mark paid, unlock membership, grant VIP/SVIP/Black Card, mutate backend state, or expose private data
- final reviewer is locked to Boss Per
- allowed owners are Boss Per, Ewvon, and Chang
- only allowlisted public/member-safe routes may appear in knowledge cards

## Validation

Run:

```bash
node knowledge/kenji/validate.mjs
```

## Not included

- no worker loader integration
- no production deployment
- no Webflow publication
- no merge
