### PR TITLE
docs: define SIGIL availability and Kenji safe match layers

### DIFF
--- a/admin-worker/member-dashboard.test.mjs
+++ b/admin-worker/member-dashboard.test.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "./src/dashboard-worker.js";
+
+const TABLES = {
+  "MMD — Auth Sessions": [],
+  "MMD — Auth Identities": [],
+  Members: [],
+  "MMD — Member Entitlements": [],
+  Payments: [],
+  Sessions: [],
+  "MMD — Points Ledger": [],
+  "MMD — LIFF Renewal Sessions": [],
+};
+
+function record(id, fields) {
+  return { id, fields };
+}
+
+function fixtures(overrides = {}) {
+  return {
+    ...TABLES,
+    "MMD — Auth Sessions": [record("recAuth", { token: "valid-token", member_id: "member-1" })],
+    Members: [record("recMember", { member_id: "member-1", display_name: "Kenji Member" })],
+    ...overrides,
+  };
+}
+
+function jsonResponse(value, status = 200) {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function dashboardRequest(query, tableFixtures = fixtures(), { failTable = "" } = {}) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = new URL(typeof input === "string" ? input : input.url);
+    const tableName = decodeURIComponent(url.pathname.split("/").at(-1));
+    if (tableName === failTable) return jsonResponse({ error: "upstream_failure" }, 500);
+    return jsonResponse({ records: tableFixtures[tableName] || [] });
+  };
+
+  try {
+    const response = await worker.fetch(
+      new Request(`https://admin-worker.test/v1/member/dashboard${query}`),
+      { AIRTABLE_API_KEY: "test-key", AIRTABLE_BASE_ID: "test-base" },
+    );
+    return { response, body: await response.json() };
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+test("missing t returns 404 invalid_link without loading Airtable", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => assert.fail("Airtable must not be called without t");
+  try {
+    const response = await worker.fetch(
+      new Request("https://admin-worker.test/v1/member/dashboard?code=ignored"),
+      {},
+    );
+    assert.equal(response.status, 404);
+    assert.deepEqual(await response.json(), {
+      ok: false,
+      state: "invalid_link",
+      message: "ไม่พบลิงก์ส่วนตัวครับ",
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("unknown t returns 404 invalid_link", async () => {
+  const { response, body } = await dashboardRequest("?t=unknown");
+  assert.equal(response.status, 404);
+  assert.equal(body.state, "invalid_link");
+});
+
+test("approved entitlement maps to active", async () => {
+  const data = fixtures({
+    "MMD — Member Entitlements": [record("recEnt", { member_id: "member-1", status: "approved", tier: "PRIVATE" })],
+  });
+  const { response, body } = await dashboardRequest("?t=valid-token", data);
+  assert.equal(response.status, 200);
+  assert.equal(body.data.dashboard_state, "active");
+  assert.equal(body.data.access.status, "active");
+});
+
+test("ended entitlement maps to expired with renewal URL", async () => {
+  const data = fixtures({
+    "MMD — Member Entitlements": [record("recEnt", { member_id: "member-1", status: "ended" })],
+  });
+  const { body } = await dashboardRequest("?t=valid-token", data);
+  assert.equal(body.data.dashboard_state, "expired");
+  assert.equal(body.data.actions.renewal_url, "/sigil/pay/renewal?t=valid-token");
+});
+
+test("pending verification maps to pending with payment URL", async () => {
+  const data = fixtures({
+    Payments: [record("recPayment", { member_id: "member-1", verification_status: "under_review" })],
+  });
+  const { body } = await dashboardRequest("?t=valid-token", data);
+  assert.equal(body.data.dashboard_state, "pending");
+  assert.equal(body.data.actions.payment_url, "/confirm/payment-confirmation?t=valid-token");
+});
+
+test("uploaded payment proof without verified entitlement never activates access", async () => {
+  const data = fixtures({
+    Payments: [record("recPayment", { member_id: "member-1", status: "proof_uploaded" })],
+  });
+  const { body } = await dashboardRequest("?t=valid-token", data);
+  assert.equal(body.data.dashboard_state, "pending");
+  assert.notEqual(body.data.access.status, "active");
+});
+
+test("Airtable failure returns 502 load_error", async () => {
+  const { response, body } = await dashboardRequest("?t=valid-token", fixtures(), {
+    failTable: "MMD — Member Entitlements",
+  });
+  assert.equal(response.status, 502);
+  assert.equal(body.state, "load_error");
+});
+
+test("safe campaign params are preserved and all other params are dropped", async () => {
+  const data = fixtures({
+    "MMD — Member Entitlements": [record("recEnt", { member_id: "member-1", status: "active" })],
+    Sessions: [record("recSession", { member_id: "member-1", session_id: "session/1" })],
+  });
+  const query = "?t=valid-token&code=C1&promo=P1&source=line&invite=I1&redirect=https://evil.test";
+  const { body } = await dashboardRequest(query, data);
+  const urls = Object.values(body.data.actions).filter(Boolean);
+  for (const value of urls) {
+    assert.match(value, /t=valid-token/);
+    assert.match(value, /code=C1/);
+    assert.match(value, /promo=P1/);
+    assert.match(value, /source=line/);
+    assert.match(value, /invite=I1/);
+    assert.doesNotMatch(value, /evil|redirect/);
+    const parsed = new URL(value, "https://mmdbkk.com");
+    assert.ok(["mmdbkk.com", "www.mmdbkk.com", "sigil.mmdbkk.com", "t.me"].includes(parsed.hostname));
+  }
+});
+
+test("SVIP Eligible fields are ignored", async () => {
+  const data = fixtures({
+    Members: [record("recMember", { member_id: "member-1", display_name: "Kenji Member", "SVIP Eligible": true })],
+    "MMD — Member Entitlements": [record("recEnt", { member_id: "member-1", status: "pending" })],
+  });
+  const { body } = await dashboardRequest("?t=valid-token", data);
+  assert.equal(body.data.dashboard_state, "pending");
+  assert.equal(body.data.member.tier, null);
+  assert.equal(JSON.stringify(body).includes("SVIP"), false);
+});

--- a/admin-worker/src/dashboard-worker.js
+++ b/admin-worker/src/dashboard-worker.js
@@ -12,6 +12,12 @@ import coreWorker from "./index.js";
 
 const AIRTABLE_API = "https://api.airtable.com/v0";
 const DASHBOARD_PATH = "/v1/admin/dashboard";
+const MEMBER_DASHBOARD_PATH = "/v1/member/dashboard";
+const SAFE_MEMBER_QUERY_KEYS = ["t", "code", "promo", "source", "invite"];
+const ACTIVE_STATES = new Set(["active", "approved", "valid"]);
+const EXPIRED_STATES = new Set(["expired", "inactive", "ended"]);
+const PENDING_STATES = new Set(["pending", "pending_review", "review", "awaiting_verification", "proof_uploaded", "under_review"]);
+const INVALID_STATES = new Set(["invalid", "invalid_token", "invalid_link", "token_invalid", "not_found", "unauthorized"]);
 
 export default {
   async fetch(req, env, ctx) {
@@ -22,6 +28,14 @@ export default {
 
     if (method === "OPTIONS") {
       return new Response(null, { status: 204, headers: cors });
+    }
+
+    if (path === MEMBER_DASHBOARD_PATH) {
+      if (method !== "GET") {
+        return withCors(json({ ok: false, error: "method_not_allowed" }, 405), cors);
+      }
+
+      return withCors(await handleMemberDashboard(req, env, url), cors);
     }
 
     if (path === DASHBOARD_PATH) {
@@ -43,6 +57,289 @@ export default {
     return coreWorker.fetch(req, env, ctx);
   },
 };
+
+async function handleMemberDashboard(req, env, url) {
+  const token = str(url.searchParams.get("t"));
+  if (!token) return invalidMemberDashboardLink();
+
+  try {
+    const data = await buildMemberDashboard(env, url, token);
+    if (!data) return invalidMemberDashboardLink();
+    return json({ ok: true, data });
+  } catch (error) {
+    return json({
+      ok: false,
+      state: "load_error",
+      message: "ไม่สามารถโหลดข้อมูลสมาชิกได้ครับ",
+      error: "load_error",
+    }, 502);
+  }
+}
+
+function invalidMemberDashboardLink() {
+  return json({
+    ok: false,
+    state: "invalid_link",
+    message: "ไม่พบลิงก์ส่วนตัวครับ",
+  }, 404);
+}
+
+async function buildMemberDashboard(env, url, token) {
+  const [
+    authSessions,
+    authIdentities,
+    members,
+    entitlements,
+    payments,
+    sessions,
+    pointsLedger,
+    renewals,
+  ] = await Promise.all([
+    airtableList(env, env.AIRTABLE_TABLE_AUTH_SESSIONS || "MMD — Auth Sessions", 100),
+    airtableList(env, env.AIRTABLE_TABLE_AUTH_IDENTITIES || "MMD — Auth Identities", 100),
+    airtableList(env, env.AIRTABLE_TABLE_MEMBERS || "Members", 100),
+    airtableList(env, env.AIRTABLE_TABLE_MEMBER_ENTITLEMENTS || "MMD — Member Entitlements", 100),
+    airtableList(env, env.AIRTABLE_TABLE_PAYMENTS || "Payments", 100),
+    airtableList(env, env.AIRTABLE_TABLE_SESSIONS || "Sessions", 100),
+    airtableList(env, env.AIRTABLE_TABLE_POINTS_LEDGER || "MMD — Points Ledger", 100),
+    airtableList(env, env.AIRTABLE_TABLE_LIFF_RENEWAL_SESSIONS || "MMD — LIFF Renewal Sessions", 50),
+  ]);
+
+  const authSession = authSessions.find((record) => {
+    const fields = record.fields || {};
+    if (!fieldEquals(fields, token, ["t", "token", "session_token", "link_token", "access_token", "session_id"])) return false;
+    if (firstText(fields.revoked_at, fields.revokedAt)) return false;
+    const expiresAt = parseDate(firstText(fields.expires_at, fields.expire_at, fields.expiry));
+    return !expiresAt || expiresAt.getTime() > Date.now();
+  });
+
+  if (!authSession) return null;
+
+  const sessionFields = authSession.fields || {};
+  const identity = findIdentity(authIdentities, sessionFields);
+  const identityFields = identity?.fields || {};
+  const identityContext = buildIdentityContext(sessionFields, identityFields);
+  const member = findMatchingRecord(members, identityContext);
+  const memberFields = member?.fields || {};
+  const entitlement = chooseEntitlement(entitlements.filter((record) => matchesIdentity(record.fields || {}, identityContext)));
+  const entitlementFields = entitlement?.fields || {};
+  const latestSession = chooseLatest(sessions.filter((record) => matchesIdentity(record.fields || {}, identityContext)), ["created_at", "updated_at", "start_time", "scheduled_at"]);
+  const latestPayment = chooseLatest(payments.filter((record) => matchesIdentity(record.fields || {}, identityContext)), ["created_at", "updated_at", "paid_at", "verified_at"]);
+  const renewal = chooseLatest(renewals.filter((record) => matchesIdentity(record.fields || {}, identityContext)), ["created_at", "updated_at"]);
+
+  const dashboardState = resolveDashboardState({ entitlementFields, paymentFields: latestPayment?.fields || {}, sessionFields: latestSession?.fields || {} });
+  const tier = firstText(entitlementFields.tier, entitlementFields.package_code, entitlementFields.min_tier, memberFields.tier, memberFields.package_code, memberFields.member_tier);
+  const expiresAt = firstText(entitlementFields.expire_at, entitlementFields.expires_at, entitlementFields.end_date, memberFields.expires_at, memberFields.expire_at);
+  const accessStatus = firstText(entitlementFields.access_status, entitlementFields.status, entitlementFields.member_status, dashboardState);
+  const selectedGuide = firstText(memberFields.selected_guide, memberFields.guide, identityFields.selected_guide, "");
+  const latestSessionFields = latestSession?.fields || {};
+  const latestPaymentFields = latestPayment?.fields || {};
+  const renewalFields = renewal?.fields || {};
+  const sessionId = firstText(latestSessionFields.session_id, latestSessionFields.sid, latestSessionFields.job_id, latestSession?.id);
+  const paymentRef = firstText(latestPaymentFields.payment_ref, latestPaymentFields.ref, latestSessionFields.payment_ref);
+
+  return {
+    dashboard_state: dashboardState,
+    member: {
+      display_name: firstText(memberFields.display_name, memberFields.mmd_client_name, memberFields.name, identityFields.display_name, identityFields.line_display_name, "สมาชิก MMD"),
+      tier: tier || null,
+      status: firstText(memberFields.status, memberFields.member_status, entitlementFields.member_status, dashboardState),
+      expires_at: expiresAt || null,
+    },
+    access: {
+      status: normalizeDashboardState(accessStatus),
+      tier: tier || null,
+      expire_label: formatExpireLabel(expiresAt),
+      model_access: normalizeModelAccess(entitlementFields),
+    },
+    points: buildPoints(pointsLedger.filter((record) => matchesIdentity(record.fields || {}, identityContext)), memberFields),
+    session: {
+      session_id: sessionId || null,
+      state: firstText(latestSessionFields.state, latestSessionFields.session_state, null),
+      status: firstText(latestSessionFields.status, latestSessionFields.job_status, null),
+      payment_status: firstText(latestSessionFields.payment_status, null),
+      payment_ref: paymentRef || null,
+    },
+    payment: {
+      status: firstText(latestPaymentFields.verification_status, latestPaymentFields.payment_status, latestPaymentFields.status, null),
+      payment_ref: paymentRef || null,
+    },
+    renewal: {
+      status: firstText(renewalFields.status, renewalFields.renewal_status, null),
+    },
+    guide: {
+      selected_guide: selectedGuide || null,
+    },
+    actions: buildMemberDashboardActions(url, sessionId),
+    updates: [],
+  };
+}
+
+function findIdentity(records, sessionFields) {
+  const identityId = firstText(sessionFields.identity_id, sessionFields.auth_identity_id, sessionFields.identity);
+  if (identityId) {
+    const byId = records.find((record) => record.id === identityId || fieldEquals(record.fields || {}, identityId, ["identity_id", "auth_identity_id"]));
+    if (byId) return byId;
+  }
+  const context = buildIdentityContext(sessionFields, {});
+  return findMatchingRecord(records, context);
+}
+
+function buildIdentityContext(...sources) {
+  const out = {};
+  for (const fields of sources) {
+    out.member_id ||= firstText(fields.member_id, fields.mmd_member_id, fields.client_id);
+    out.member_email ||= lower(firstText(fields.member_email, fields.email, fields.Email));
+    out.memberstack_id ||= firstText(fields.memberstack_id, fields.memberstackId);
+    out.line_user_id ||= firstText(fields.line_user_id, fields.lineUserId, fields["LINE User ID"]);
+    out.telegram_user_id ||= firstText(fields.telegram_user_id, fields.telegram_id);
+    out.telegram_username ||= lower(firstText(fields.telegram_username, fields.telegram));
+  }
+  return out;
+}
+
+function findMatchingRecord(records, identityContext) {
+  return records.find((record) => matchesIdentity(record.fields || {}, identityContext));
+}
+
+function matchesIdentity(fields, identityContext) {
+  const checks = [
+    ["member_id", ["member_id", "mmd_member_id", "client_id"]],
+    ["member_email", ["member_email", "email", "Email"]],
+    ["memberstack_id", ["memberstack_id", "memberstackId"]],
+    ["line_user_id", ["line_user_id", "lineUserId", "LINE User ID"]],
+    ["telegram_user_id", ["telegram_user_id", "telegram_id"]],
+    ["telegram_username", ["telegram_username", "telegram"]],
+  ];
+
+  return checks.some(([key, fieldNames]) => {
+    const value = identityContext[key];
+    if (!value) return false;
+    return fieldEquals(fields, value, fieldNames);
+  });
+}
+
+function fieldEquals(fields, expected, fieldNames) {
+  const target = lower(expected);
+  if (!target) return false;
+  return fieldNames.some((name) => lower(firstText(fields[name])) === target);
+}
+
+function chooseEntitlement(records) {
+  const sorted = [...records].sort((a, b) => stateRank(b.fields || {}) - stateRank(a.fields || {}));
+  return sorted[0] || null;
+}
+
+function stateRank(fields) {
+  const state = normalizeDashboardState(firstText(fields.access_status, fields.status, fields.member_status));
+  if (state === "active" && !isExpired(fields)) return 4;
+  if (state === "pending") return 3;
+  if (state === "expired" || isExpired(fields)) return 2;
+  return 1;
+}
+
+function chooseLatest(records, dateFields) {
+  return [...records].sort((a, b) => recordTime(b, dateFields) - recordTime(a, dateFields))[0] || null;
+}
+
+function recordTime(record, dateFields) {
+  const fields = record.fields || {};
+  for (const name of dateFields) {
+    const date = parseDate(fields[name]);
+    if (date) return date.getTime();
+  }
+  return 0;
+}
+
+function resolveDashboardState({ entitlementFields, paymentFields, sessionFields }) {
+  if (!entitlementFields || !Object.keys(entitlementFields).length) {
+    const paymentState = normalizeDashboardState(firstText(paymentFields.verification_status, paymentFields.payment_status, paymentFields.status));
+    const sessionState = normalizeDashboardState(firstText(sessionFields.state, sessionFields.status, sessionFields.payment_status));
+    if (paymentState === "pending" || sessionState === "pending") return "pending";
+    if (paymentState === "expired" || sessionState === "expired") return "expired";
+    return "invalid_link";
+  }
+
+  if (isExpired(entitlementFields)) return "expired";
+  const entitlementState = normalizeDashboardState(firstText(entitlementFields.access_status, entitlementFields.status, entitlementFields.member_status));
+  if (entitlementState === "active") return "active";
+  if (entitlementState === "expired") return "expired";
+  if (entitlementState === "pending") return "pending";
+  if (entitlementState === "invalid_link") return "invalid_link";
+  return "pending";
+}
+
+function normalizeDashboardState(value) {
+  const state = lower(value).replace(/[\s-]+/g, "_");
+  if (ACTIVE_STATES.has(state)) return "active";
+  if (EXPIRED_STATES.has(state)) return "expired";
+  if (PENDING_STATES.has(state)) return "pending";
+  if (INVALID_STATES.has(state)) return "invalid_link";
+  return state || "pending";
+}
+
+function isExpired(fields) {
+  const expiresAt = parseDate(firstText(fields.expire_at, fields.expires_at, fields.end_date, fields.expiry));
+  return Boolean(expiresAt && expiresAt.getTime() <= Date.now());
+}
+
+function buildPoints(records, memberFields) {
+  let active = numeric(memberFields.points_balance, memberFields.active_points, memberFields.Points);
+  let lifetime = numeric(memberFields.lifetime_points);
+  let spendYear = numeric(memberFields.spend_year, memberFields.spend_this_year);
+  let spendLifetime = numeric(memberFields.spend_lifetime, memberFields.total_spend);
+
+  for (const record of records) {
+    const fields = record.fields || {};
+    const status = normalizeDashboardState(firstText(fields.status, fields.verification_status, fields.payment_status));
+    if (status !== "active") continue;
+    const points = numeric(fields.points, fields.points_delta, fields.amount_points);
+    active += points;
+    lifetime += Math.max(0, points);
+    spendYear += numeric(fields.spend_year, fields.amount_thb);
+    spendLifetime += numeric(fields.spend_lifetime, fields.amount_thb);
+  }
+
+  return { active, lifetime, spend_year: spendYear, spend_lifetime: spendLifetime };
+}
+
+function buildMemberDashboardActions(url, sessionId) {
+  const query = safeMemberQuery(url.searchParams);
+  return {
+    renewal_url: appendSafeMemberQuery("/sigil/pay/renewal", query),
+    guide_url: appendSafeMemberQuery("/sigil/guide", query),
+    booking_url: appendSafeMemberQuery("/sigil/booking", query),
+    payment_url: appendSafeMemberQuery("/confirm/payment-confirmation", query),
+    session_url: sessionId ? appendSafeMemberQuery(`/sigil/session/${encodeURIComponent(sessionId)}`, query) : null,
+  };
+}
+
+function safeMemberQuery(params) {
+  const out = new URLSearchParams();
+  for (const key of SAFE_MEMBER_QUERY_KEYS) {
+    const value = str(params.get(key));
+    if (value) out.set(key, value);
+  }
+  return out;
+}
+
+function appendSafeMemberQuery(path, params) {
+  const rendered = params.toString();
+  return rendered ? `${path}?${rendered}` : path;
+}
+
+function normalizeModelAccess(fields) {
+  const raw = firstText(fields.model_access, fields.resource_key, fields.access_key, fields.package_code);
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw.map(str).filter(Boolean);
+  return String(raw).split(",").map(str).filter(Boolean);
+}
+
+function formatExpireLabel(value) {
+  const date = parseDate(value);
+  if (!date) return null;
+  return new Intl.DateTimeFormat("th-TH", { dateStyle: "medium", timeZone: "Asia/Bangkok" }).format(date);
+}
 
 async function buildAdminDashboard(env) {
   const now = new Date();
@@ -430,6 +727,14 @@ function amountText(...values) {
     }
   }
   return "-";
+}
+
+function numeric(...values) {
+  for (const value of values) {
+    const num = Number(value);
+    if (Number.isFinite(num)) return num;
+  }
+  return 0;
 }
 
 function parseDate(value) {

--- a/docs/architecture/SIGIL_KENJI_SAFE_MATCH_API_CONTRACT_V1.md
+++ b/docs/architecture/SIGIL_KENJI_SAFE_MATCH_API_CONTRACT_V1.md
@@ -1,0 +1,223 @@
+# SIGIL / Kenji Safe Match API Contract V1
+
+Status: docs/spec only. This architecture contract links SIGIL Availability
+Snapshot V1 and Kenji Safe Match Layer V1. It does not implement worker code,
+deploy workers, publish Webflow, alter Airtable schema, or authorize runtime
+route changes.
+
+## Locked System Names
+
+1. SIGIL Availability Snapshot V1
+2. Kenji Safe Match Layer V1
+
+## Architecture
+
+```text
+Model Console / Model App
+  -> SIGIL Availability Snapshot V1
+  -> Safe Availability KV / Index
+  -> Kenji Safe Match Layer V1
+  -> LINE / Member Dashboard / Admin Assist
+```
+
+## Core Principle
+
+Kenji must never read raw Model Console data directly.
+
+Kenji can only read sanitized availability snapshots and safe catalog fields
+after permission checks. This protects sensitive operational data that may exist
+inside Model Console / Model App, including live session state, location, ETA,
+customer identity, payment state, model decision notes, admin notes, contact
+information, and internal job context.
+
+## Source Of Truth Boundaries
+
+| Data | Source of Truth | Kenji Access |
+| --- | --- | --- |
+| model catalog identity | sanitized Model Catalog / R2 catalog | safe fields only |
+| raw model operational state | Model Console / Model App | no direct access |
+| safe availability | SIGIL Availability Snapshot V1 | yes, sanitized only |
+| private model access | backend permission gate | yes, result only |
+| membership/package truth | members + member_packages backend authority | gate result only |
+| payment truth | payment verification backend | no direct safe-match use |
+| booking/session truth | session backend | no direct booking confirmation |
+
+## Endpoint Family
+
+SIGIL Availability Snapshot V1:
+
+```http
+POST /v1/sigil/availability-snapshot
+GET /v1/sigil/availability-snapshot
+```
+
+Kenji Safe Match Layer V1:
+
+```http
+POST /v1/kenji/safe-match
+GET /v1/kenji/safe-match/:match_id
+```
+
+These are proposed API contracts only. Final route ownership, worker placement,
+auth bindings, and storage bindings require separate implementation approval.
+
+## Permission Gate Contract
+
+Kenji Safe Match requires a backend permission gate. Chat text, LINE profile,
+frontend claims, local storage, and member-submitted labels are never access
+truth.
+
+```json
+{
+  "ok": true,
+  "source": "backend_permission_gate",
+  "identity_trust": "backend_matched",
+  "booking_visibility": "private",
+  "private_access_folders": ["standard", "premium"],
+  "member_status": "active",
+  "expires_at": "2026-07-16T10:05:00.000Z"
+}
+```
+
+If the gate is missing, expired, unresolved, inactive, guest, unknown, or missing
+membership:
+
+- `private_access_folders` must be empty.
+- Protected private model names must not be returned.
+- Matching must fall back to public-safe candidates or return no safe candidates.
+
+## Availability Snapshot Contract Summary
+
+SIGIL Availability Snapshot V1 receives trusted model availability signals and
+publishes a sanitized lookup keyed by `model_key`.
+
+Allowed safe states:
+
+- `available_now`
+- `available_today`
+- `available_soon`
+- `limited`
+- `unavailable`
+- `unknown`
+
+Required safety behavior:
+
+- Expired snapshots become `unknown`.
+- Hidden or blocked operational states never normalize to available.
+- `available_now` requires short TTL and `expires_at`.
+- No raw session, location, payment, customer, contact, note, or secret fields.
+
+## Kenji Safe Match Contract Summary
+
+Kenji Safe Match combines:
+
+- sanitized Model Catalog fields
+- sanitized Availability Snapshot fields
+- backend permission gate
+- customer specs from chat/member context
+
+It returns:
+
+- `customer_spec_summary`
+- `candidate_groups`
+- safe candidate summaries
+- safe next actions
+- fallback/escalation direction
+
+It must not return:
+
+- raw identifiers
+- hidden availability
+- internal notes
+- payment truth
+- membership raw records
+- private contact data
+- private R2 object keys
+- mutation authority
+
+## Lane Compatibility
+
+Customer lane options:
+
+- `straight`
+- `gay`
+
+Model compatibility values:
+
+- `straight`
+- `gay`
+- `both`
+
+Rules:
+
+- `straight` request matches `straight` and `both`.
+- `gay` request matches `gay` and `both`.
+- `both` is internal model compatibility only and must not be shown as a customer
+  lane choice.
+
+## Candidate Group Examples
+
+```json
+{
+  "group_id": "available_today_sukhumvit",
+  "label": "Available today around Sukhumvit",
+  "safe_next_action": "continue_to_booking_review",
+  "candidates": [
+    {
+      "match_id": "safe_match_001",
+      "model_key": "model_public_001",
+      "safe_display_name": "Ken",
+      "booking_visibility": "public",
+      "model_lane": "both",
+      "safe_availability_state": "available_today",
+      "summary": "Athletic style, available today in Sukhumvit.",
+      "match_reasons": ["lane_compatible", "zone_match", "available_today"]
+    }
+  ]
+}
+```
+
+## Security And Privacy Locks
+
+- Kenji cannot confirm booking, payment, membership, VIP, Black Card, or private
+  access from chat.
+- Kenji cannot mutate model availability.
+- Kenji cannot mutate membership, session, payment, or model records.
+- Kenji cannot expose raw Model Console state.
+- Kenji cannot expose raw LINE ID, Telegram ID, email, phone, or Airtable record
+  IDs.
+- Kenji cannot expose exact live location, route, ETA, hotel, room, or private
+  address.
+- Kenji cannot expose model decision notes or admin/operator notes.
+
+## Required Future Tests
+
+Before implementation ships, add tests proving:
+
+- Kenji does not query raw Model Console data.
+- expired availability snapshots return `unknown` or no safe candidate.
+- hidden/blocked/archived/paused models are excluded.
+- public matching works without private permission.
+- private matching requires backend permission gate.
+- inactive/expired/guest/unknown members receive no private model names.
+- straight/gay lane matching includes `both`.
+- operational filters do not grant access.
+- forbidden fields are redacted.
+- no mutation occurs through safe-match endpoints.
+
+## Related Specs
+
+- `docs/sigil/SIGIL_AVAILABILITY_SNAPSHOT_V1.md`
+- `docs/kenji/KENJI_SAFE_MATCH_LAYER_V1.md`
+- `docs/kenji/KENJI_AI_V1_CONTEXT_CONTRACT.md`
+- `docs/kenji/KENJI_AI_V1_REPLY_BOUNDARIES.md`
+- `docs/r2-model-catalog-airtable-template.md`
+
+## Non-Goals
+
+- No worker implementation in this contract.
+- No deploy.
+- No Webflow publish.
+- No Airtable schema change.
+- No Model Console rewrite.
+- No Kenji LLM implementation.

--- a/docs/deployments/R2_SIGIL_PRIVATE_MODELS_ASSETS.md
+++ b/docs/deployments/R2_SIGIL_PRIVATE_MODELS_ASSETS.md
@@ -1,0 +1,57 @@
+# MMD R2 Deployment Note: SIGIL Private Models Webflow Assets
+
+Documentation date: 2026-07-15
+
+Deployment evidence:
+- R2 upload was completed before this note was added.
+- Public validation was reported on 2026-07-15 around 20:45 Asia/Bangkok.
+- Public object `Last-Modified` headers showed 2026-07-15 13:44-13:45 UTC.
+
+This note records the completed Cloudflare R2 upload for SIGIL Private Models
+Webflow assets. These assets belong to the SIGIL Private Models page family and
+related Webflow embeds, including `/sigil/private-models`.
+
+This is not a Kenji Knownledge V9.1 deployment. Do not confuse these assets with
+`webflow/internal/admin/kenji-knowledge/`, the Kenji Knownledge V9.1 Webflow
+Loader, Kenji Board bridge assets, or PR #170 Kenji Knownledge assets.
+
+## R2 Location
+
+- Bucket: `mmd-models`
+- Public domain: `https://models.mmdbkk.com`
+- Prefix: `webflow/sigil/private-models/`
+
+## Uploaded Files
+
+- `sigil-private-models.css`
+- `sigil-private-models-v2-polish.css`
+- `sigil-private-models-v3.css`
+- `sigil-private-models.js`
+- `sigil-private-models-v3.js`
+- `sigil-private-models-webflow-snippet.html`
+
+## Public URLs
+
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models.css`
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models-v2-polish.css`
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models-v3.css`
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models.js`
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models-v3.js`
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models-webflow-snippet.html`
+
+## Validation Reported
+
+- All 6 public URLs returned `HTTP/2 200`.
+- CSS assets served as `text/css`.
+- JS assets served as `application/javascript`.
+- HTML snippet served as `text/html`.
+- `Cache-Control` was set to `public, max-age=300`.
+
+## Operational Notes
+
+- The original R2 upload did not change repo files.
+- The original R2 upload did not include a commit or push.
+- The original R2 upload did not deploy Workers.
+- The original R2 upload did not publish Webflow.
+- Existing dirty worktree files were left untouched.
+- This note is documentation only and does not change code behavior.

--- a/docs/kenji/KENJI_SAFE_MATCH_LAYER_V1.md
+++ b/docs/kenji/KENJI_SAFE_MATCH_LAYER_V1.md
@@ -1,0 +1,258 @@
+# Kenji Safe Match Layer V1
+
+Status: docs/spec only. This document defines a future safe matching contract
+for Kenji in LINE/member chat. It does not implement worker code, deploy workers,
+publish Webflow, alter Airtable schema, or authorize Kenji to expose private
+model data.
+
+## Purpose
+
+Kenji Safe Match Layer V1 lets Kenji search model names, summarize customer
+specs, and suggest candidate groups using only safe sources:
+
+- sanitized Model Catalog fields
+- SIGIL Availability Snapshot V1
+- backend permission gate
+
+Kenji must never read raw Model Console data directly. Kenji must never treat
+LINE text, member chat text, local storage, or frontend claims as access truth.
+
+## Architecture Position
+
+```text
+Model Console / Model App
+  -> SIGIL Availability Snapshot V1
+  -> Safe Availability KV / Index
+  -> Kenji Safe Match Layer V1
+  -> LINE / Member Dashboard / Admin Assist
+```
+
+## Proposed Endpoint Contract
+
+Primary match endpoint:
+
+```http
+POST /v1/kenji/safe-match
+```
+
+Optional match detail endpoint:
+
+```http
+GET /v1/kenji/safe-match/:match_id
+```
+
+These route names are contract placeholders. Final worker ownership and route
+bindings must be approved before implementation.
+
+## Auth Rules
+
+- Endpoint access requires Kenji backend/service auth.
+- Public LINE clients must not call this endpoint directly.
+- Member Dashboard callers must go through the approved backend path.
+- The endpoint must require a backend permission gate result before returning
+  private candidates.
+- No bearer token, confirm key, service token, or internal route key may be
+  returned in the response.
+
+## Request Shape
+
+```json
+{
+  "request_id": "kenji_match_20260716_001",
+  "channel": "line",
+  "locale": "th-TH",
+  "query": "หุ่น athletic ว่างวันนี้ แถวสุขุมวิท",
+  "customer_specs": {
+    "lane": "gay",
+    "city": "Bangkok",
+    "zones": ["sukhumvit"],
+    "date": "2026-07-16",
+    "time_bucket": "today",
+    "budget_thb": {
+      "min": 6000,
+      "max": 12000
+    },
+    "preferences": ["athletic", "friendly"],
+    "operational_filters": {
+      "burn": false,
+      "mk": false,
+      "live": true,
+      "available": true
+    }
+  },
+  "identity_context": {
+    "trust": "backend_matched"
+  },
+  "permission_scope": {
+    "source": "backend_permission_gate",
+    "booking_visibility": "public",
+    "private_access_folders": []
+  },
+  "limit": 5
+}
+```
+
+## Response Shape
+
+```json
+{
+  "ok": true,
+  "layer": "kenji_safe_match_v1",
+  "request_id": "kenji_match_20260716_001",
+  "match_policy": {
+    "booking_visibility": "public",
+    "permission_gate_applied": true,
+    "availability_snapshot_applied": true,
+    "private_access_applied": false
+  },
+  "customer_spec_summary": {
+    "lane": "gay",
+    "city": "Bangkok",
+    "zones": ["sukhumvit"],
+    "time_bucket": "today",
+    "safe_summary": "Looking for gay-compatible candidates around Sukhumvit today."
+  },
+  "candidate_groups": [
+    {
+      "group_id": "available_today_sukhumvit",
+      "label": "Available today around Sukhumvit",
+      "safe_next_action": "continue_to_booking_review",
+      "candidates": [
+        {
+          "match_id": "safe_match_001",
+          "model_key": "model_public_001",
+          "safe_display_name": "Ken",
+          "booking_visibility": "public",
+          "model_lane": "both",
+          "safe_availability_state": "available_today",
+          "city": "Bangkok",
+          "zones": ["sukhumvit"],
+          "summary": "Athletic style, available today in Sukhumvit.",
+          "match_reasons": ["lane_compatible", "zone_match", "available_today"],
+          "safe_next_action": "continue_to_booking_review"
+        }
+      ]
+    }
+  ],
+  "fallback": null,
+  "generated_at": "2026-07-16T10:00:00.000Z"
+}
+```
+
+## Matching Rules
+
+Kenji Safe Match must:
+
+- Search only sanitized Model Catalog fields and sanitized Availability Snapshot
+  fields.
+- Apply backend permission scope before returning private candidates.
+- Apply booking visibility before ranking.
+- Apply lane compatibility:
+  - `straight` request matches `straight` and `both`.
+  - `gay` request matches `gay` and `both`.
+- Treat `both` as internal model compatibility only, not a customer lane option.
+- Apply operational filters independently from membership or private folder access.
+- Treat missing or expired availability as `unknown`, not available.
+- Prefer candidate groups and safe next actions over definitive booking claims.
+- Escalate or return `no_safe_candidates` when the safe data is insufficient.
+
+## Private Candidate Rules
+
+Private candidates may be returned only when all conditions are true:
+
+- Permission gate source is `backend_permission_gate`.
+- Permission gate is fresh and not expired.
+- Caller is authorized for private matching.
+- Requested private folder is within authoritative allowed folders.
+- Candidate model access folder is within authoritative allowed folders.
+- Candidate `booking_visibility` is `private`.
+- Candidate lane matches requested lane or `both`.
+- Candidate is active and not hidden, blocked, archived, paused, suspended, or
+  review-only.
+
+Inactive, expired, guest, unknown, unresolved, or missing membership must result
+in no protected private model names.
+
+## Safe Candidate Fields
+
+Allowed fields:
+
+- `match_id`
+- `model_key`
+- `safe_display_name`
+- `booking_visibility`
+- `model_lane`
+- `safe_availability_state`
+- `availability_bucket`
+- `city`
+- `zones`
+- `safe_image_url`
+- `public_profile_url`
+- `summary`
+- `match_reasons`
+- `safe_next_action`
+
+Forbidden fields:
+
+- phone, email, LINE ID, Telegram ID, Telegram username in LINE/member chat
+- raw Airtable record ID
+- raw session ID unless separately approved as a safe session reference
+- R2 private object key
+- exact live GPS, hotel, room, private address, travel route, or ETA details
+- model decision notes, admin notes, risk flags, complaints, or operator comments
+- payment status, payment reference, slip/proof URLs, banking details
+- membership/package raw records
+- tokens, bearer values, confirm keys, service secrets
+
+## Error Shape
+
+```json
+{
+  "ok": false,
+  "layer": "kenji_safe_match_v1",
+  "error": {
+    "code": "permission_unresolved",
+    "message": "Safe model matching requires a backend permission check."
+  },
+  "safe_next_action": "continue_public_flow_or_escalate"
+}
+```
+
+Suggested error codes:
+
+- `invalid_request`
+- `permission_unresolved`
+- `permission_denied`
+- `catalog_unavailable`
+- `availability_snapshot_unavailable`
+- `no_safe_candidates`
+- `internal_error`
+
+## Reply Boundary
+
+Kenji may use this layer to say safe things like:
+
+- "I found a few public candidates that may fit your request."
+- "I can help continue this into a booking review."
+- "I cannot confirm private availability from chat alone."
+- "This needs MMD review before any private access or booking decision."
+
+Kenji must not say:
+
+- "This model is secretly available."
+- "I confirmed your booking."
+- "I unlocked private access."
+- "I verified your payment."
+- "I found your LINE ID / phone / Telegram."
+
+## Non-Goals
+
+- No booking creation.
+- No payment confirmation.
+- No membership unlock.
+- No private access mutation.
+- No Model Console writeback.
+- No raw availability exposure.
+- No direct public LINE access to internal endpoints.
+- No Webflow publish.
+- No worker deployment.

--- a/docs/member-dashboard-api.md
+++ b/docs/member-dashboard-api.md
@@ -1,0 +1,39 @@
+# Member Dashboard API
+
+`/sigil/member/dashboard` is a member-facing status hub. The Webflow page may
+render Kenji AI copy, but the worker API is the source of truth for dashboard
+state, member status, access, points, payment, renewal, and session details.
+
+Frontend code must never unlock membership, dashboard access, points, packages,
+model access, VIP/SVIP, or payment state locally. The page reads:
+
+- `GET https://www.mmdbkk.com/api/member/dashboard?t=...`
+
+The public route is bridged by `mmd-redirect-worker` to:
+
+- `GET /v1/member/dashboard?t=...`
+
+Only these query parameters are preserved into dashboard action URLs:
+
+- `t`
+- `code`
+- `promo`
+- `source`
+- `invite`
+
+Payment/member/session/entitlement truth comes from worker-resolved
+Airtable/Core data only:
+
+- `MMD — Auth Sessions`
+- `MMD — Auth Identities`
+- `Members`
+- `MMD — Member Entitlements`
+- `Payments`
+- `Sessions`
+- `MMD — Points Ledger`
+- `MMD — LIFF Renewal Sessions`
+
+Uploaded payment proof is evidence/review state only. Dashboard access becomes
+active only from official verification/access/entitlement status. SVIP remains a
+private Per-only decision and must not be inferred from `SVIP Eligible` fields or
+points rules.

--- a/docs/sigil/SIGIL_AVAILABILITY_SNAPSHOT_V1.md
+++ b/docs/sigil/SIGIL_AVAILABILITY_SNAPSHOT_V1.md
@@ -1,0 +1,191 @@
+# SIGIL Availability Snapshot V1
+
+Status: docs/spec only. This document defines the API contract for a future
+sanitized availability layer. It does not implement worker code, deploy workers,
+publish Webflow, alter Airtable schema, or authorize Kenji to read raw Model
+Console data.
+
+## Purpose
+
+SIGIL Availability Snapshot V1 is the safe boundary between Model Console /
+Model App operational state and any downstream matching or chat intelligence.
+
+Model Console / Model App may contain sensitive operational data:
+
+- live session state
+- location, ETA, exact zone movement, or route context
+- customer identity
+- payment state
+- model decision notes
+- admin notes
+- contact information
+- internal job context
+
+Kenji must never read that raw source directly. Kenji may only read sanitized
+availability snapshots produced by this layer.
+
+## Architecture Position
+
+```text
+Model Console / Model App
+  -> SIGIL Availability Snapshot V1
+  -> Safe Availability KV / Index
+  -> Kenji Safe Match Layer V1
+  -> LINE / Member Dashboard / Admin Assist
+```
+
+## Proposed Endpoint Contracts
+
+Internal write endpoint:
+
+```http
+POST /v1/sigil/availability-snapshot
+```
+
+Internal read endpoint:
+
+```http
+GET /v1/sigil/availability-snapshot
+```
+
+These names are contract placeholders. Final worker ownership, route paths, and
+bindings must be approved before implementation.
+
+## Auth Rules
+
+- Write access requires internal service auth from trusted Model Console /
+  Model App infrastructure.
+- Internal read access requires admin/service auth.
+- Public LINE, member chat, Webflow browser code, and Kenji reply code must not
+  call the write endpoint.
+- Secrets, bearer tokens, confirm keys, service tokens, and route ownership keys
+  must never be returned by this layer.
+
+## Write Request Shape
+
+```json
+{
+  "source": "model_console",
+  "source_event_id": "evt_20260716_001",
+  "snapshot_generated_at": "2026-07-16T10:00:00.000Z",
+  "models": [
+    {
+      "model_key": "model_public_001",
+      "availability_state": "available_today",
+      "availability_window": {
+        "date": "2026-07-16",
+        "starts_at": "2026-07-16T13:00:00.000Z",
+        "ends_at": "2026-07-16T18:00:00.000Z",
+        "timezone": "Asia/Bangkok"
+      },
+      "location_scope": {
+        "city": "Bangkok",
+        "zones": ["sukhumvit"]
+      },
+      "operational_flags": {
+        "burn": false,
+        "mk": false,
+        "live": true
+      },
+      "confidence": "operator_confirmed",
+      "expires_at": "2026-07-16T10:10:00.000Z"
+    }
+  ]
+}
+```
+
+## Sanitized Snapshot Shape
+
+```json
+{
+  "model_key": "model_public_001",
+  "safe_availability_state": "available_today",
+  "availability_bucket": "today",
+  "city": "Bangkok",
+  "zones": ["sukhumvit"],
+  "operational_flags": {
+    "burn": false,
+    "mk": false,
+    "live": true
+  },
+  "confidence": "operator_confirmed",
+  "updated_at": "2026-07-16T10:00:00.000Z",
+  "expires_at": "2026-07-16T10:10:00.000Z"
+}
+```
+
+## Allowed Availability States
+
+- `available_now`
+- `available_today`
+- `available_soon`
+- `limited`
+- `unavailable`
+- `unknown`
+
+Raw Model Console states may normalize into these values, but raw labels must
+not be exposed downstream.
+
+## Safe Availability KV / Index
+
+The future storage layer should be optimized for short-lived lookup by
+`model_key` and safe filter fields.
+
+Suggested key:
+
+```text
+availability:v1:{model_key}
+```
+
+Suggested secondary indexes:
+
+- `city`
+- `zones[]`
+- `availability_bucket`
+- `safe_availability_state`
+- `operational_flags`
+- `updated_at`
+- `expires_at`
+
+## Filtering Rules
+
+- Expired snapshots must be treated as `unknown`.
+- Missing snapshots must be treated as `unknown`.
+- Hidden, blocked, archived, suspended, paused, or review-only states must never
+  normalize to available.
+- `available_now` must be short-lived and require `expires_at`.
+- Operational flags are filters only. They must never grant membership, private
+  access, or model folder access.
+- The layer may remove a model from the safe index rather than publish
+  `unavailable` when the source state is sensitive.
+
+## Forbidden Output Fields
+
+Never expose these through the snapshot:
+
+- customer name, member identity, LINE ID, Telegram ID, phone, or email
+- raw session ID unless separately approved as a safe public/session reference
+- exact live GPS, hotel, room, travel route, ETA details, or private address
+- payment state, payment reference, slip/proof URLs, bank/private data
+- model decision notes, admin notes, risk flags, complaints, or operator comments
+- raw Airtable record IDs
+- R2 private object keys
+- tokens, bearer values, confirm keys, service secrets
+
+## Consumer Rules
+
+Kenji Safe Match Layer V1 may read only the sanitized snapshot or a sanitized
+index derived from it. It must not query Model Console / Model App directly.
+
+Admin Assist may read richer operator state only through authenticated internal
+admin routes, not through Kenji public/member chat context.
+
+## Non-Goals
+
+- No booking confirmation.
+- No payment confirmation.
+- No membership/access mutation.
+- No Model Console writeback from Kenji.
+- No raw model operational feed to LINE.
+- No Webflow publish.
+- No worker deployment.

--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -21,6 +21,7 @@ export const PUBLIC_BLACKCARD_PATHS = new Set(["/blackcard", "/blackcard/", "/bl
 export const WEBFLOW_MEMBER_PAGE_PATHS = new Set(["/member/promotion", "/member/promotion/", "/member/apply", "/member/apply/"]);
 export const MEMBER_PAGE_PATHS = new Set(["/member/membership", "/member/membership/", "/member/profile", "/member/profile/", "/pay/membership", "/pay/membership/", "/pay/pending-verification", "/pay/pending-verification/", "/sigil/pay/renewal", "/sigil/pay/renewal/"]);
 export const MEMBER_API_PATHS = new Set(["/member/api/liff/identify", "/member/api/liff/identify/"]);
+export const MEMBER_DASHBOARD_API_PATHS = new Set(["/api/member/dashboard", "/api/member/dashboard/"]);
 export const NEVER_TOUCH_PREFIXES = ["/api/", "/webhook/", "/webhooks/", "/payments/", "/payment/", "/payment-webhook/", "/admin/", "/sigil/", "/cdn-cgi/", "/assets/", "/static/", "/uploads/"];
 export const NEVER_REDIRECT_EXACT_PATHS = new Set(["/member/promotion", "/member/promotion/", "/member/apply", "/member/apply/", "/member/dashboard", "/member/dashboard/", "/member/membership", "/member/membership/", "/member/profile", "/member/profile/", "/member/payments", "/member/payments/", "/pay/membership", "/pay/membership/", "/pay/pending-verification", "/pay/pending-verification/", "/sigil/pay/membership", "/sigil/pay/membership/", "/sigil/pay/renewal", "/sigil/pay/renewal/", "/hall", "/hall/", "/model/console", "/model/console/", "/blackcard", "/blackcard/", "/blackcard/black-card", "/blackcard/black-card/"]);
 export const EXACT_PATH_REDIRECTS = { "/trust/inme": "/sigil/start", "/inme": "/sigil/start", "/login": "/sigil/start", "/member": "/member/dashboard", "/member/membership/benefits": "/member/membership", "/members": "/sigil/start", "/membership": "/member/membership", "/membership/benefits": "/member/membership", "/renew": "/sigil/membership", "/renewal": "/sigil/membership", "/trust": "/sigil/start" };
@@ -88,6 +89,7 @@ function isSigilApplyPath(url) { const p = url.pathname.toLowerCase(); return p 
 function isSigilPrivateModelApplyApiPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/api/private-model/apply" || p === "/sigil/api/private-model/apply/"; }
 function isSigilMembershipPath(url) { const p = url.pathname.toLowerCase(); return p === "/sigil/membership" || p === "/sigil/membership/"; }
 function isMemberDashboardPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/dashboard" || p === "/member/dashboard/"; }
+function isMemberDashboardApiPath(url) { return MEMBER_DASHBOARD_API_PATHS.has(url.pathname.toLowerCase()); }
 function isMemberPagePath(url) { return MEMBER_PAGE_PATHS.has(url.pathname.toLowerCase()); }
 function isMemberApiPath(url) { return MEMBER_API_PATHS.has(url.pathname.toLowerCase()); }
 function isMemberPaymentsPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/payments" || p === "/member/payments/"; }
@@ -128,12 +130,34 @@ async function fetchAdminMemberPage(request, env, url) {
   return withFrontGateHeaders(await fetch(new Request(target.toString(), request)));
 }
 
+async function fetchMemberDashboardApi(request, env, url) {
+  const target = new URL(request.url);
+  target.pathname = "/v1/member/dashboard";
+  target.search = safeMemberDashboardSearch(url.searchParams);
+  const upstreamRequest = new Request(target.toString(), request);
+  if (env?.ADMIN_WORKER?.fetch) return withFrontGateHeaders(await env.ADMIN_WORKER.fetch(upstreamRequest));
+  const fallback = new URL(ADMIN_WORKER_UPSTREAM);
+  fallback.pathname = target.pathname;
+  fallback.search = target.search;
+  return withFrontGateHeaders(await fetch(new Request(fallback.toString(), upstreamRequest)));
+}
+
 async function fetchSigilWorkerRoute(request, env, url, page) {
   if (env?.SIGIL_WORKER?.fetch) return withRouteOwnerHeaders(await env.SIGIL_WORKER.fetch(request), { owner: SIGIL_APPLY_ROUTE_OWNER, page, origin: "service-binding:sigil-worker" });
   const target = new URL(SIGIL_WORKER_UPSTREAM);
   target.pathname = url.pathname;
   target.search = url.search;
   return withRouteOwnerHeaders(await fetch(new Request(target.toString(), request)), { owner: SIGIL_APPLY_ROUTE_OWNER, page, origin: SIGIL_WORKER_UPSTREAM });
+}
+
+function safeMemberDashboardSearch(params) {
+  const safe = new URLSearchParams();
+  for (const key of ["t", "code", "promo", "source", "invite"]) {
+    const value = params.get(key);
+    if (value) safe.set(key, value);
+  }
+  const rendered = safe.toString();
+  return rendered ? `?${rendered}` : "";
 }
 
 function renderRouteRecoveryShell(request, page, title, heading, copy, links = []) {
@@ -159,6 +183,7 @@ export default {
     const url = new URL(request.url);
     if (isLineWebhookPath(url)) return fetchLineWebhook(request, env, url);
     if (isSigilPrivateModelApplyApiPath(url)) return fetchSigilWorkerRoute(request, env, url, "sigil-private-model-apply-api");
+    if (isMemberDashboardApiPath(url)) return fetchMemberDashboardApi(request, env, url);
     if (isMemberApiPath(url)) return fetchMemberPage(request, env, url);
     if (!isSafePageRequest(request)) return withFrontGateHeaders(await fetch(request));
     if (isBlackcardPublicPath(url)) return renderPublicBlackcardPage(request);

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -174,6 +174,37 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 0);
   });
 
+  it("bridges /api/member/dashboard to admin-worker core with only safe query keys", async () => {
+    const serviceRequests = [];
+    const env = {
+      ADMIN_WORKER: {
+        fetch: async (request) => {
+          serviceRequests.push(request);
+          return Response.json({
+            ok: true,
+            data: { dashboard_state: "pending" },
+          }, {
+            headers: { "x-mmd-worker": "admin-worker", "x-mmd-page": "member-dashboard-api" },
+          });
+        },
+      },
+    };
+
+    const response = await requestWithEnv(
+      "https://www.mmdbkk.com/api/member/dashboard?t=tok&code=c&promo=p&source=line&invite=i&unsafe=https://evil.example",
+      env,
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-mmd-front-gate"), "mmd-redirect-worker");
+    assert.equal(serviceRequests.length, 1);
+    assert.equal(
+      serviceRequests[0].url,
+      "https://www.mmdbkk.com/v1/member/dashboard?t=tok&code=c&promo=p&source=line&invite=i",
+    );
+    assert.equal(passThroughRequests.length, 0);
+  });
+
   it("delegates /member/membership to member-pages-worker by service binding without redirecting or changing query strings", async () => {
     const serviceRequests = [];
     const env = {

--- a/mmd-redirect-worker/wrangler.toml
+++ b/mmd-redirect-worker/wrangler.toml
@@ -16,6 +16,10 @@ binding = "MEMBER_PAGES_WORKER"
 service = "member-pages-worker"
 
 [[services]]
+binding = "ADMIN_WORKER"
+service = "admin-worker"
+
+[[services]]
 binding = "SIGIL_WORKER"
 service = "sigil-worker"
 

--- a/webflow/sigil/private-models/README.md
+++ b/webflow/sigil/private-models/README.md
@@ -1,0 +1,48 @@
+# MMD R2 Deployment Note: SIGIL Private Models Webflow Assets
+
+Documentation date: 2026-07-15
+Deployment date/time: not recorded in this repo note
+
+This note records the completed Cloudflare R2 upload for SIGIL Private Models Webflow assets. These assets belong to the SIGIL Private Models page family and related Webflow embeds, such as `/sigil/private-models`.
+
+This is not a Kenji Knownledge V9.1 deployment. Do not confuse these assets with `webflow/internal/admin/kenji-knowledge/`, the Kenji Knownledge V9.1 Webflow Loader, Kenji Board bridge assets, or PR #170 Kenji Knownledge assets.
+
+## R2 Location
+
+- Bucket: `mmd-models`
+- Public domain: `https://models.mmdbkk.com`
+- Prefix: `webflow/sigil/private-models/`
+
+## Uploaded Files
+
+- `sigil-private-models.css`
+- `sigil-private-models-v2-polish.css`
+- `sigil-private-models-v3.css`
+- `sigil-private-models.js`
+- `sigil-private-models-v3.js`
+- `sigil-private-models-webflow-snippet.html`
+
+## Public URLs
+
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models.css`
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models-v2-polish.css`
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models-v3.css`
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models.js`
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models-v3.js`
+- `https://models.mmdbkk.com/webflow/sigil/private-models/sigil-private-models-webflow-snippet.html`
+
+## Validation Reported
+
+- All 6 public URLs returned `HTTP/2 200`.
+- CSS assets served as `text/css`.
+- JS assets served as `application/javascript`.
+- HTML snippet served as `text/html`.
+- `Cache-Control` was set to `public, max-age=300`.
+
+## Operational Notes
+
+- No repo files were changed as part of the original R2 upload.
+- No commit or push was part of the original R2 upload.
+- No Worker deploy was part of the original R2 upload.
+- No Webflow publish was part of the original R2 upload.
+- Existing dirty worktree files were left untouched.


### PR DESCRIPTION
Docs-only spec for SIGIL Availability Snapshot V1 and Kenji Safe Match Layer V1.

Scope:
- Adds API contract docs for SIGIL Availability Snapshot V1
- Adds Kenji Safe Match Layer V1 docs
- Adds architecture contract for safe model search, client spec summary, and safe candidate matching
- Locks rule that Kenji must not read raw Model Console directly
- Defines permission gate for public, member, premium, vip, blackcard, and admin/operator

No worker changes.
No deploy.
No Webflow publish.
No dirty worktree cleanup.