### PR TITLE
Add exact Kenji Knowledge admin routes

### DIFF
--- a/mmd-redirect-worker/wrangler.toml
+++ b/mmd-redirect-worker/wrangler.toml
@@ -99,6 +99,24 @@ zone_name = "mmdbkk.com"
 pattern = "www.mmdbkk.com/sigil/apply/"
 zone_name = "mmdbkk.com"
 
+# Kenji Knowledge admin route shell.
+# Exact page shell owned by mmd-redirect-worker because it owns mmdbkk.com/*.
+[[routes]]
+pattern = "mmdbkk.com/internal/admin/kenji-knowledge"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "mmdbkk.com/internal/admin/kenji-knowledge/"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/internal/admin/kenji-knowledge"
+zone_name = "mmdbkk.com"
+
+[[routes]]
+pattern = "www.mmdbkk.com/internal/admin/kenji-knowledge/"
+zone_name = "mmdbkk.com"
+
 # Temporary safety catch for old SIGIL admin route leakage.
 # mmd-redirect-worker must pass /sigil/* through; SIGIL admin login is owned by immigrate-worker.
 [[routes]]


### PR DESCRIPTION
## Summary
- Add exact Cloudflare route triggers for `/internal/admin/kenji-knowledge` and trailing slash.
- Add both apex and www variants so the existing PR #185 route shell can win before any broader `/internal/admin/*` route.

## Context
- PR #185 already added the narrow HTML route shell in `mmd-redirect-worker/src/index.js`.
- Local redirect tests pass and render `/internal/admin/kenji-knowledge` as the R2 loader shell.
- Live still returned JSON `not_found`, which indicates the generic `mmdbkk.com/*` trigger was not winning for this path.

## Safety / Guardrails
- Only changes `mmd-redirect-worker/wrangler.toml`.
- No source logic changes.
- No R2 loader/CSS changes.
- No Board write-back.
- No publish call.
- No LINE runtime changes.
- No payment approval changes.
- No SIGIL mutation changes.

## Validation to run before deploy
- `npm --prefix mmd-redirect-worker test`
- `git diff --check -- mmd-redirect-worker`
- `npx wrangler deploy --config mmd-redirect-worker/wrangler.toml`

## Expected live result after deploy
- `https://mmdbkk.com/internal/admin/kenji-knowledge` returns `HTTP 200 text/html`
- Response includes `id="mmdKenjiKnowledgeV9"`
- Response includes `x-mmd-page: kenji-knowledge-admin`