### PR TITLE
fix(payments): route merged config through slip evidence wrapper

### DIFF
--- a/payments-worker/wrangler.merged.toml
+++ b/payments-worker/wrangler.merged.toml
@@ -1,6 +1,13 @@
 name = "payments-worker"
-main = "src/index.js"
+main = "index.with-slip-evidence.js"
 compatibility_date = "2026-01-20"
+
+# Production entrypoint:
+# - index.with-slip-evidence.js handles /v1/pay/slip/evidence first.
+# - All other payment routes are delegated back to index.js.
+#
+# This mirrors wrangler 2.toml so deploys using wrangler.merged.toml do not
+# fall back to src/index.js and return 404 for the slip evidence route.
 
 # Production API routes for SIGIL payment flows.
 # These prevent sigil.mmdbkk.com/v1/* payment requests from falling through to origin and returning Cloudflare 522.


### PR DESCRIPTION
## Summary

- Updates `payments-worker/wrangler.merged.toml` to use `index.with-slip-evidence.js` as the production entrypoint.
- Adds comments explaining that the wrapper handles `/v1/pay/slip/evidence` before delegating all existing payment routes back to `index.js`.

## Why

`GET https://sigil.mmdbkk.com/v1/pay/slip/evidence` still returns `404`, which indicates a deploy path may still be using `wrangler.merged.toml` with `main = "src/index.js"`. That entrypoint does not know the slip evidence route. This PR makes both known payment Wrangler configs route through the slip evidence wrapper.

## Deploy

After merge:

```bash
wrangler deploy --config "payments-worker/wrangler.merged.toml"
```

or use the already-updated primary config:

```bash
wrangler deploy --config "payments-worker/wrangler 2.toml"
```

## Smoke

```bash
curl -i https://sigil.mmdbkk.com/v1/pay/slip/evidence
```

Expected: `405 Method Not Allowed` with `Allow: POST`, not `404`.