### PR TITLE
docs: define SIGIL availability and Kenji safe match layers

### DIFF
--- a/docs/architecture/SIGIL_KENJI_SAFE_MATCH_API_CONTRACT_V1.md
+++ b/docs/architecture/SIGIL_KENJI_SAFE_MATCH_API_CONTRACT_V1.md
@@ -1,0 +1,223 @@
+# SIGIL / Kenji Safe Match API Contract V1
+
+Status: docs/spec only. This architecture contract links SIGIL Availability
+Snapshot V1 and Kenji Safe Match Layer V1. It does not implement worker code,
+deploy workers, publish Webflow, alter Airtable schema, or authorize runtime
+route changes.
+
+## Locked System Names
+
+1. SIGIL Availability Snapshot V1
+2. Kenji Safe Match Layer V1
+
+## Architecture
+
+```text
+Model Console / Model App
+  -> SIGIL Availability Snapshot V1
+  -> Safe Availability KV / Index
+  -> Kenji Safe Match Layer V1
+  -> LINE / Member Dashboard / Admin Assist
+```
+
+## Core Principle
+
+Kenji must never read raw Model Console data directly.
+
+Kenji can only read sanitized availability snapshots and safe catalog fields
+after permission checks. This protects sensitive operational data that may exist
+inside Model Console / Model App, including live session state, location, ETA,
+customer identity, payment state, model decision notes, admin notes, contact
+information, and internal job context.
+
+## Source Of Truth Boundaries
+
+| Data | Source of Truth | Kenji Access |
+| --- | --- | --- |
+| model catalog identity | sanitized Model Catalog / R2 catalog | safe fields only |
+| raw model operational state | Model Console / Model App | no direct access |
+| safe availability | SIGIL Availability Snapshot V1 | yes, sanitized only |
+| private model access | backend permission gate | yes, result only |
+| membership/package truth | members + member_packages backend authority | gate result only |
+| payment truth | payment verification backend | no direct safe-match use |
+| booking/session truth | session backend | no direct booking confirmation |
+
+## Endpoint Family
+
+SIGIL Availability Snapshot V1:
+
+```http
+POST /v1/sigil/availability-snapshot
+GET /v1/sigil/availability-snapshot
+```
+
+Kenji Safe Match Layer V1:
+
+```http
+POST /v1/kenji/safe-match
+GET /v1/kenji/safe-match/:match_id
+```
+
+These are proposed API contracts only. Final route ownership, worker placement,
+auth bindings, and storage bindings require separate implementation approval.
+
+## Permission Gate Contract
+
+Kenji Safe Match requires a backend permission gate. Chat text, LINE profile,
+frontend claims, local storage, and member-submitted labels are never access
+truth.
+
+```json
+{
+  "ok": true,
+  "source": "backend_permission_gate",
+  "identity_trust": "backend_matched",
+  "booking_visibility": "private",
+  "private_access_folders": ["standard", "premium"],
+  "member_status": "active",
+  "expires_at": "2026-07-16T10:05:00.000Z"
+}
+```
+
+If the gate is missing, expired, unresolved, inactive, guest, unknown, or missing
+membership:
+
+- `private_access_folders` must be empty.
+- Protected private model names must not be returned.
+- Matching must fall back to public-safe candidates or return no safe candidates.
+
+## Availability Snapshot Contract Summary
+
+SIGIL Availability Snapshot V1 receives trusted model availability signals and
+publishes a sanitized lookup keyed by `model_key`.
+
+Allowed safe states:
+
+- `available_now`
+- `available_today`
+- `available_soon`
+- `limited`
+- `unavailable`
+- `unknown`
+
+Required safety behavior:
+
+- Expired snapshots become `unknown`.
+- Hidden or blocked operational states never normalize to available.
+- `available_now` requires short TTL and `expires_at`.
+- No raw session, location, payment, customer, contact, note, or secret fields.
+
+## Kenji Safe Match Contract Summary
+
+Kenji Safe Match combines:
+
+- sanitized Model Catalog fields
+- sanitized Availability Snapshot fields
+- backend permission gate
+- customer specs from chat/member context
+
+It returns:
+
+- `customer_spec_summary`
+- `candidate_groups`
+- safe candidate summaries
+- safe next actions
+- fallback/escalation direction
+
+It must not return:
+
+- raw identifiers
+- hidden availability
+- internal notes
+- payment truth
+- membership raw records
+- private contact data
+- private R2 object keys
+- mutation authority
+
+## Lane Compatibility
+
+Customer lane options:
+
+- `straight`
+- `gay`
+
+Model compatibility values:
+
+- `straight`
+- `gay`
+- `both`
+
+Rules:
+
+- `straight` request matches `straight` and `both`.
+- `gay` request matches `gay` and `both`.
+- `both` is internal model compatibility only and must not be shown as a customer
+  lane choice.
+
+## Candidate Group Examples
+
+```json
+{
+  "group_id": "available_today_sukhumvit",
+  "label": "Available today around Sukhumvit",
+  "safe_next_action": "continue_to_booking_review",
+  "candidates": [
+    {
+      "match_id": "safe_match_001",
+      "model_key": "model_public_001",
+      "safe_display_name": "Ken",
+      "booking_visibility": "public",
+      "model_lane": "both",
+      "safe_availability_state": "available_today",
+      "summary": "Athletic style, available today in Sukhumvit.",
+      "match_reasons": ["lane_compatible", "zone_match", "available_today"]
+    }
+  ]
+}
+```
+
+## Security And Privacy Locks
+
+- Kenji cannot confirm booking, payment, membership, VIP, Black Card, or private
+  access from chat.
+- Kenji cannot mutate model availability.
+- Kenji cannot mutate membership, session, payment, or model records.
+- Kenji cannot expose raw Model Console state.
+- Kenji cannot expose raw LINE ID, Telegram ID, email, phone, or Airtable record
+  IDs.
+- Kenji cannot expose exact live location, route, ETA, hotel, room, or private
+  address.
+- Kenji cannot expose model decision notes or admin/operator notes.
+
+## Required Future Tests
+
+Before implementation ships, add tests proving:
+
+- Kenji does not query raw Model Console data.
+- expired availability snapshots return `unknown` or no safe candidate.
+- hidden/blocked/archived/paused models are excluded.
+- public matching works without private permission.
+- private matching requires backend permission gate.
+- inactive/expired/guest/unknown members receive no private model names.
+- straight/gay lane matching includes `both`.
+- operational filters do not grant access.
+- forbidden fields are redacted.
+- no mutation occurs through safe-match endpoints.
+
+## Related Specs
+
+- `docs/sigil/SIGIL_AVAILABILITY_SNAPSHOT_V1.md`
+- `docs/kenji/KENJI_SAFE_MATCH_LAYER_V1.md`
+- `docs/kenji/KENJI_AI_V1_CONTEXT_CONTRACT.md`
+- `docs/kenji/KENJI_AI_V1_REPLY_BOUNDARIES.md`
+- `docs/r2-model-catalog-airtable-template.md`
+
+## Non-Goals
+
+- No worker implementation in this contract.
+- No deploy.
+- No Webflow publish.
+- No Airtable schema change.
+- No Model Console rewrite.
+- No Kenji LLM implementation.

