### PR TITLE
fix(payments): route SIGIL v1 payment API to payments worker

### DIFF
--- a/payments-worker/PAYMENT_API_ROUTES.md
+++ b/payments-worker/PAYMENT_API_ROUTES.md
@@ -1,0 +1,76 @@
+# payments-worker SIGIL API routes
+
+This file records the production routing contract for the MMD Privé / SIGIL payment API.
+
+## Cloudflare route ownership
+
+The payments worker must own these production host routes so requests do not fall through to the origin and return Cloudflare `522`:
+
+```toml
+routes = [
+  { pattern = "sigil.mmdbkk.com/v1/pay/*", zone_name = "mmdbkk.com" },
+  { pattern = "sigil.mmdbkk.com/v1/payments/*", zone_name = "mmdbkk.com" },
+  { pattern = "sigil.mmdbkk.com/v1/confirm/*", zone_name = "mmdbkk.com" }
+]
+```
+
+## Current production endpoints
+
+| Method | Path | Purpose | Notes |
+| --- | --- | --- | --- |
+| POST | `/v1/pay/verify` | Create or return a payment intent | Manual PromptPay flow, pending review |
+| POST | `/v1/payments/notify` | Internal/admin payment notification | Requires internal auth, can mark paid/verified |
+| POST | `/v1/confirm/link` | Create customer/model confirmation links | Internal flow |
+
+## Slip evidence route contract
+
+Planned route:
+
+```txt
+POST /v1/pay/slip/evidence
+```
+
+Purpose: accept customer slip evidence from the Payment Confirmation page.
+
+Hard lock:
+
+```txt
+Slip = supporting evidence only.
+Payment / access / session confirmation = official verification required.
+```
+
+The slip evidence route must not:
+
+- mark payment as paid
+- mark verification as verified
+- unlock access
+- activate member status
+- confirm session/job
+- award points
+
+The route may:
+
+- accept `multipart/form-data`
+- record `session_id`, `payment_ref`, `payment_type`, `payment_stage`, `source_page`, `proof_type`
+- attach/store a slip only when a safe storage target exists
+- write a pending/manual review note
+- notify Telegram/admin for manual verification
+
+Recommended GET smoke behavior after deployment:
+
+```txt
+GET /v1/pay/slip/evidence -> 405 Method Not Allowed
+Allow: POST
+```
+
+Recommended POST response before official verification:
+
+```json
+{
+  "ok": true,
+  "evidence_only": true,
+  "verification_status": "pending",
+  "payment_status": "pending",
+  "message": "Slip evidence received. Official verification is still required."
+}
+```

