### PR TITLE
Add SIGIL origin to admin-worker CORS

### DIFF
--- a/admin-worker/wrangler.toml
+++ b/admin-worker/wrangler.toml
@@ -8,7 +8,7 @@ workers_dev = true
 
 # ใช้สำหรับ CORS (browser calls)
 [vars]
-ALLOWED_ORIGINS = "https://mmdbkk.com,https://www.mmdbkk.com,https://mmdprive.com,https://www.mmdprive.com,https://mmdprive.webflow.io"
+ALLOWED_ORIGINS = "https://mmdbkk.com,https://www.mmdbkk.com,https://mmdprive.webflow.io,https://sigil.mmdbkk.com,https://mmdprive.com,https://www.mmdprive.com"
 
 # Base URLs (LOCK)
 PAYMENTS_BASE_URL = "https://payments-worker.malemodel-bkk.workers.dev"


### PR DESCRIPTION
## Summary

Updates `admin-worker/wrangler.toml` so browser calls to the admin dashboard worker are allowed from the active MMD/SIGIL domains.

## Changed

`ALLOWED_ORIGINS` now includes:

```text
https://mmdbkk.com
https://www.mmdbkk.com
https://mmdprive.webflow.io
https://sigil.mmdbkk.com
https://mmdprive.com
https://www.mmdprive.com
```

## Why

`/internal/admin/dashboard` is now calling:

```text
https://admin-worker.malemodel-bkk.workers.dev/v1/admin/dashboard
```

from browser context. If the page is served from `sigil.mmdbkk.com`, the worker must include that origin in CORS, otherwise the frontend can show `Failed to fetch` before auth is evaluated.

## Safety

- No secrets changed
- No route logic changed
- No Airtable schema changed
- No dashboard-worker code changed
- Only worker CORS vars changed

## Deploy after merge

```bash
cd admin-worker
npx wrangler deploy --config wrangler.toml
```