--- a/docs/kenji/KENJI_SAFE_MATCH_LAYER_V1.md
+++ b/docs/kenji/KENJI_SAFE_MATCH_LAYER_V1.md
@@ -1,0 +1,258 @@
+# Kenji Safe Match Layer V1
+
+Status: docs/spec only. This document defines a future safe matching contract
+for Kenji in LINE/member chat. It does not implement worker code, deploy workers,
+publish Webflow, alter Airtable schema, or authorize Kenji to expose private
+model data.
+
+## Purpose
+
+Kenji Safe Match Layer V1 lets Kenji search model names, summarize customer
+specs, and suggest candidate groups using only safe sources:
+
+- sanitized Model Catalog fields
+- SIGIL Availability Snapshot V1
+- backend permission gate
+
+Kenji must never read raw Model Console data directly. Kenji must never treat
+LINE text, member chat text, local storage, or frontend claims as access truth.
+
+## Architecture Position
+
+```text
+Model Console / Model App
+  -> SIGIL Availability Snapshot V1
+  -> Safe Availability KV / Index
+  -> Kenji Safe Match Layer V1
+  -> LINE / Member Dashboard / Admin Assist
+```
+
+## Proposed Endpoint Contract
+
+Primary match endpoint:
+
+```http
+POST /v1/kenji/safe-match
+```
+
+Optional match detail endpoint:
+
+```http
+GET /v1/kenji/safe-match/:match_id
+```
+
+These route names are contract placeholders. Final worker ownership and route
+bindings must be approved before implementation.
+
+## Auth Rules
+
+- Endpoint access requires Kenji backend/service auth.
+- Public LINE clients must not call this endpoint directly.
+- Member Dashboard callers must go through the approved backend path.
+- The endpoint must require a backend permission gate result before returning
+  private candidates.
+- No bearer token, confirm key, service token, or internal route key may be
+  returned in the response.
+
+## Request Shape
+
+```json
+{
+  "request_id": "kenji_match_20260716_001",
+  "channel": "line",
+  "locale": "th-TH",
+  "query": "หุ่น athletic ว่างวันนี้ แถวสุขุมวิท",
+  "customer_specs": {
+    "lane": "gay",
+    "city": "Bangkok",
+    "zones": ["sukhumvit"],
+    "date": "2026-07-16",
+    "time_bucket": "today",
+    "budget_thb": {
+      "min": 6000,
+      "max": 12000
+    },
+    "preferences": ["athletic", "friendly"],
+    "operational_filters": {
+      "burn": false,
+      "mk": false,
+      "live": true,
+      "available": true
+    }
+  },
+  "identity_context": {
+    "trust": "backend_matched"
+  },
+  "permission_scope": {
+    "source": "backend_permission_gate",
+    "booking_visibility": "public",
+    "private_access_folders": []
+  },
+  "limit": 5
+}
+```
+
+## Response Shape
+
+```json
+{
+  "ok": true,
+  "layer": "kenji_safe_match_v1",
+  "request_id": "kenji_match_20260716_001",
+  "match_policy": {
+    "booking_visibility": "public",
+    "permission_gate_applied": true,
+    "availability_snapshot_applied": true,
+    "private_access_applied": false
+  },
+  "customer_spec_summary": {
+    "lane": "gay",
+    "city": "Bangkok",
+    "zones": ["sukhumvit"],
+    "time_bucket": "today",
+    "safe_summary": "Looking for gay-compatible candidates around Sukhumvit today."
+  },
+  "candidate_groups": [
+    {
+      "group_id": "available_today_sukhumvit",
+      "label": "Available today around Sukhumvit",
+      "safe_next_action": "continue_to_booking_review",
+      "candidates": [
+        {
+          "match_id": "safe_match_001",
+          "model_key": "model_public_001",
+          "safe_display_name": "Ken",
+          "booking_visibility": "public",
+          "model_lane": "both",
+          "safe_availability_state": "available_today",
+          "city": "Bangkok",
+          "zones": ["sukhumvit"],
+          "summary": "Athletic style, available today in Sukhumvit.",
+          "match_reasons": ["lane_compatible", "zone_match", "available_today"],
+          "safe_next_action": "continue_to_booking_review"
+        }
+      ]
+    }
+  ],
+  "fallback": null,
+  "generated_at": "2026-07-16T10:00:00.000Z"
+}
+```
+
+## Matching Rules
+
+Kenji Safe Match must:
+
+- Search only sanitized Model Catalog fields and sanitized Availability Snapshot
+  fields.
+- Apply backend permission scope before returning private candidates.
+- Apply booking visibility before ranking.
+- Apply lane compatibility:
+  - `straight` request matches `straight` and `both`.
+  - `gay` request matches `gay` and `both`.
+- Treat `both` as internal model compatibility only, not a customer lane option.
+- Apply operational filters independently from membership or private folder access.
+- Treat missing or expired availability as `unknown`, not available.
+- Prefer candidate groups and safe next actions over definitive booking claims.
+- Escalate or return `no_safe_candidates` when the safe data is insufficient.
+
+## Private Candidate Rules
+
+Private candidates may be returned only when all conditions are true:
+
+- Permission gate source is `backend_permission_gate`.
+- Permission gate is fresh and not expired.
+- Caller is authorized for private matching.
+- Requested private folder is within authoritative allowed folders.
+- Candidate model access folder is within authoritative allowed folders.
+- Candidate `booking_visibility` is `private`.
+- Candidate lane matches requested lane or `both`.
+- Candidate is active and not hidden, blocked, archived, paused, suspended, or
+  review-only.
+
+Inactive, expired, guest, unknown, unresolved, or missing membership must result
+in no protected private model names.
+
+## Safe Candidate Fields
+
+Allowed fields:
+
+- `match_id`
+- `model_key`
+- `safe_display_name`
+- `booking_visibility`
+- `model_lane`
+- `safe_availability_state`
+- `availability_bucket`
+- `city`
+- `zones`
+- `safe_image_url`
+- `public_profile_url`
+- `summary`
+- `match_reasons`
+- `safe_next_action`
+
+Forbidden fields:
+
+- phone, email, LINE ID, Telegram ID, Telegram username in LINE/member chat
+- raw Airtable record ID
+- raw session ID unless separately approved as a safe session reference
+- R2 private object key
+- exact live GPS, hotel, room, private address, travel route, or ETA details
+- model decision notes, admin notes, risk flags, complaints, or operator comments
+- payment status, payment reference, slip/proof URLs, banking details
+- membership/package raw records
+- tokens, bearer values, confirm keys, service secrets
+
+## Error Shape
+
+```json
+{
+  "ok": false,
+  "layer": "kenji_safe_match_v1",
+  "error": {
+    "code": "permission_unresolved",
+    "message": "Safe model matching requires a backend permission check."
+  },
+  "safe_next_action": "continue_public_flow_or_escalate"
+}
+```
+
+Suggested error codes:
+
+- `invalid_request`
+- `permission_unresolved`
+- `permission_denied`
+- `catalog_unavailable`
+- `availability_snapshot_unavailable`
+- `no_safe_candidates`
+- `internal_error`
+
+## Reply Boundary
+
+Kenji may use this layer to say safe things like:
+
+- "I found a few public candidates that may fit your request."
+- "I can help continue this into a booking review."
+- "I cannot confirm private availability from chat alone."
+- "This needs MMD review before any private access or booking decision."
+
+Kenji must not say:
+
+- "This model is secretly available."
+- "I confirmed your booking."
+- "I unlocked private access."
+- "I verified your payment."
+- "I found your LINE ID / phone / Telegram."
+
+## Non-Goals
+
+- No booking creation.
+- No payment confirmation.
+- No membership unlock.
+- No private access mutation.
+- No Model Console writeback.
+- No raw availability exposure.
+- No direct public LINE access to internal endpoints.
+- No Webflow publish.
+- No worker deployment.