--- a/payments-worker/wrangler 2.toml
+++ b/payments-worker/wrangler 2.toml
@@ -7,4 +7,24 @@ workers_dev = true
 # These prevent sigil.mmdbkk.com/v1/* payment requests from falling through to origin and returning Cloudflare 522.
 routes = [
   { pattern = "sigil.mmdbkk.com/v1/pay/*", zone_name = "mmdbkk.com" },
-  { pattern = "sigil.mmdbkk.com/v1/payments/*",
+  { pattern = "sigil.mmdbkk.com/v1/payments/*", zone_name = "mmdbkk.com" },
+  { pattern = "sigil.mmdbkk.com/v1/confirm/*", zone_name = "mmdbkk.com" }
+]
+
+[vars]
+AIRTABLE_BASE_ID = "appsV1ILPRfIjkaYg"
+AIRTABLE_TABLE_PAYMENTS = "tblWGGJJOx5eBvBZJ"
+AIRTABLE_TABLE_SESSIONS = "tblC98mKWbzmPuNzX"
+AIRTABLE_TABLE_POINTS_LEDGER = "points_ledger"
+TELEGRAM_CHAT_ID = "-1003546439681"
+TG_THREAD_CONFIRM = "61"
+TG_THREAD_POINTS = "17"
+POINTS_RATE = "100"
+WEB_BASE_URL = "https://mmdbkk.com"
+ALLOWED_ORIGINS = "https://mmdbkk.com,https://www.mmdbkk.com,https://sigil.mmdbkk.com,https://mmdprive.com,https://www.mmdprive.com,https://mmdprive.webflow.io"
+PAY_SESSIONS_TTL_DAYS = "30"
+
+[[kv_namespaces]]
+binding = "PAY_SESSIONS_KV"
+id = "e0c6b8a0785e462dad6d01f61a893e87"
+preview_id = "8f3ede8e3b0f447ea046cee47c7eef0b"

--- a/payments-worker/wrangler 2.toml
+++ b/payments-worker/wrangler 2.toml
@@ -3,20 +3,8 @@ main = "index.js"
 compatibility_date = "2026-03-12"
 workers_dev = true
 
-[vars]
-AIRTABLE_BASE_ID = "appsV1ILPRfIjkaYg"
-AIRTABLE_TABLE_PAYMENTS = "tblWGGJJOx5eBvBZJ"
-AIRTABLE_TABLE_SESSIONS = "tblC98mKWbzmPuNzX"
-AIRTABLE_TABLE_POINTS_LEDGER = "points_ledger"
-TELEGRAM_CHAT_ID = "-1003546439681"
-TG_THREAD_CONFIRM = "61"
-TG_THREAD_POINTS = "17"
-POINTS_RATE = "100"
-WEB_BASE_URL = "https://mmdbkk.com"
-ALLOWED_ORIGINS = "https://mmdbkk.com,https://www.mmdbkk.com,https://mmdprive.com,https://www.mmdprive.com,https://mmdprive.webflow.io"
-PAY_SESSIONS_TTL_DAYS = "30"
-
-[[kv_namespaces]]
-binding = "PAY_SESSIONS_KV"
-id = "e0c6b8a0785e462dad6d01f61a893e87"
-preview_id = "8f3ede8e3b0f447ea046cee47c7eef0b"
+# Production API routes for SIGIL payment flows.
+# These prevent sigil.mmdbkk.com/v1/* payment requests from falling through to origin and returning Cloudflare 522.
+routes = [
+  { pattern = "sigil.mmdbkk.com/v1/pay/*", zone_name = "mmdbkk.com" },
+  { pattern = "sigil.mmdbkk.com/v1/payments/*",

--- a/payments-worker/wrangler.merged.toml
+++ b/payments-worker/wrangler.merged.toml
@@ -2,12 +2,20 @@ name = "payments-worker"
 main = "src/index.js"
 compatibility_date = "2026-01-20"
 
+# Production API routes for SIGIL payment flows.
+# These prevent sigil.mmdbkk.com/v1/* payment requests from falling through to origin and returning Cloudflare 522.
+routes = [
+  { pattern = "sigil.mmdbkk.com/v1/pay/*", zone_name = "mmdbkk.com" },
+  { pattern = "sigil.mmdbkk.com/v1/payments/*", zone_name = "mmdbkk.com" },
+  { pattern = "sigil.mmdbkk.com/v1/confirm/*", zone_name = "mmdbkk.com" }
+]
+
 kv_namespaces = [
   { binding = "PAY_SESSIONS_KV", id = "a9b6e92309024aa8a7ed1869d2c80afd" }
 ]
 
 [vars]
-ALLOWED_ORIGINS = "\"https://mmdprive.com,https://mmdprive.webflow.io,https://mmdbkk.com\""
+ALLOWED_ORIGINS = "\"https://mmdprive.com,https://mmdprive.webflow.io,https://mmdbkk.com,https://www.mmdbkk.com,https://sigil.mmdbkk.com\""
 
 WEB_BASE_URL = "https://mmdprive.webflow.io"
 CONFIRM_BASE_URL = "https://mmdprive.webflow.io"
@@ -63,4 +71,3 @@ AT_PAYMENTS__CREATED_AT            = "flduxcPpowBxEZSLu"
 TELEGRAM_CHAT_ID = "-1003546439681"
 TG_THREAD_CONFIRM = "61"
 TG_THREAD_POINTS = "17"
-


### PR DESCRIPTION
## Summary

- Adds Cloudflare route ownership for `sigil.mmdbkk.com/v1/pay/*`, `sigil.mmdbkk.com/v1/payments/*`, and `sigil.mmdbkk.com/v1/confirm/*` in both payments-worker Wrangler configs.
- Adds `https://sigil.mmdbkk.com` to allowed origins.
- Documents the SIGIL payment route contract and the planned `/v1/pay/slip/evidence` evidence-only upload route.

## Why

Current smoke tests on `sigil.mmdbkk.com/v1/pay/*` return Cloudflare `522`, which indicates the requests are falling through to origin instead of being handled by the Worker. The new routes should make these API paths enter `payments-worker` after deploy.

## Safety lock

Slip evidence remains supporting evidence only. It must not mark payment paid, unlock access, confirm a session, activate membership, or award points without official verification.

## Deploy / smoke

After merge and deploy:

```bash
wrangler deploy --config "payments-worker/wrangler 2.toml"

curl -i https://sigil.mmdbkk.com/v1/pay/verify
curl -i https://sigil.mmdbkk.com/v1/payments/notify
curl -i https://sigil.mmdbkk.com/v1/pay/slip/evidence
```

Expected result after routing is fixed: no `522`. Existing POST-only routes may return `404`, `405`, or `400` depending on the handler state, but they should no longer time out through origin.

## Note

This PR fixes Worker route ownership and documents `/v1/pay/slip/evidence`. The actual slip evidence POST handler still needs to be implemented or wired before the Payment Confirmation frontend switches to that endpoint.