### PR TITLE
Add Kenji Knowledge admin route shell

### DIFF
--- a/mmd-redirect-worker/src/index.js
+++ b/mmd-redirect-worker/src/index.js
@@ -13,6 +13,7 @@ export const FRONT_GATE = "mmd-redirect-worker";
 export const FRONT_VERSION = "20260710-member-apply-webflow-pass-through";
 export const PUBLIC_BLACKCARD_PAGE = "public-blackcard";
 export const SIGIL_APPLY_ROUTE_OWNER = "sigil-worker";
+export const KENJI_KNOWLEDGE_ADMIN_PATHS = new Set(["/internal/admin/kenji-knowledge", "/internal/admin/kenji-knowledge/"]);
 
 export const REDIRECT_HOSTS = new Set(["www.mmdbkk.com", "mmdbkk.com", "mmdprive.com", "www.mmdprive.com", "malemodel-bkk.workers.dev"]);
 export const NEVER_TOUCH_HOSTS = new Set(["sigil.mmdbkk.com"]);
@@ -93,6 +94,7 @@ function isMemberApiPath(url) { return MEMBER_API_PATHS.has(url.pathname.toLower
 function isMemberPaymentsPath(url) { const p = url.pathname.toLowerCase(); return p === "/member/payments" || p === "/member/payments/"; }
 function isHallPath(url) { const p = url.pathname.toLowerCase(); return p === "/hall" || p === "/hall/"; }
 function isModelConsolePath(url) { const p = url.pathname.toLowerCase(); return p === "/model/console" || p === "/model/console/"; }
+function isKenjiKnowledgeAdminPath(url) { return KENJI_KNOWLEDGE_ADMIN_PATHS.has(url.pathname.toLowerCase()); }
 function isMemberPath(url) { const p = url.pathname.toLowerCase(); return p === "/member" || p === "/member/" || p.startsWith("/member/"); }
 function isKnownLegacyMemberRedirect(url) { return Boolean(EXACT_PATH_REDIRECTS[normalizePath(url.pathname).toLowerCase()]); }
 
@@ -153,6 +155,10 @@ function renderPublicBlackcardPage(request) {
 function renderHallRecovery(request) { return renderRouteRecoveryShell(request, "hall", "MMD Privé | Hall", "MMD Hall", "พื้นที่กลางสำหรับเข้าสู่ระบบสมาชิก ตรวจสถานะ และไปต่อยังเส้นทางที่เกี่ยวข้องของ MMD Privé", [{ label: "Enter Member Area", href: "/member/dashboard" }, { label: "Member Payments", href: "/member/payments" }]); }
 function renderModelConsoleRecovery(request) { return renderRouteRecoveryShell(request, "model-console", "MMD Privé | Model Console", "Model Console", "พื้นที่สำหรับผู้ให้บริการตรวจสถานะงานและไปต่อยังขั้นตอนที่เกี่ยวข้องของ MMD Privé", [{ label: "Continue", href: "/v1/model/session/dashboard" }, { label: "Member Area", href: "/member/dashboard" }]); }
 function renderMemberStaticRecovery(request) { return renderRouteRecoveryShell(request, "member-static", "MMD Privé | Member", "Member Page", "หน้านี้อยู่ในพื้นที่สมาชิกของ MMD Privé และพร้อมเชื่อมต่อกับเนื้อหาหลักในขั้นต่อไป", [{ label: "Enter Member Area", href: "/member/dashboard" }, { label: "Membership", href: "/member/membership" }]); }
+function renderKenjiKnowledgeAdminShell(request) {
+  const html = `<!doctype html><html lang="th"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex,nofollow"><title>Kenji Knowledge Admin</title><link rel="stylesheet" href="https://models.mmdbkk.com/webflow/internal/admin/kenji-knowledge/kenji-knowledge-v9-board-bridge.css"></head><body><div id="mmdKenjiKnowledgeV9"></div><script defer src="https://models.mmdbkk.com/webflow/internal/admin/kenji-knowledge/kenji-knowledge-v9-1-webflow-loader.js"></script></body></html>`;
+  return new Response(request.method.toUpperCase() === "HEAD" ? null : html, { status: 200, headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store, no-cache, must-revalidate, max-age=0", "x-mmd-worker": FRONT_GATE, "x-mmd-front-gate": FRONT_GATE, "x-mmd-front-version": FRONT_VERSION, "x-mmd-page": "kenji-knowledge-admin", "x-mmd-route-owner": FRONT_GATE, "x-mmd-origin": "front-gate:kenji-knowledge-r2-loader-shell" } });
+}
 
 export default {
   async fetch(request, env = {}) {
@@ -168,6 +174,7 @@ export default {
     if (isWebflowMemberPagePath(url)) return fetchPassThrough(request);
     if (isMemberPagePath(url)) return fetchMemberPage(request, env, url);
     if (isMemberPaymentsPath(url)) return fetchAdminMemberPage(request, env, url);
+    if (isKenjiKnowledgeAdminPath(url)) return renderKenjiKnowledgeAdminShell(request);
     if (isHallPath(url)) return renderHallRecovery(request);
     if (isModelConsolePath(url)) return renderModelConsoleRecovery(request);
     if (isMemberPath(url) && !isKnownLegacyMemberRedirect(url)) return renderMemberStaticRecovery(request);

--- a/mmd-redirect-worker/test/redirect.test.mjs
+++ b/mmd-redirect-worker/test/redirect.test.mjs
@@ -585,6 +585,31 @@ describe("MMD permanent redirect guard", () => {
     assert.equal(passThroughRequests.length, 0);
   });
 
+  it("renders /internal/admin/kenji-knowledge as the R2 loader shell", async () => {
+    const urls = [
+      "https://mmdbkk.com/internal/admin/kenji-knowledge",
+      "https://mmdbkk.com/internal/admin/kenji-knowledge/",
+      "https://www.mmdbkk.com/internal/admin/kenji-knowledge?cb=test",
+    ];
+
+    for (const url of urls) {
+      const response = await request(url);
+      const html = await response.text();
+
+      assert.equal(response.status, 200, url);
+      assert.equal(response.headers.get("location"), null, url);
+      assert.match(response.headers.get("content-type") || "", /^text\/html/i, url);
+      assert.equal(response.headers.get("x-mmd-front-gate"), "mmd-redirect-worker", url);
+      assert.equal(response.headers.get("x-mmd-page"), "kenji-knowledge-admin", url);
+      assert.match(html, /<link rel="stylesheet" href="https:\/\/models\.mmdbkk\.com\/webflow\/internal\/admin\/kenji-knowledge\/kenji-knowledge-v9-board-bridge\.css">/, url);
+      assert.match(html, /<div id="mmdKenjiKnowledgeV9"><\/div>/, url);
+      assert.match(html, /<script defer src="https:\/\/models\.mmdbkk\.com\/webflow\/internal\/admin\/kenji-knowledge\/kenji-knowledge-v9-1-webflow-loader\.js"><\/script>/, url);
+      assert.doesNotMatch(html, /\/v1\/admin\/sigil\/board\/publish|method:\s*["']POST|payment approved|unlock membership/i, url);
+    }
+
+    assert.equal(passThroughRequests.length, 0);
+  });
+
   it("renders unknown /member/* routes as polished MMD Privé pages without redirecting", async () => {
     const urls = [
       "https://mmdbkk.com/member/kenji-20-ai?t=abc&cb=test",


### PR DESCRIPTION
## Summary
- Add narrow HTML route shell for /internal/admin/kenji-knowledge and trailing slash.
- Serve the existing R2 loader architecture through mmd-redirect-worker.
- Preserve the existing Webflow/R2 snippet:
  - CSS from models.mmdbkk.com
  - <div id="mmdKenjiKnowledgeV9"></div>
  - deferred loader from models.mmdbkk.com

## Owner decision
- mmd-redirect-worker owns mmdbkk.com/*.
- admin-worker does not own production /internal/admin/* routing.
- member-pages-worker is member-page only.
- This patch adds only the narrow route needed for /internal/admin/kenji-knowledge.

## Safety / Guardrails
- No route pattern changes.
- No R2 loader/CSS changes.
- No Board write-back.
- No /v1/admin/sigil/board/publish call.
- No LINE runtime changes.
- No payment approval changes.
- No SIGIL mutation changes.
- No deploy.

## Validation
- node --check mmd-redirect-worker/src/index.js
- node --test mmd-redirect-worker/test/redirect.test.mjs
- npm --prefix mmd-redirect-worker run check
- npm --prefix mmd-redirect-worker test — 53/53 passed
- git diff --check -- mmd-redirect-worker
- R2 asset HEAD checks both returned HTTP/2 200