--- a/docs/sigil/SIGIL_AVAILABILITY_SNAPSHOT_V1.md
+++ b/docs/sigil/SIGIL_AVAILABILITY_SNAPSHOT_V1.md
@@ -1,0 +1,191 @@
+# SIGIL Availability Snapshot V1
+
+Status: docs/spec only. This document defines the API contract for a future
+sanitized availability layer. It does not implement worker code, deploy workers,
+publish Webflow, alter Airtable schema, or authorize Kenji to read raw Model
+Console data.
+
+## Purpose
+
+SIGIL Availability Snapshot V1 is the safe boundary between Model Console /
+Model App operational state and any downstream matching or chat intelligence.
+
+Model Console / Model App may contain sensitive operational data:
+
+- live session state
+- location, ETA, exact zone movement, or route context
+- customer identity
+- payment state
+- model decision notes
+- admin notes
+- contact information
+- internal job context
+
+Kenji must never read that raw source directly. Kenji may only read sanitized
+availability snapshots produced by this layer.
+
+## Architecture Position
+
+```text
+Model Console / Model App
+  -> SIGIL Availability Snapshot V1
+  -> Safe Availability KV / Index
+  -> Kenji Safe Match Layer V1
+  -> LINE / Member Dashboard / Admin Assist
+```
+
+## Proposed Endpoint Contracts
+
+Internal write endpoint:
+
+```http
+POST /v1/sigil/availability-snapshot
+```
+
+Internal read endpoint:
+
+```http
+GET /v1/sigil/availability-snapshot
+```
+
+These names are contract placeholders. Final worker ownership, route paths, and
+bindings must be approved before implementation.
+
+## Auth Rules
+
+- Write access requires internal service auth from trusted Model Console /
+  Model App infrastructure.
+- Internal read access requires admin/service auth.
+- Public LINE, member chat, Webflow browser code, and Kenji reply code must not
+  call the write endpoint.
+- Secrets, bearer tokens, confirm keys, service tokens, and route ownership keys
+  must never be returned by this layer.
+
+## Write Request Shape
+
+```json
+{
+  "source": "model_console",
+  "source_event_id": "evt_20260716_001",
+  "snapshot_generated_at": "2026-07-16T10:00:00.000Z",
+  "models": [
+    {
+      "model_key": "model_public_001",
+      "availability_state": "available_today",
+      "availability_window": {
+        "date": "2026-07-16",
+        "starts_at": "2026-07-16T13:00:00.000Z",
+        "ends_at": "2026-07-16T18:00:00.000Z",
+        "timezone": "Asia/Bangkok"
+      },
+      "location_scope": {
+        "city": "Bangkok",
+        "zones": ["sukhumvit"]
+      },
+      "operational_flags": {
+        "burn": false,
+        "mk": false,
+        "live": true
+      },
+      "confidence": "operator_confirmed",
+      "expires_at": "2026-07-16T10:10:00.000Z"
+    }
+  ]
+}
+```
+
+## Sanitized Snapshot Shape
+
+```json
+{
+  "model_key": "model_public_001",
+  "safe_availability_state": "available_today",
+  "availability_bucket": "today",
+  "city": "Bangkok",
+  "zones": ["sukhumvit"],
+  "operational_flags": {
+    "burn": false,
+    "mk": false,
+    "live": true
+  },
+  "confidence": "operator_confirmed",
+  "updated_at": "2026-07-16T10:00:00.000Z",
+  "expires_at": "2026-07-16T10:10:00.000Z"
+}
+```
+
+## Allowed Availability States
+
+- `available_now`
+- `available_today`
+- `available_soon`
+- `limited`
+- `unavailable`
+- `unknown`
+
+Raw Model Console states may normalize into these values, but raw labels must
+not be exposed downstream.
+
+## Safe Availability KV / Index
+
+The future storage layer should be optimized for short-lived lookup by
+`model_key` and safe filter fields.
+
+Suggested key:
+
+```text
+availability:v1:{model_key}
+```
+
+Suggested secondary indexes:
+
+- `city`
+- `zones[]`
+- `availability_bucket`
+- `safe_availability_state`
+- `operational_flags`
+- `updated_at`
+- `expires_at`
+
+## Filtering Rules
+
+- Expired snapshots must be treated as `unknown`.
+- Missing snapshots must be treated as `unknown`.
+- Hidden, blocked, archived, suspended, paused, or review-only states must never
+  normalize to available.
+- `available_now` must be short-lived and require `expires_at`.
+- Operational flags are filters only. They must never grant membership, private
+  access, or model folder access.
+- The layer may remove a model from the safe index rather than publish
+  `unavailable` when the source state is sensitive.
+
+## Forbidden Output Fields
+
+Never expose these through the snapshot:
+
+- customer name, member identity, LINE ID, Telegram ID, phone, or email
+- raw session ID unless separately approved as a safe public/session reference
+- exact live GPS, hotel, room, travel route, ETA details, or private address
+- payment state, payment reference, slip/proof URLs, bank/private data
+- model decision notes, admin notes, risk flags, complaints, or operator comments
+- raw Airtable record IDs
+- R2 private object keys
+- tokens, bearer values, confirm keys, service secrets
+
+## Consumer Rules
+
+Kenji Safe Match Layer V1 may read only the sanitized snapshot or a sanitized
+index derived from it. It must not query Model Console / Model App directly.
+
+Admin Assist may read richer operator state only through authenticated internal
+admin routes, not through Kenji public/member chat context.
+
+## Non-Goals
+
+- No booking confirmation.
+- No payment confirmation.
+- No membership/access mutation.
+- No Model Console writeback from Kenji.
+- No raw model operational feed to LINE.
+- No Webflow publish.
+- No worker deployment.


### PR DESCRIPTION
Docs-only spec for SIGIL Availability Snapshot V1 and Kenji Safe Match Layer V1.

Scope:
- Adds API contract docs for SIGIL Availability Snapshot V1
- Adds Kenji Safe Match Layer V1 docs
- Adds architecture contract for safe model search, client spec summary, and safe candidate matching
- Locks rule that Kenji must not read raw Model Console directly
- Defines permission gate for public, member, premium, vip, blackcard, and admin/operator

No worker changes.
No deploy.
No Webflow publish.
No dirty worktree cleanup.